### PR TITLE
Adds mini-map preview & a few small quality-of-life fixes to error path for report

### DIFF
--- a/components/Report.vue
+++ b/components/Report.vue
@@ -16,22 +16,32 @@
 			<h3 class="title is-4 place">
 				Projected Future Conditions for <span v-html="place"></span>
 			</h3>
+			
 			<div v-if="$fetchState.pending">
 				<!-- Drama dots -->
 				<h4 class="title is-5">Loading data&hellip;</h4>
 				<b-progress type="is-info"></b-progress>
 			</div>
 			<div v-else-if="$fetchState.error" class="error">
-				<p>
+				<p class="content is-size-5">
 					Oh no! Something&rsquo;s amiss and the report for this place
 					couldn&rsquo;t be loaded.
 				</p>
-				<b-button tag="nuxt-link" to="/">
-					Go back and try another place</b-button
+				<b-button
+					class="is-warning"
+					tag="nuxt-link"
+					to="/#controls"
+					icon-left="emoticon-sad-outline"
+				>
+					<strong>We&rsquo;re sorry</strong>, please try again</b-button
 				>
 			</div>
+
 			<div v-else>
 				<!-- The report! -->
+				<div class="report--minimap--wrapper">
+					<MiniMap/>
+				</div>
 				<div class="report-controls">
 					<div class="content is-size-5">
 						<p>The tables and charts below are specific to the selected point, or have been averaged across the selected HUC or ecoregion.  Note that the precision of these results depends on the grid resolution (pixel size) of the underlying dataset.  Also note that some data layers are not available as point data or at the HUC or ecoregion level.</p>
@@ -91,6 +101,7 @@
 <script>
 import TempReport from '~/components/reports/temperature/TempReport'
 import PrecipReport from '~/components/reports/precipitation/PrecipReport'
+import MiniMap from '~/components/reports/MiniMap'
 import { mapGetters } from 'vuex'
 import lodash from 'lodash'
 import deepdash from 'deepdash'
@@ -99,7 +110,7 @@ const _ = deepdash(lodash)
 
 export default {
 	name: 'Report',
-	components: { TempReport, PrecipReport },
+	components: { TempReport, PrecipReport, MiniMap },
 	data() {
 		return {
 			originalData: undefined, // for the raw stuff back from API

--- a/components/reports/MiniMap.vue
+++ b/components/reports/MiniMap.vue
@@ -1,0 +1,93 @@
+<template>
+	<div>
+		<div class="report--minimap--wrapper">
+			<div id="report--minimmap--map"></div>
+		</div>
+	</div>
+</template>
+
+<style lang="scss" scoped>
+.report--minimap--wrapper {
+	margin: 2rem 0 3rem;
+}
+#report--minimmap--map {
+	height: 20vw;
+	width: 20vw;
+}
+</style>
+
+<script>
+import _ from 'lodash'
+import { mapGetters } from 'vuex'
+
+export default {
+	name: 'MiniMap',
+	computed: {
+		...mapGetters({
+			latLng: 'getLatLng',
+			hucId: 'getHucId',
+		}),
+	},
+	data() {
+		return {
+			marker: undefined,
+			geoJsonLayer: undefined,
+		}
+	},
+	mounted() {
+		this.map = L.map('report--minimmap--map', this.getBaseMapAndLayers())
+
+		if (this.latLng) {
+			this.marker = L.marker(this.latLng).addTo(this.map)
+			this.map.panTo(this.latLng)
+		} else if (this.hucId) {
+			// Fetch the GeoJSON outline
+			this.loadHucGeoJSON()
+		}
+	},
+	methods: {
+		async loadHucGeoJSON() {
+			let queryUrl = process.env.apiUrl + '/huc/huc8/' + this.hucId
+			// TODO, add error handling here.
+			let geoJson = await this.$http.$get(queryUrl)
+			this.geoJsonLayer = L.geoJSON(geoJson).addTo(this.map)
+			this.map.fitBounds(this.geoJsonLayer.getBounds())
+		},
+		getBaseMapAndLayers() {
+			var baseLayer = new this.$L.tileLayer.wms(process.env.geoserverUrl, {
+				transparent: true,
+				srs: 'EPSG:3338',
+				format: 'image/png',
+				version: '1.3.0',
+				layers: ['atlas_mapproxy:alaska_osm'],
+			})
+
+			// Projection definition.
+			var proj = new this.$L.Proj.CRS(
+				'EPSG:3338',
+				'+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +ellps=GRS80 +datum=NAD83 +units=m +no_defs',
+				{
+					resolutions: [4096, 2048, 1024, 512, 256, 128, 64],
+				}
+			)
+
+			// Map base configuration
+			var config = {
+				zoom: 3,
+				minZoom: 0,
+				maxZoom: 6,
+				center: [64.7, -155],
+				scrollWheelZoom: false,
+				crs: proj,
+				continuousWorld: true,
+				zoomControl: false,
+				doubleClickZoom: false,
+				attributionControl: false,
+				layers: [baseLayer],
+			}
+
+			return config
+		},
+	},
+}
+</script>


### PR DESCRIPTION
New Minimap, check for:

 1. If you pick by clicking on the huge map or choosing a place name, it shows a marker on the preview minimap & be zoomed in to the proximal region
 2. If you pick a HUC, it should show the outline as GeoJSON + be fitted within the map

On the quality-of-life issues, to replicate the fail state search for then select "Outlet Portland Canal Watershed HUC 19010107".  (This one fails right now because part of the enclosing BBOX is outside the Rasdaman coverage extent, will fix later).  You should see a yellow button with a frown face, and when clicked it should put the Controls at the top of the window (i.e. not go back to the very top of the whole page, which it did before).