### PR TITLE
Changes to dynamic text section (intro blurb)

### DIFF
--- a/assets/scss/bulma-overrides.scss
+++ b/assets/scss/bulma-overrides.scss
@@ -1,6 +1,6 @@
 @charset "utf-8";
 
-@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600&family=Paytone+One&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@350;400;600&family=Paytone+One&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@300;400;500&display=swap');
 
 // Update Bulma's global variables

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -60,7 +60,7 @@
 									<strong>Winter</strong> is December, January and February.
 									<strong>Spring</strong> is March, April and May.
 									<strong>Summer</strong> is June, July and August, and
-									<strong>fall</strong> is September, October and November.
+									<strong>Fall</strong> is September, October and November.
 								</p>
 							</div>
 							<b-field label="Units">

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -37,7 +37,7 @@
 				<h3 class="title is-3 centered">
 					Projected Conditions for <span v-html="place"></span>
 				</h3>
-				<QualitativeText :reportData="results" :place="place" :units="units" />
+				<QualitativeText :reportData="results" :units="units" />
 			</section>
 			<section class="section">
 				<div class="columns">

--- a/components/reports/QualitativeText.vue
+++ b/components/reports/QualitativeText.vue
@@ -1,23 +1,39 @@
 <template>
   <div class="qualitative-text">
-    <div v-html="generateText()"></div>
+    <div class="generated" v-html="generateText()"></div>
+    <p class="about-blurb">
+      Late&ndash;century, high-emissions (RCP8.5), MRI or NCAR model (whichever
+      shows greater change).<br />See tables below for more detailed
+      information.
+    </p>
   </div>
 </template>
 <style lang="scss" scoped>
 .qualitative-text {
-  width: 50vw;
+  width: 55vw;
   font-size: 1.55rem;
-  margin: 2.5rem auto 0;
-  padding: 1rem;
+  margin: 2.5rem auto -1rem;
+  padding: 1rem 0;
   text-align: center;
   line-height: 1.35;
   font-weight: 350;
-  
+
   // Because it's v-html injected, need to use /deep/.
   ::v-deep * {
     p:not(:last-child) {
       margin-bottom: 1.5rem;
     }
+    p:last-child {
+      margin-bottom: 2rem;
+    }
+  }
+
+  .about-blurb {
+    margin: 1rem;
+    border-top: 1px solid #efeced;
+    padding-top: 0.5rem;
+    font-weight: 400;
+    font-size: 1rem;
   }
 }
 </style>

--- a/components/reports/QualitativeText.vue
+++ b/components/reports/QualitativeText.vue
@@ -6,10 +6,13 @@
 <style lang="scss" scoped>
 .qualitative-text {
   width: 50vw;
-  font-size: 1.25rem;
-  margin: 0 auto;
+  font-size: 1.55rem;
+  margin: 2.5rem auto 0;
+  padding: 1rem;
   text-align: center;
-
+  line-height: 1.35;
+  font-weight: 350;
+  
   // Because it's v-html injected, need to use /deep/.
   ::v-deep * {
     p:not(:last-child) {

--- a/components/reports/QualitativeText.vue
+++ b/components/reports/QualitativeText.vue
@@ -247,7 +247,7 @@ export default {
       returnedString +=
         '<p>Models have higher uncertainty with regard to precipitation,<br/> but <strong>' +
         seasonWithHighestPrecipChange.toLowerCase() +
-        '</strong> is likely to get wetter (<strong>+' +
+        '</strong> is likely to have more precipitation (<strong>+' +
         annualHighestPrecipPercentChange +
         '%</strong>).</p>'
 

--- a/components/reports/QualitativeText.vue
+++ b/components/reports/QualitativeText.vue
@@ -22,235 +22,217 @@
 import { mapGetters } from 'vuex'
 export default {
   name: 'QualitativeText',
-  props: ['reportData', 'place', 'units'],
-  mounted() {
-    this.generateText()
-  },
+  props: ['reportData', 'units'],
   watch: {
     reportData: function () {
       this.generateText()
     },
   },
+  data: function () {
+    return {
+      seasons: ['MAM', 'JJA', 'SON', 'DJF'],
+      seasonNames: {
+        DJF: 'Winter',
+        MAM: 'Spring',
+        JJA: 'Summer',
+        SON: 'Fall',
+      },
+    }
+  },
   computed: {
     ...mapGetters({
       hucName: 'getRawHucName',
+      place: 'getPlaceName',
     }),
+    unitsText() {
+      if (this.units) {
+        return this.units == 'metric' ? '&deg;C' : '&deg;F'
+      }
+    },
   },
   methods: {
     // Generate Qualitative Text
     // Input: None. (Uses reportData, place, and units properties)
     // Output: Text string containing HTML list items of processed seasonal metrics.
     generateText: function () {
-      let reportData = this.reportData
-
-      if (!reportData) {
-        console.log("there is no ~~~~data")
+      if (!this.reportData || !this.place) {
         return
       }
+      return this.generateAnnualMetricsHtml()
+    },
+    collectSeasonalMetrics(season) {
+      let historicalTemp = this.reportData['1910-2009'][season]['CRU-TS31'][
+        'CRU_historical'
+      ]['tas']
 
-      let path = this.$route.path
+      let historicalPrecip = this.reportData['1910-2009'][season]['CRU-TS31'][
+        'CRU_historical'
+      ]['pr']
 
-      let place = this.place
-
-      if (!place) {
-        console.log("there is no place")
-        return
+      var seasonMetrics = {
+        season: this.seasonNames[season],
+        maxTempDiff: 0,
+        maxPrecipDiff: 0,
+        precipPercentChange: 0,
+        aboveFreezing: false,
       }
 
-      let seasons = ['MAM', 'JJA', 'SON', 'DJF']
-      let season_names = {
-        DJF: 'Winter',
-        MAM: 'Spring',
-        JJA: 'Summer',
-        SON: 'Fall',
+      // For RCP8.5 only / late-century, pick the model with the greater change
+      // and use that value.
+
+      // Take an average of both temperature and precipitation for the same season and RCP from both models.
+      // Ensure the values are numbers before attempting to use the Math library on them.
+      let tempMax = Math.max(
+        this.reportData['2070_2100'][season]['MRI-CGCM3']['rcp85']['tas'],
+        this.reportData['2070_2100'][season]['CCSM4']['rcp85']['tas']
+      )
+
+      let precipMax = Math.max(
+        this.reportData['2070_2100'][season]['MRI-CGCM3']['rcp85']['pr'],
+        this.reportData['2070_2100'][season]['CCSM4']['rcp85']['pr']
+      )
+
+      // If the maximum temperature difference is less than the current temperature difference,
+      // set the new value as the greatest seasonal temperature difference.
+      if (seasonMetrics['maxTempDiff'] < tempMax - historicalTemp) {
+        seasonMetrics['maxTempDiff'] = Math.round(tempMax - historicalTemp)
       }
-      let periods = ['2040_2070', '2070_2100']
-      let rcps = ['rcp45', 'rcp85']
 
-      let unit_type = this.units
-      let units = this.units == 'metric' ? '&deg;C' : '&deg;F'
-
-      // Subfunction - collect_seasonal_metrics
-      // Input: season - Season to collect metrics for. Listed above as constant seasons.
-      // Output: season_metrics - JSON object containing metrics about the given season.
-      function collect_seasonal_metrics(season) {
-        let historical_temp = Math.round(
-          Number(
-            reportData['1910-2009'][season]['CRU-TS31']['CRU_historical']['tas']
-          )
+      // If the maximum precipitation difference is less than the current precipitation difference,
+      // set the new value as the greatest seasonal precipitation difference and compute new
+      // percentage changed stored as a rounded integer.
+      if (seasonMetrics['maxPrecipDiff'] < precipMax - historicalPrecip) {
+        seasonMetrics['maxPrecipDiff'] = precipMax - historicalPrecip
+        seasonMetrics['precipPercentChange'] = Math.round(
+          (precipMax / historicalPrecip) * 100 - 100
         )
-        let historical_precip = Number(
-          reportData['1910-2009'][season]['CRU-TS31']['CRU_historical']['pr']
-        )
-        var season_metrics = {
-          season: season_names[season],
-          max_temp_diff: 0,
-          max_precip_diff: 0,
-          precip_percent_change: 0,
-          above_freezing: false,
-        }
-
-        periods.forEach((period) => {
-          rcps.forEach((rcp) => {
-            // Take an average of both temperature and precipitation for the same season and RCP from both models.
-            // Ensure the values are numbers before attempting to use the Math library on them.
-            let temperature_average = Math.round(
-              (Number(reportData[period][season]['MRI-CGCM3'][rcp]['tas']) +
-                Number(reportData[period][season]['CCSM4'][rcp]['tas'])) /
-                2
-            )
-            let precip_average =
-              (Number(reportData[period][season]['MRI-CGCM3'][rcp]['pr']) +
-                Number(reportData[period][season]['CCSM4'][rcp]['pr'])) /
-              2
-
-            // If the maximum temperature difference is less than the current temperature difference,
-            // set the new value as the greatest seasonal temperature difference.
-            if (
-              season_metrics['max_temp_diff'] <
-              temperature_average - historical_temp
-            ) {
-              season_metrics['max_temp_diff'] =
-                temperature_average - historical_temp
-            }
-
-            // If the maximum precipitation difference is less than the current precipitation difference,
-            // set the new value as the greatest seasonal precipitation difference and compute new
-            // percentage changed stored as a rounded integer.
-            if (
-              season_metrics['max_precip_diff'] <
-              precip_average - historical_precip
-            ) {
-              season_metrics['max_precip_diff'] = (
-                precip_average - historical_precip
-              ).toFixed(2)
-              season_metrics['precip_percent_change'] = Math.round(
-                (precip_average / historical_precip) * 100 - 100
-              )
-            }
-
-            // We set this season to above freezing if one of the modeled averages is above freezing
-            // while the historical value for temperature is below freezing.
-            if (
-              (unit_type == 'metric' &&
-                historical_temp < 0 &&
-                temperature_average > 0) ||
-              (unit_type == 'imperial' &&
-                historical_temp < 32 &&
-                temperature_average > 32)
-            ) {
-              season_metrics['above_freezing'] = true
-            }
-          })
-        })
-
-        return season_metrics
       }
 
-      // Subfunction: Generate annual metrics HTML string
-      // Input: None. (Uses constant seasons)
-      // Output: A string containing HTML for a linked list of all
-      //         annual metrics of importance.
-      var generate_annual_metrics_html = () => {
-        var annual_temperature_average = 0
-        var annual_highest_temp_change = 0
-        var season_with_highest_temp_change = 'None'
-        var annual_highest_precip_percent_change = 0
-        var season_with_highest_precip_change = 'None'
-        var above_freezing_seasons = []
-
-        seasons.forEach((season) => {
-          var season_output = collect_seasonal_metrics(season)
-
-          // Collect highest seasonal temperature averages to compute annual average later.
-          annual_temperature_average =
-            annual_temperature_average + season_output['max_temp_diff']
-
-          // Check if this temperature difference is the highest out of all the seasons thus far.
-          if (annual_highest_temp_change < season_output['max_temp_diff']) {
-            annual_highest_temp_change = season_output['max_temp_diff']
-            season_with_highest_temp_change = season_output['season']
-          }
-
-          // Check if this prepitation change is the highest out of all the seasons thus far.
-          if (
-            annual_highest_precip_percent_change <
-            season_output['precip_percent_change']
-          ) {
-            annual_highest_precip_percent_change =
-              season_output['precip_percent_change']
-            season_with_highest_precip_change = season_output['season']
-          }
-
-          // If a season was marked as being above freezing when historically below freezing,
-          // push it onto an array of seasons.
-          if (season_output['above_freezing'] == true) {
-            above_freezing_seasons.push(season_output['season'])
-          }
-        })
-
-        // Average value against the 4 seasons included.
-        annual_temperature_average = Math.round(annual_temperature_average / 4)
-
-        var returned_string = ''
-
-        if (path.includes('community')) {
-          returned_string +=
-            '<p>In <strong>' + place + '</strong>'
-        } else if (path.includes('huc')) {
-          returned_string += '<p>In the <strong>' + this.hucName + '</strong>'
-        } else {
-          returned_string += '<p>At <strong>' + place + '</strong>'
-        }
-
-        // Create the returned string using the values from the loop above.
-        returned_string +=
-          ',<br/>average annual temperatures<br/>may increase by up to <strong>' +
-          annual_temperature_average +
-          units +
-          '</strong> by the end of the century.</p>'
-
-        returned_string +=
-          '<p><strong>' +
-          season_with_highest_temp_change +
-          '</strong> temperatures are increasing the most (<strong>+' +
-          annual_highest_temp_change +
-          units +
-          '</strong>).</p>'
-
-        // If any season is marked as above freezing in the future when historically below freezing,
-        // expand those values out to be added as an additional list item.
-        if (above_freezing_seasons.length > 0) {
-          // If less than 3 seasons are marked as now above freezing, just join them with an AND
-          if (above_freezing_seasons.length < 3) {
-            returned_string +=
-              '<p><strong>' +
-              above_freezing_seasons.join(' and ') +
-              '</strong> may transition from below freezing to <strong>above freezing</strong> in the future.</p>'
-          } else {
-            // Pop off the last season to be a special case.
-            let last_season = above_freezing_seasons.pop()
-
-            // Join the other seasons by commas and the last season by an AND.
-            returned_string +=
-              '<p><strong>' +
-              above_freezing_seasons.join(', ') +
-              ', and ' +
-              last_season +
-              '</strong> may transition from below freezing to <strong>above freezing</strong> in the future.</p>'
-          }
-        }
-        returned_string +=
-          '<p>Models have high uncertainty with regard to precipitation,<br/> but <strong>' +
-          season_with_highest_precip_change +
-          '</strong> is likely to get wetter (<strong>+' +
-          annual_highest_precip_percent_change +
-          '%</strong>).</p>'
-
-        return returned_string
+      // We set this season to above freezing if one of the modeled averages is above freezing
+      // while the historical value for temperature is below freezing.
+      if (
+        (this.units == 'metric' && historicalTemp < 0 && tempMax > 0) ||
+        (this.units == 'imperial' && historicalTemp < 32 && tempMax >= 32)
+      ) {
+        seasonMetrics['aboveFreezing'] = true
       }
-      console.log(generate_annual_metrics_html())
-      return generate_annual_metrics_html()
+
+      return seasonMetrics
+    },
+    // Subfunction: Generate annual metrics HTML string
+    // Input: None. (Uses constant seasons)
+    // Output: A string containing HTML for a linked list of all
+    //         annual metrics of importance.
+    generateAnnualMetricsHtml: function () {
+      var annualTemperatureAverage = 0
+      var annualHighestTempChange = 0
+      var seasonWithHighestTempChange = 'None'
+      var annualHighestPrecipPercentChange = 0
+      var seasonWithHighestPrecipChange = 'None'
+      var aboveFreezingSeasons = []
+
+      this.seasons.forEach((season) => {
+        let seasonOutput = this.collectSeasonalMetrics(season)
+
+        // Collect highest seasonal temperature averages to compute annual average later.
+        annualTemperatureAverage =
+          annualTemperatureAverage + seasonOutput['maxTempDiff']
+
+        // Check if this temperature difference is the highest out of all the seasons thus far.
+        if (annualHighestTempChange < seasonOutput['maxTempDiff']) {
+          annualHighestTempChange = seasonOutput['maxTempDiff']
+          seasonWithHighestTempChange = seasonOutput['season']
+        }
+
+        // Check if this prepitation change is the highest out of all the seasons thus far.
+        if (
+          annualHighestPrecipPercentChange < seasonOutput['precipPercentChange']
+        ) {
+          annualHighestPrecipPercentChange = seasonOutput['precipPercentChange']
+          seasonWithHighestPrecipChange = seasonOutput['season']
+        }
+
+        // If a season was marked as being above freezing when historically below freezing,
+        // push it onto an array of seasons.
+        if (seasonOutput['aboveFreezing'] == true) {
+          aboveFreezingSeasons.push(seasonOutput['season'])
+        }
+      })
+
+      // Average value against the 4 seasons included.
+      annualTemperatureAverage = Math.round(annualTemperatureAverage / 4)
+
+      var returnedString = ''
+
+      // TODO.  If we do these kinds of comparisons a lot, we probably want
+      // to move this logic to the store or another component in some way.
+      // This code does need some special grammar, though, which wouldn't
+      // generalize!
+      if (this.$route.path.includes('community')) {
+        returnedString += '<p>In <strong>' + this.place + '</strong>'
+      } else if (this.$route.path.includes('huc')) {
+        returnedString += '<p>In the <strong>' + this.hucName + '</strong>'
+      } else {
+        returnedString += '<p>At <strong>' + this.place + '</strong>'
+      }
+
+      // Create the returned string using the values from the loop above.
+      returnedString +=
+        ',<br/>average annual temperatures<br/>may increase by about <strong>' +
+        annualTemperatureAverage +
+        this.unitsText +
+        '</strong> by the end of the century.</p>'
+
+      returnedString +=
+        '<p><strong>' +
+        seasonWithHighestTempChange +
+        '</strong> temperatures are increasing the most (<strong>+' +
+        annualHighestTempChange +
+        this.unitsText +
+        '</strong>).</p>'
+
+      // If any season is marked as above freezing in the future when historically below freezing,
+      // expand those values out to be added as an additional list item.
+      if (aboveFreezingSeasons.length > 0) {
+        returnedString += '<p>'
+        let transitioningSeasons = ''
+
+        switch (aboveFreezingSeasons.length) {
+          case 1:
+            transitioningSeasons =
+              '<strong>' + aboveFreezingSeasons[0] + '</strong>'
+            break
+          case 2:
+            transitioningSeasons =
+              '<strong>' +
+              aboveFreezingSeasons[0] +
+              '</strong> and <strong>' +
+              aboveFreezingSeasons[1].toLowerCase() +
+              '</strong>'
+            break
+          case 3:
+            transitioningSeasons =
+              '<strong>' +
+              aboveFreezingSeasons[0] +
+              '</strong>, <strong>' +
+              aboveFreezingSeasons[1].toLowerCase() +
+              '</strong> and <strong>' +
+              aboveFreezingSeasons[2].toLowerCase() +
+              '</strong>'
+            break
+        }
+        returnedString +=
+          transitioningSeasons +
+          ' may transition from below freezing to <strong>above freezing</strong> in the future.</p>'
+      }
+      returnedString +=
+        '<p>Models have higher uncertainty with regard to precipitation,<br/> but <strong>' +
+        seasonWithHighestPrecipChange.toLowerCase() +
+        '</strong> is likely to get wetter (<strong>+' +
+        annualHighestPrecipPercentChange +
+        '%</strong>).</p>'
+
+      return returnedString
     },
   },
 }

--- a/components/reports/QualitativeText.vue
+++ b/components/reports/QualitativeText.vue
@@ -100,7 +100,6 @@ export default {
       // and use that value.
 
       // Take an average of both temperature and precipitation for the same season and RCP from both models.
-      // Ensure the values are numbers before attempting to use the Math library on them.
       let tempMax = Math.max(
         this.reportData['2070_2100'][season]['MRI-CGCM3']['rcp85']['tas'],
         this.reportData['2070_2100'][season]['CCSM4']['rcp85']['tas']

--- a/store/index.js
+++ b/store/index.js
@@ -62,7 +62,11 @@ export const getters = {
         id: Number(state.route.params.communityId),
       })
       if (place) {
-        return place.name
+        let name = place.name
+        if (place.alt_name) {
+          name += ' <span class="alt_name">(' + place.alt_name + ')</span>'
+        }
+        return name
       }
       throw 'Could not find the community by ID.'
     }


### PR DESCRIPTION
Summary of changed things / things to look for when reviewing the code:

 * Use of `camelCase` not `snake_case` in Javascript (it's normal/expected that the API is returning keyed stuff with a different syntax).
 * Instead of local assignment, i.e. `let someProperty = this.someProperty`, some of the code is move around and made into methods in the Vue object; this generally eases the issue of lost `this` context.  Not always!  In some of the `forEach` iterators, the `this` context is specifically provided.  Ah, Javascript.
 * Some data accessors moved from properties to using the Vuex store (`place`).
 * Removed the initial render on `mounted()` hook, only uses the watcher.
 * Removed the `Number()` type coercion, I know the pain of Javascript being marginal with handling types but I was able to get things working without those or `parseInt` through tracing the implicit type conversions that occur with`Math.max` and `Math.round`.
 * Made a few things more verbose/explicit (in the `switch` statement).  I did this just because it was easier to control the upper/lowercasing of the transitional seasons.

