### PR TITLE
Adds data download button to bottom of report section

### DIFF
--- a/components/Report.vue
+++ b/components/Report.vue
@@ -109,6 +109,9 @@
 							>access these datasets</a
 						>.
 					</p>
+					<p>
+						<DownloadCsvButton />
+					</p>
 				</div>
 			</section>
 			<hr />
@@ -149,6 +152,7 @@ import TempReport from '~/components/reports/temperature/TempReport'
 import PrecipReport from '~/components/reports/precipitation/PrecipReport'
 import MiniMap from '~/components/reports/MiniMap'
 import QualitativeText from '~/components/reports/QualitativeText'
+import DownloadCsvButton from '~/components/reports/DownloadCsvButton'
 import { mapGetters } from 'vuex'
 import lodash from 'lodash'
 import deepdash from 'deepdash'
@@ -157,7 +161,7 @@ const _ = deepdash(lodash)
 
 export default {
 	name: 'Report',
-	components: { TempReport, PrecipReport, MiniMap, QualitativeText },
+	components: { TempReport, PrecipReport, MiniMap, QualitativeText, DownloadCsvButton },
 	data() {
 		return {
 			originalData: undefined, // for the raw stuff back from API

--- a/components/reports/DownloadCsvButton.vue
+++ b/components/reports/DownloadCsvButton.vue
@@ -1,0 +1,25 @@
+<template>
+	<a :href="downloadTarget" class="button">Download data as CSV</a>
+</template>
+<style lang="scss" scoped>
+</style>
+<script>
+export default {
+	name: 'DownloadCsvButton',
+	computed: {
+		downloadTarget() {
+			let urlFragment
+			let latLng = this.$store.getters.getLatLng
+
+			if (latLng) {
+				// Community or direct lat/lng
+				urlFragment = 'point/' + latLng[0] + '/' + latLng[1]
+			} else {
+				// HUC.
+				urlFragment = 'huc/' + this.$store.getters.getHucId
+			}
+			return process.env.apiUrl + '/iem/' + urlFragment + "?format=csv"
+		},
+	},
+}
+</script>


### PR DESCRIPTION
To test this:

 * Pick a community.  Scroll down to the "Download data" button & click.  You should get a download prompt with the CSV report.
 * Pick a point on the map directly.  Scroll down to the "download data" button & click.  You should get a download prompt with the CSV report.
 * Pick a HUC.  Scroll down to the "download data" button & click.  You should get a download prompt.

If the data API hasn't been updated at the default location, run a local copy and set the env var `SNAP_API_URL` to your local copy.