### PR TITLE
Modified fixed precision to 2 on the lat / lon variables after someone clicks on the map.

### DIFF
--- a/components/Map.vue
+++ b/components/Map.vue
@@ -37,8 +37,8 @@ export default {
 	methods: {
 		handleMapClick(event) {
 			this.latlng = {
-				lat: event.latlng.lat.toFixed(4),
-				lng: event.latlng.lng.toFixed(4),
+				lat: event.latlng.lat.toFixed(2),
+				lng: event.latlng.lng.toFixed(2),
 			}
 			this.$router.push({
 				path: '/report/' + this.latlng.lat + '/' + this.latlng.lng,


### PR DESCRIPTION
This PR changes the fixed precision of the lat / lon variables after someone clicks on the map to 2 down from 4. 

I've clicked on a number of places on the map and have not seen this impact the ability to get output from the backend API.

Fixes #34 