### PR TITLE
Adds loading indicator, removes click handler for buttons to reset state

### DIFF
--- a/components/Report.vue
+++ b/components/Report.vue
@@ -1,18 +1,29 @@
 <template>
 	<div class="container">
 		<section class="section">
-			<b-button v-on:click="clearLocation"
-				>Go Back / Show Location Pickers</b-button
+			<b-button tag="nuxt-link" to="/">
+				Go Back / Show Location Pickers</b-button
 			>
 			<h3 class="title is-4">
 				Projected Future Conditions for <span v-html="place"></span>
 			</h3>
-		</section>
-		<section class="section">
-			<TempReport></TempReport>
-		</section>
-		<section class="section">
-			<PrecipReport></PrecipReport>
+			<div v-if="$fetchState.pending">
+				<!-- Drama dots -->
+				<h4 class="title is-5">Loading data&hellip;</h4>
+			</div>
+			<div v-else-if="$fetchState.error" class="error">
+				<p>
+					Oh no! Something&rsquo;s amiss and the report for this place
+					couldn&rsquo;t be loaded.
+				</p>
+				<b-button tag="nuxt-link" to="/">
+					Go back and try another place</b-button
+				>
+			</div>
+			<div v-else>
+				<TempReport></TempReport>
+				<PrecipReport></PrecipReport>
+			</div>
 		</section>
 	</div>
 </template>
@@ -22,18 +33,27 @@ import TempReport from '~/components/TempReport'
 import PrecipReport from '~/components/PrecipReport'
 import { mapGetters } from 'vuex'
 
+// For mocking/scaffolding only
+function sleep(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
 export default {
 	name: 'Report',
 	components: { TempReport, PrecipReport },
-	methods: {
-		clearLocation() {
-			this.$router.push({ path: '/' })
-		},
+	data() {
+		return {
+			results: undefined,
+		}
 	},
 	computed: {
 		...mapGetters({
 			place: 'getPlaceName',
 		}),
+	},
+	async fetch() {
+		// Example doing real fetch: this.results = await this.$http.$get('https://api.nuxtjs.dev/mountains')
+		await sleep(5000)
 	},
 }
 </script>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -41,6 +41,7 @@ export default {
     '@nuxt/content',
     // https://www.npmjs.com/package/nuxt-leaflet
     'nuxt-leaflet',
+    '@nuxt/http',
   ],
 
   // Axios module configuration: https://go.nuxtjs.dev/config-axios

--- a/package-lock.json
+++ b/package-lock.json
@@ -1504,6 +1504,21 @@
         }
       }
     },
+    "@nuxt/http": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@nuxt/http/-/http-0.6.4.tgz",
+      "integrity": "sha512-7tVuqjac611WArO9oLrzJqx9SRdTNrMZqBBKHaFbmWsnaIZyxb8tJcYPcjUZe8m9zWGvPiGAyi1JnToAaw7dKA==",
+      "requires": {
+        "@nuxtjs/proxy": "^2.1.0",
+        "abort-controller": "^3.0.0",
+        "consola": "^2.15.0",
+        "defu": "^3.2.2",
+        "destr": "^1.0.1",
+        "ky": "^0.25.1",
+        "node-fetch": "^2.6.1",
+        "web-streams-polyfill": "^3.0.1"
+      }
+    },
     "@nuxt/loading-screen": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@nuxt/loading-screen/-/loading-screen-2.0.3.tgz",
@@ -2567,6 +2582,14 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
     },
     "accepts": {
       "version": "1.3.7",
@@ -5150,6 +5173,11 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -7351,6 +7379,11 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.4.tgz",
       "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA=="
+    },
+    "ky": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-0.25.1.tgz",
+      "integrity": "sha512-PjpCEWlIU7VpiMVrTwssahkYXX1by6NCT0fhTUX34F3DTinARlgMpriuroolugFPcMgpPWrOW4mTb984Qm1RXA=="
     },
     "last-call-webpack-plugin": {
       "version": "3.0.0",
@@ -13642,6 +13675,11 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
       "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw=="
+    },
+    "web-streams-polyfill": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.0.3.tgz",
+      "integrity": "sha512-d2H/t0eqRNM4w2WvmTdoeIvzAUSpK7JmATB8Nr2lb7nQ9BTIJVjbQ/TRFVEh2gUH1HwclPdoPtfMoFfetXaZnA=="
     },
     "webpack": {
       "version": "4.46.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@nuxt/content": "^1.11.1",
+    "@nuxt/http": "^0.6.4",
     "@nuxtjs/axios": "^5.12.5",
     "core-js": "^3.8.3",
     "leaflet": "^1.7.1",


### PR DESCRIPTION
This commit finishes adjusting the code to rely on routing (and the vuex-router-sync module) instead of directly managing the state of the application with mutations.  And, it adds a Loading indicator.  Testing:

 - Choose a community and select it to activate the report fold-out.
 - Observe that there's a "Loading..." indicator that stays there for ~5 seconds, then goes away and shows the table.
 - Click the "Go Back / Show Location Pickers" button.  It should hide the report and show the community selector + map again.  (Identical behavior to last time, but with different code).