### PR TITLE
Add decadal temp/precip charts that display historical range alongside projected means using new taspr endpoint

### DIFF
--- a/components/Report.vue
+++ b/components/Report.vue
@@ -202,7 +202,6 @@ export default {
 				this.results = _.cloneDeep(this.originalData)
 				this.convertReportData()
 			}
-			this.combineDecades()
 		},
 	},
 	methods: {
@@ -251,36 +250,6 @@ export default {
 				}
 			})
 		},
-		combineDecades() {
-			let decades = {
-				'2040_2070': ['2040_2049', '2050_2059', '2060_2069'],
-				'2070_2100': ['2070_2079', '2080_2089', '2090_2099'],
-			}
-
-			let combined = {}
-			Object.keys(decades).forEach(decadeRange => {
-				combined[decadeRange] = {};
-				['DJF', 'JJA', 'MAM', 'SON'].forEach(season => {
-					combined[decadeRange][season] = {};
-					['CCSM4', 'MRI-CGCM3'].forEach(model => {
-						combined[decadeRange][season][model] = {};
-						['rcp45', 'rcp60', 'rcp85'].forEach(scenario => {
-							combined[decadeRange][season][model][scenario] = {}
-							let tasValues = []
-							let prValues = []
-							decades[decadeRange].forEach(decade => {
-								tasValues.push(this.results[decade][season][model][scenario]['tas'])
-								prValues.push(this.results[decade][season][model][scenario]['pr'])
-							})
-							combined[decadeRange][season][model][scenario]['tas'] = _.round(_.mean(tasValues), 1)
-							combined[decadeRange][season][model][scenario]['pr'] = _.round(_.mean(prValues), 1)
-						})
-					})
-				})
-			})
-
-			this.results = _.merge(this.results, combined)
-		}
 	},
 }
 </script>

--- a/components/reports/DownloadCsvButton.vue
+++ b/components/reports/DownloadCsvButton.vue
@@ -18,7 +18,7 @@ export default {
 				// HUC.
 				urlFragment = 'huc/' + this.$store.getters.getHucId
 			}
-			return process.env.apiUrl + '/iem/' + urlFragment + "?format=csv"
+			return process.env.apiUrl + '/taspr/' + urlFragment + "?format=csv"
 		},
 	},
 }

--- a/components/reports/QualitativeText.vue
+++ b/components/reports/QualitativeText.vue
@@ -80,13 +80,9 @@ export default {
       return this.generateAnnualMetricsHtml()
     },
     collectSeasonalMetrics(season) {
-      let historicalTemp = this.reportData['1910-2009'][season]['CRU-TS31'][
-        'CRU_historical'
-      ]['tas']
+      let historicalTemp = this.reportData['1950_2009'][season]['CRU-TS40']['CRU_historical']['tas']['mean']
 
-      let historicalPrecip = this.reportData['1910-2009'][season]['CRU-TS31'][
-        'CRU_historical'
-      ]['pr']
+      let historicalPrecip = this.reportData['1950_2009'][season]['CRU-TS40']['CRU_historical']['pr']['mean']
 
       var seasonMetrics = {
         season: this.seasonNames[season],
@@ -101,13 +97,21 @@ export default {
 
       // Take an average of both temperature and precipitation for the same season and RCP from both models.
       let tempMax = Math.max(
-        this.reportData['2070_2100'][season]['MRI-CGCM3']['rcp85']['tas'],
-        this.reportData['2070_2100'][season]['CCSM4']['rcp85']['tas']
+      this.reportData['2070_2079'][season]['MRI-CGCM3']['rcp85']['tas'],
+      this.reportData['2080_2089'][season]['MRI-CGCM3']['rcp85']['tas'],
+      this.reportData['2090_2099'][season]['MRI-CGCM3']['rcp85']['tas'],
+      this.reportData['2070_2079'][season]['CCSM4']['rcp85']['tas'],
+      this.reportData['2080_2089'][season]['CCSM4']['rcp85']['tas'],
+      this.reportData['2090_2099'][season]['CCSM4']['rcp85']['tas']
       )
 
       let precipMax = Math.max(
-        this.reportData['2070_2100'][season]['MRI-CGCM3']['rcp85']['pr'],
-        this.reportData['2070_2100'][season]['CCSM4']['rcp85']['pr']
+        this.reportData['2070_2079'][season]['MRI-CGCM3']['rcp85']['pr'],
+        this.reportData['2080_2089'][season]['MRI-CGCM3']['rcp85']['pr'],
+        this.reportData['2090_2099'][season]['MRI-CGCM3']['rcp85']['pr'],
+        this.reportData['2070_2079'][season]['CCSM4']['rcp85']['pr'],
+        this.reportData['2080_2089'][season]['CCSM4']['rcp85']['pr'],
+        this.reportData['2090_2099'][season]['CCSM4']['rcp85']['pr']
       )
 
       // If the maximum temperature difference is less than the current temperature difference,

--- a/components/reports/precipitation/PrecipReport.vue
+++ b/components/reports/precipitation/PrecipReport.vue
@@ -19,9 +19,15 @@
 			>
 		</div>
 		<div class="chart-wrapper">
-			<ReportPrecipChart :reportData="reportData" :units="units" />
+			<b-field label="Season">
+				<b-radio v-model="precip_season" name="precip_season" native-value="DJF">Winter</b-radio>
+				<b-radio v-model="precip_season" name="precip_season" native-value="MAM">Spring</b-radio>
+				<b-radio v-model="precip_season" name="precip_season" native-value="JJA">Summer</b-radio>
+				<b-radio v-model="precip_season" name="precip_season" native-value="SON">Fall</b-radio>
+			</b-field>
+			<ReportPrecipChart :reportData="reportData" :chartData="chartData" :units="units" :season="precip_season" />
 		</div>
-		<div class="chart-wrapper">
+		<div class="table-wrapper">
 			<ReportPrecipTable :reportData="reportData" :units="units" />
 		</div>
 	</div>
@@ -33,7 +39,12 @@ import ReportPrecipTable from './ReportPrecipTable'
 
 export default {
 	name: 'PrecipReport',
-	props: ['reportData', 'units'],
+	props: ['reportData', 'chartData', 'units'],
 	components: { ReportPrecipChart, ReportPrecipTable },
+	data() {
+		return {
+			precip_season: 'DJF'
+		}
+	},
 }
 </script>

--- a/components/reports/precipitation/PrecipReport.vue
+++ b/components/reports/precipitation/PrecipReport.vue
@@ -25,7 +25,7 @@
 				<b-radio v-model="precip_season" name="precip_season" native-value="JJA">Summer</b-radio>
 				<b-radio v-model="precip_season" name="precip_season" native-value="SON">Fall</b-radio>
 			</b-field>
-			<ReportPrecipChart :reportData="reportData" :chartData="chartData" :units="units" :season="precip_season" />
+			<ReportPrecipChart :reportData="reportData" :units="units" :season="precip_season" />
 		</div>
 		<div class="table-wrapper">
 			<ReportPrecipTable :reportData="reportData" :units="units" />
@@ -39,7 +39,7 @@ import ReportPrecipTable from './ReportPrecipTable'
 
 export default {
 	name: 'PrecipReport',
-	props: ['reportData', 'chartData', 'units'],
+	props: ['reportData', 'units'],
 	components: { ReportPrecipChart, ReportPrecipTable },
 	data() {
 		return {

--- a/components/reports/precipitation/ReportPrecipChart.vue
+++ b/components/reports/precipitation/ReportPrecipChart.vue
@@ -89,8 +89,8 @@ export default {
 						type: 'scatter',
 						mode: 'markers',
 						name: traceLabels_lu[model][scenario],
-						text: traceLabels_lu[model][scenario],
 						hoverinfo: 'x+y+z+text',
+						hovertemplate: '%{y}' + units,
 						x: decades.slice(1),
 						y: [],
 					}

--- a/components/reports/precipitation/ReportPrecipChart.vue
+++ b/components/reports/precipitation/ReportPrecipChart.vue
@@ -98,7 +98,7 @@ export default {
 			})
 
 			decade_keys.forEach(decade => {
-				if (decade === '2040_2070' || decade === '2070_2100') {
+				if (decade === '2040_2069' || decade === '2070_2099') {
 					return
 				}
 

--- a/components/reports/precipitation/ReportPrecipChart.vue
+++ b/components/reports/precipitation/ReportPrecipChart.vue
@@ -12,7 +12,7 @@
 import _ from 'lodash'
 export default {
 	name: 'ReportPrecipChart',
-	props: ['reportData', 'chartData', 'units', 'season'],
+	props: ['reportData', 'units', 'season'],
 	mounted() {
 		this.renderPlot()
 	},
@@ -41,10 +41,10 @@ export default {
 				'SON': 'September - November',
 			}
 
-			let decade_keys = Object.keys(this.chartData)
+			let decade_keys = Object.keys(this.reportData)
 			let decades = decade_keys.map(x => x.replace('_', '-'))
 
-			var historical = {
+			let historical = {
 				type: 'box',
 				name: 'Historical',
 				x: decades.slice(0, 1),
@@ -84,8 +84,12 @@ export default {
 			})
 
 			decade_keys.forEach(decade => {
+				if (decade === '2040_2070' || decade === '2070_2100') {
+					return
+				}
+
 				if (decade === '1950_2009') {
-					let prData = this.chartData[decade][this.season]['CRU-TS40']['CRU_historical']['pr']
+					let prData = this.reportData[decade][this.season]['CRU-TS40']['CRU_historical']['pr']
 					historical['median'].push(prData['mean'])
 					historical['q1'].push(prData['lo_std'])
 					historical['q3'].push(prData['hi_std'])
@@ -94,7 +98,7 @@ export default {
 				} else {
 					models.forEach(model => {
 						scenarios.forEach(scenario => {
-							scatterTraces[model][scenario]['y'].push(this.chartData[decade][this.season][model][scenario]['pr'])
+							scatterTraces[model][scenario]['y'].push(this.reportData[decade][this.season][model][scenario]['pr'])
 						})
 					})
 				}

--- a/components/reports/precipitation/ReportPrecipChart.vue
+++ b/components/reports/precipitation/ReportPrecipChart.vue
@@ -167,6 +167,7 @@ export default {
 						opacity: 0.2
 					},
 				],
+				hovermode: 'x unified',
 			}
 
 			this.$Plotly.newPlot('precip-chart', data_traces, layout, {

--- a/components/reports/precipitation/ReportPrecipChart.vue
+++ b/components/reports/precipitation/ReportPrecipChart.vue
@@ -142,6 +142,20 @@ export default {
 						size: 24,
 					},
 				},
+				shapes: [
+					{
+						type: 'rect',
+						x0: 0,
+						y0: this.reportData['1950_2009'][this.season]['CRU-TS40']['CRU_historical']['pr']['q1'],
+						x1: decades.length - 1,
+						y1: this.reportData['1950_2009'][this.season]['CRU-TS40']['CRU_historical']['pr']['q3'],
+						line: {
+							width: 0
+						},
+						fillcolor: '#cccccc',
+						opacity: 0.2
+					},
+				],
 			}
 
 			this.$Plotly.newPlot('precip-chart', data_traces, layout, {

--- a/components/reports/precipitation/ReportPrecipChart.vue
+++ b/components/reports/precipitation/ReportPrecipChart.vue
@@ -60,16 +60,23 @@ export default {
 				upperfence: [],
 			}
 
-			let models = ['MRI-CGCM3', 'CCSM4']
-			let scenarios = ['rcp45', 'rcp85']
+			let models = ['5modelAvg', 'MRI-CGCM3', 'CCSM4']
+			let scenarios = ['rcp45', 'rcp60', 'rcp85']
 
 			let traceLabels_lu = {
+				'5modelAvg': {
+					'rcp45': 'RCP 4.5 (5-model Avg.)',
+					'rcp60': 'RCP 6.0 (5-model Avg.)',
+					'rcp85': 'RCP 8.5 (5-model Avg.)',
+				},
 				'MRI-CGCM3': {
 					'rcp45': 'RCP 4.5 (MRI)',
+					'rcp60': 'RCP 6.0 (MRI)',
 					'rcp85': 'RCP 8.5 (MRI)',
 				},
 				'CCSM4': {
 					'rcp45': 'RCP 4.5 (NCAR)',
+					'rcp60': 'RCP 6.0 (NCAR)',
 					'rcp85': 'RCP 8.5 (NCAR)',
 				},
 			}
@@ -82,6 +89,8 @@ export default {
 						type: 'scatter',
 						mode: 'markers',
 						name: traceLabels_lu[model][scenario],
+						text: traceLabels_lu[model][scenario],
+						hoverinfo: 'x+y+z+text',
 						x: decades.slice(1),
 						y: [],
 					}

--- a/components/reports/precipitation/ReportPrecipChart.vue
+++ b/components/reports/precipitation/ReportPrecipChart.vue
@@ -100,7 +100,7 @@ export default {
 					},
 				},
 				title: {
-					text: 'Historical and projected precipitation ranges (' + season_lu[this.season] + ')',
+					text: 'Historical and projected precipitation (' + season_lu[this.season] + ')',
 					font: {
 						size: 24,
 					},

--- a/components/reports/precipitation/ReportPrecipChart.vue
+++ b/components/reports/precipitation/ReportPrecipChart.vue
@@ -90,9 +90,9 @@ export default {
 
 				if (decade === '1950_2009') {
 					let prData = this.reportData[decade][this.season]['CRU-TS40']['CRU_historical']['pr']
-					historical['median'].push(prData['mean'])
-					historical['q1'].push(prData['lo_std'])
-					historical['q3'].push(prData['hi_std'])
+					historical['median'].push(prData['median'])
+					historical['q1'].push(prData['q1'])
+					historical['q3'].push(prData['q3'])
 					historical['lowerfence'].push(prData['min'])
 					historical['upperfence'].push(prData['max'])
 				} else {

--- a/components/reports/precipitation/ReportPrecipChart.vue
+++ b/components/reports/precipitation/ReportPrecipChart.vue
@@ -146,9 +146,11 @@ export default {
 					{
 						type: 'rect',
 						x0: 0,
+						x1: 1,
+						xref: 'paper',
 						y0: this.reportData['1950_2009'][this.season]['CRU-TS40']['CRU_historical']['pr']['q1'],
-						x1: decades.length - 1,
 						y1: this.reportData['1950_2009'][this.season]['CRU-TS40']['CRU_historical']['pr']['q3'],
+						yref: 'y',
 						line: {
 							width: 0
 						},

--- a/components/reports/precipitation/ReportPrecipChart.vue
+++ b/components/reports/precipitation/ReportPrecipChart.vue
@@ -44,7 +44,7 @@ export default {
 			let decade_keys = Object.keys(this.chartData)
 			let decades = decade_keys.map(x => x.replace('_', '-'))
 
-			let historical = {
+			var historical = {
 				type: 'box',
 				name: 'Historical',
 				x: decades.slice(0, 1),
@@ -55,21 +55,33 @@ export default {
 				upperfence: [],
 			}
 
-			let rcp45 = {
-				type: 'scatter',
-				mode: 'markers',
-				name: 'RCP 4.5',
-				x: decades.slice(1),
-				y: [],
+			let models = ['MRI-CGCM3', 'CCSM4']
+			let scenarios = ['rcp45', 'rcp85']
+
+			let traceLabels_lu = {
+				'MRI-CGCM3': {
+					'rcp45': 'RCP 4.5 (MRI)',
+					'rcp85': 'RCP 8.5 (MRI)',
+				},
+				'CCSM4': {
+					'rcp45': 'RCP 4.5 (NCAR)',
+					'rcp85': 'RCP 8.5 (NCAR)',
+				},
 			}
 
-			let rcp85 = {
-				type: 'scatter',
-				mode: 'markers',
-				name: 'RCP 8.5',
-				x: decades.slice(1),
-				y: [],
-			}
+			let scatterTraces = {}
+			models.forEach(model => {
+				scatterTraces[model] = {}
+				scenarios.forEach(scenario => {
+					scatterTraces[model][scenario] = {
+						type: 'scatter',
+						mode: 'markers',
+						name: traceLabels_lu[model][scenario],
+						x: decades.slice(1),
+						y: [],
+					}
+				})
+			})
 
 			decade_keys.forEach(decade => {
 				if (decade === '1950_2009') {
@@ -80,14 +92,21 @@ export default {
 					historical['lowerfence'].push(prData['min'])
 					historical['upperfence'].push(prData['max'])
 				} else {
-					let rcp45_mean = this.chartData[decade][this.season]['5modelAvg']['rcp45']['pr']
-					let rcp85_mean = this.chartData[decade][this.season]['5modelAvg']['rcp85']['pr']
-					rcp45['y'].push(rcp45_mean)
-					rcp85['y'].push(rcp85_mean)
+					models.forEach(model => {
+						scenarios.forEach(scenario => {
+							scatterTraces[model][scenario]['y'].push(this.chartData[decade][this.season][model][scenario]['pr'])
+						})
+					})
 				}
 			})
 
-			data_traces.push(historical, rcp45, rcp85)
+			data_traces.push(historical)
+
+			models.forEach(model => {
+				scenarios.forEach(scenario => {
+					data_traces.push(scatterTraces[model][scenario])
+				})
+			})
 
 			let layout = {
 				boxmode: 'group',

--- a/components/reports/precipitation/ReportPrecipChart.vue
+++ b/components/reports/precipitation/ReportPrecipChart.vue
@@ -42,6 +42,11 @@ export default {
 			}
 
 			let decade_keys = Object.keys(this.reportData)
+			decade_keys = decade_keys.filter(value => {
+				if (value !== '2040_2069' && value !== '2070_2099') {
+					return value
+				}
+			})
 			let decades = decade_keys.map(x => x.replace('_', '-'))
 
 			let historical = {

--- a/components/reports/precipitation/ReportPrecipChart.vue
+++ b/components/reports/precipitation/ReportPrecipChart.vue
@@ -82,6 +82,11 @@ export default {
 			}
 
 			let scatterTraces = {}
+			let symbols = {
+				'5modelAvg': 'circle',
+				'MRI-CGCM3': 'square',
+				'CCSM4': 'diamond',
+			}
 			models.forEach(model => {
 				scatterTraces[model] = {}
 				scenarios.forEach(scenario => {
@@ -91,6 +96,10 @@ export default {
 						name: traceLabels_lu[model][scenario],
 						hoverinfo: 'x+y+z+text',
 						hovertemplate: '%{y}' + units,
+						marker: {
+							symbol: Array(decades.length).fill(symbols[model]),
+							size: 8,
+						},
 						x: decades.slice(1),
 						y: [],
 					}

--- a/components/reports/precipitation/ReportPrecipTable.vue
+++ b/components/reports/precipitation/ReportPrecipTable.vue
@@ -50,7 +50,7 @@
 						}}<UnitWidget variable="pr" :units="units" type="light" />
 					</td>
 					<td>
-						{{ reportData['2040_2070']['DJF']['MRI-CGCM3']['rcp45']['pr']
+						{{ reportData['2040_2069']['DJF']['MRI-CGCM3']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
 							:units="units"
@@ -60,12 +60,12 @@
 								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
-								reportData['2040_2070']['DJF']['MRI-CGCM3']['rcp45']['pr']
+								reportData['2040_2069']['DJF']['MRI-CGCM3']['rcp45']['pr']
 							"
 						/>
 					</td>
 					<td>
-						{{ reportData['2040_2070']['DJF']['CCSM4']['rcp45']['pr']
+						{{ reportData['2040_2069']['DJF']['CCSM4']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
 							:units="units"
@@ -74,39 +74,11 @@
 							:past="
 								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
-							:future="reportData['2040_2070']['DJF']['CCSM4']['rcp45']['pr']"
+							:future="reportData['2040_2069']['DJF']['CCSM4']['rcp45']['pr']"
 						/>
 					</td>
 					<td>
-						{{ reportData['2040_2070']['DJF']['MRI-CGCM3']['rcp85']['pr']
-						}}<UnitWidget
-							variable="pr"
-							:units="units"
-							type="light"
-						/><PrecipDiffWidget
-							:past="
-								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['pr']['mean']
-							"
-							:future="
-								reportData['2040_2070']['DJF']['MRI-CGCM3']['rcp85']['pr']
-							"
-						/>
-					</td>
-					<td>
-						{{ reportData['2040_2070']['DJF']['CCSM4']['rcp85']['pr']
-						}}<UnitWidget
-							variable="pr"
-							:units="units"
-							type="light"
-						/><PrecipDiffWidget
-							:past="
-								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['pr']['mean']
-							"
-							:future="reportData['2040_2070']['DJF']['CCSM4']['rcp85']['pr']"
-						/>
-					</td>
-					<td>
-						{{ reportData['2070_2100']['DJF']['MRI-CGCM3']['rcp45']['pr']
+						{{ reportData['2040_2069']['DJF']['MRI-CGCM3']['rcp85']['pr']
 						}}<UnitWidget
 							variable="pr"
 							:units="units"
@@ -116,12 +88,12 @@
 								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
-								reportData['2070_2100']['DJF']['MRI-CGCM3']['rcp45']['pr']
+								reportData['2040_2069']['DJF']['MRI-CGCM3']['rcp85']['pr']
 							"
 						/>
 					</td>
 					<td>
-						{{ reportData['2070_2100']['DJF']['CCSM4']['rcp45']['pr']
+						{{ reportData['2040_2069']['DJF']['CCSM4']['rcp85']['pr']
 						}}<UnitWidget
 							variable="pr"
 							:units="units"
@@ -130,11 +102,11 @@
 							:past="
 								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
-							:future="reportData['2070_2100']['DJF']['CCSM4']['rcp45']['pr']"
+							:future="reportData['2040_2069']['DJF']['CCSM4']['rcp85']['pr']"
 						/>
 					</td>
 					<td>
-						{{ reportData['2070_2100']['DJF']['MRI-CGCM3']['rcp85']['pr']
+						{{ reportData['2070_2099']['DJF']['MRI-CGCM3']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
 							:units="units"
@@ -144,12 +116,12 @@
 								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
-								reportData['2070_2100']['DJF']['MRI-CGCM3']['rcp85']['pr']
+								reportData['2070_2099']['DJF']['MRI-CGCM3']['rcp45']['pr']
 							"
 						/>
 					</td>
 					<td>
-						{{ reportData['2070_2100']['DJF']['CCSM4']['rcp85']['pr']
+						{{ reportData['2070_2099']['DJF']['CCSM4']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
 							:units="units"
@@ -158,7 +130,35 @@
 							:past="
 								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
-							:future="reportData['2070_2100']['DJF']['CCSM4']['rcp85']['pr']"
+							:future="reportData['2070_2099']['DJF']['CCSM4']['rcp45']['pr']"
+						/>
+					</td>
+					<td>
+						{{ reportData['2070_2099']['DJF']['MRI-CGCM3']['rcp85']['pr']
+						}}<UnitWidget
+							variable="pr"
+							:units="units"
+							type="light"
+						/><PrecipDiffWidget
+							:past="
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['pr']['mean']
+							"
+							:future="
+								reportData['2070_2099']['DJF']['MRI-CGCM3']['rcp85']['pr']
+							"
+						/>
+					</td>
+					<td>
+						{{ reportData['2070_2099']['DJF']['CCSM4']['rcp85']['pr']
+						}}<UnitWidget
+							variable="pr"
+							:units="units"
+							type="light"
+						/><PrecipDiffWidget
+							:past="
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['pr']['mean']
+							"
+							:future="reportData['2070_2099']['DJF']['CCSM4']['rcp85']['pr']"
 						/>
 					</td>
 				</tr>
@@ -170,7 +170,7 @@
 						}}<UnitWidget variable="pr" :units="units" type="light" />
 					</td>
 					<td>
-						{{ reportData['2040_2070']['MAM']['MRI-CGCM3']['rcp45']['pr']
+						{{ reportData['2040_2069']['MAM']['MRI-CGCM3']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
 							:units="units"
@@ -180,12 +180,12 @@
 								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
-								reportData['2040_2070']['MAM']['MRI-CGCM3']['rcp45']['pr']
+								reportData['2040_2069']['MAM']['MRI-CGCM3']['rcp45']['pr']
 							"
 						/>
 					</td>
 					<td>
-						{{ reportData['2040_2070']['MAM']['CCSM4']['rcp45']['pr']
+						{{ reportData['2040_2069']['MAM']['CCSM4']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
 							:units="units"
@@ -194,39 +194,11 @@
 							:past="
 								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
-							:future="reportData['2040_2070']['MAM']['CCSM4']['rcp45']['pr']"
+							:future="reportData['2040_2069']['MAM']['CCSM4']['rcp45']['pr']"
 						/>
 					</td>
 					<td>
-						{{ reportData['2040_2070']['MAM']['MRI-CGCM3']['rcp85']['pr']
-						}}<UnitWidget
-							variable="pr"
-							:units="units"
-							type="light"
-						/><PrecipDiffWidget
-							:past="
-								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['pr']['mean']
-							"
-							:future="
-								reportData['2040_2070']['MAM']['MRI-CGCM3']['rcp85']['pr']
-							"
-						/>
-					</td>
-					<td>
-						{{ reportData['2040_2070']['MAM']['CCSM4']['rcp85']['pr']
-						}}<UnitWidget
-							variable="pr"
-							:units="units"
-							type="light"
-						/><PrecipDiffWidget
-							:past="
-								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['pr']['mean']
-							"
-							:future="reportData['2040_2070']['MAM']['CCSM4']['rcp85']['pr']"
-						/>
-					</td>
-					<td>
-						{{ reportData['2070_2100']['MAM']['MRI-CGCM3']['rcp45']['pr']
+						{{ reportData['2040_2069']['MAM']['MRI-CGCM3']['rcp85']['pr']
 						}}<UnitWidget
 							variable="pr"
 							:units="units"
@@ -236,12 +208,12 @@
 								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
-								reportData['2070_2100']['MAM']['MRI-CGCM3']['rcp45']['pr']
+								reportData['2040_2069']['MAM']['MRI-CGCM3']['rcp85']['pr']
 							"
 						/>
 					</td>
 					<td>
-						{{ reportData['2070_2100']['MAM']['CCSM4']['rcp45']['pr']
+						{{ reportData['2040_2069']['MAM']['CCSM4']['rcp85']['pr']
 						}}<UnitWidget
 							variable="pr"
 							:units="units"
@@ -250,11 +222,11 @@
 							:past="
 								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
-							:future="reportData['2070_2100']['MAM']['CCSM4']['rcp45']['pr']"
+							:future="reportData['2040_2069']['MAM']['CCSM4']['rcp85']['pr']"
 						/>
 					</td>
 					<td>
-						{{ reportData['2070_2100']['MAM']['MRI-CGCM3']['rcp85']['pr']
+						{{ reportData['2070_2099']['MAM']['MRI-CGCM3']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
 							:units="units"
@@ -264,12 +236,12 @@
 								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
-								reportData['2070_2100']['MAM']['MRI-CGCM3']['rcp85']['pr']
+								reportData['2070_2099']['MAM']['MRI-CGCM3']['rcp45']['pr']
 							"
 						/>
 					</td>
 					<td>
-						{{ reportData['2070_2100']['MAM']['CCSM4']['rcp85']['pr']
+						{{ reportData['2070_2099']['MAM']['CCSM4']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
 							:units="units"
@@ -278,7 +250,35 @@
 							:past="
 								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
-							:future="reportData['2070_2100']['MAM']['CCSM4']['rcp85']['pr']"
+							:future="reportData['2070_2099']['MAM']['CCSM4']['rcp45']['pr']"
+						/>
+					</td>
+					<td>
+						{{ reportData['2070_2099']['MAM']['MRI-CGCM3']['rcp85']['pr']
+						}}<UnitWidget
+							variable="pr"
+							:units="units"
+							type="light"
+						/><PrecipDiffWidget
+							:past="
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['pr']['mean']
+							"
+							:future="
+								reportData['2070_2099']['MAM']['MRI-CGCM3']['rcp85']['pr']
+							"
+						/>
+					</td>
+					<td>
+						{{ reportData['2070_2099']['MAM']['CCSM4']['rcp85']['pr']
+						}}<UnitWidget
+							variable="pr"
+							:units="units"
+							type="light"
+						/><PrecipDiffWidget
+							:past="
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['pr']['mean']
+							"
+							:future="reportData['2070_2099']['MAM']['CCSM4']['rcp85']['pr']"
 						/>
 					</td>
 				</tr>
@@ -290,7 +290,7 @@
 						}}<UnitWidget variable="pr" :units="units" type="light" />
 					</td>
 					<td>
-						{{ reportData['2040_2070']['JJA']['MRI-CGCM3']['rcp45']['pr']
+						{{ reportData['2040_2069']['JJA']['MRI-CGCM3']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
 							:units="units"
@@ -300,12 +300,12 @@
 								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
-								reportData['2040_2070']['JJA']['MRI-CGCM3']['rcp45']['pr']
+								reportData['2040_2069']['JJA']['MRI-CGCM3']['rcp45']['pr']
 							"
 						/>
 					</td>
 					<td>
-						{{ reportData['2040_2070']['JJA']['CCSM4']['rcp45']['pr']
+						{{ reportData['2040_2069']['JJA']['CCSM4']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
 							:units="units"
@@ -314,39 +314,11 @@
 							:past="
 								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
-							:future="reportData['2040_2070']['JJA']['CCSM4']['rcp45']['pr']"
+							:future="reportData['2040_2069']['JJA']['CCSM4']['rcp45']['pr']"
 						/>
 					</td>
 					<td>
-						{{ reportData['2040_2070']['JJA']['MRI-CGCM3']['rcp85']['pr']
-						}}<UnitWidget
-							variable="pr"
-							:units="units"
-							type="light"
-						/><PrecipDiffWidget
-							:past="
-								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['pr']['mean']
-							"
-							:future="
-								reportData['2040_2070']['JJA']['MRI-CGCM3']['rcp85']['pr']
-							"
-						/>
-					</td>
-					<td>
-						{{ reportData['2040_2070']['JJA']['CCSM4']['rcp85']['pr']
-						}}<UnitWidget
-							variable="pr"
-							:units="units"
-							type="light"
-						/><PrecipDiffWidget
-							:past="
-								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['pr']['mean']
-							"
-							:future="reportData['2040_2070']['JJA']['CCSM4']['rcp85']['pr']"
-						/>
-					</td>
-					<td>
-						{{ reportData['2070_2100']['JJA']['MRI-CGCM3']['rcp45']['pr']
+						{{ reportData['2040_2069']['JJA']['MRI-CGCM3']['rcp85']['pr']
 						}}<UnitWidget
 							variable="pr"
 							:units="units"
@@ -356,12 +328,12 @@
 								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
-								reportData['2070_2100']['JJA']['MRI-CGCM3']['rcp45']['pr']
+								reportData['2040_2069']['JJA']['MRI-CGCM3']['rcp85']['pr']
 							"
 						/>
 					</td>
 					<td>
-						{{ reportData['2070_2100']['JJA']['CCSM4']['rcp45']['pr']
+						{{ reportData['2040_2069']['JJA']['CCSM4']['rcp85']['pr']
 						}}<UnitWidget
 							variable="pr"
 							:units="units"
@@ -370,11 +342,11 @@
 							:past="
 								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
-							:future="reportData['2070_2100']['JJA']['CCSM4']['rcp45']['pr']"
+							:future="reportData['2040_2069']['JJA']['CCSM4']['rcp85']['pr']"
 						/>
 					</td>
 					<td>
-						{{ reportData['2070_2100']['JJA']['MRI-CGCM3']['rcp85']['pr']
+						{{ reportData['2070_2099']['JJA']['MRI-CGCM3']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
 							:units="units"
@@ -384,12 +356,12 @@
 								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
-								reportData['2070_2100']['JJA']['MRI-CGCM3']['rcp85']['pr']
+								reportData['2070_2099']['JJA']['MRI-CGCM3']['rcp45']['pr']
 							"
 						/>
 					</td>
 					<td>
-						{{ reportData['2070_2100']['JJA']['CCSM4']['rcp85']['pr']
+						{{ reportData['2070_2099']['JJA']['CCSM4']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
 							:units="units"
@@ -398,7 +370,35 @@
 							:past="
 								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
-							:future="reportData['2070_2100']['JJA']['CCSM4']['rcp85']['pr']"
+							:future="reportData['2070_2099']['JJA']['CCSM4']['rcp45']['pr']"
+						/>
+					</td>
+					<td>
+						{{ reportData['2070_2099']['JJA']['MRI-CGCM3']['rcp85']['pr']
+						}}<UnitWidget
+							variable="pr"
+							:units="units"
+							type="light"
+						/><PrecipDiffWidget
+							:past="
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['pr']['mean']
+							"
+							:future="
+								reportData['2070_2099']['JJA']['MRI-CGCM3']['rcp85']['pr']
+							"
+						/>
+					</td>
+					<td>
+						{{ reportData['2070_2099']['JJA']['CCSM4']['rcp85']['pr']
+						}}<UnitWidget
+							variable="pr"
+							:units="units"
+							type="light"
+						/><PrecipDiffWidget
+							:past="
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['pr']['mean']
+							"
+							:future="reportData['2070_2099']['JJA']['CCSM4']['rcp85']['pr']"
 						/>
 					</td>
 				</tr>
@@ -410,7 +410,7 @@
 						}}<UnitWidget variable="pr" :units="units" type="light" />
 					</td>
 					<td>
-						{{ reportData['2040_2070']['SON']['MRI-CGCM3']['rcp45']['pr']
+						{{ reportData['2040_2069']['SON']['MRI-CGCM3']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
 							:units="units"
@@ -420,12 +420,12 @@
 								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
-								reportData['2040_2070']['SON']['MRI-CGCM3']['rcp45']['pr']
+								reportData['2040_2069']['SON']['MRI-CGCM3']['rcp45']['pr']
 							"
 						/>
 					</td>
 					<td>
-						{{ reportData['2040_2070']['SON']['CCSM4']['rcp45']['pr']
+						{{ reportData['2040_2069']['SON']['CCSM4']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
 							:units="units"
@@ -434,39 +434,11 @@
 							:past="
 								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
-							:future="reportData['2040_2070']['SON']['CCSM4']['rcp45']['pr']"
+							:future="reportData['2040_2069']['SON']['CCSM4']['rcp45']['pr']"
 						/>
 					</td>
 					<td>
-						{{ reportData['2040_2070']['SON']['MRI-CGCM3']['rcp85']['pr']
-						}}<UnitWidget
-							variable="pr"
-							:units="units"
-							type="light"
-						/><PrecipDiffWidget
-							:past="
-								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['pr']['mean']
-							"
-							:future="
-								reportData['2040_2070']['SON']['MRI-CGCM3']['rcp85']['pr']
-							"
-						/>
-					</td>
-					<td>
-						{{ reportData['2040_2070']['SON']['CCSM4']['rcp85']['pr']
-						}}<UnitWidget
-							variable="pr"
-							:units="units"
-							type="light"
-						/><PrecipDiffWidget
-							:past="
-								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['pr']['mean']
-							"
-							:future="reportData['2040_2070']['SON']['CCSM4']['rcp85']['pr']"
-						/>
-					</td>
-					<td>
-						{{ reportData['2070_2100']['SON']['MRI-CGCM3']['rcp45']['pr']
+						{{ reportData['2040_2069']['SON']['MRI-CGCM3']['rcp85']['pr']
 						}}<UnitWidget
 							variable="pr"
 							:units="units"
@@ -476,12 +448,12 @@
 								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
-								reportData['2070_2100']['SON']['MRI-CGCM3']['rcp45']['pr']
+								reportData['2040_2069']['SON']['MRI-CGCM3']['rcp85']['pr']
 							"
 						/>
 					</td>
 					<td>
-						{{ reportData['2070_2100']['SON']['CCSM4']['rcp45']['pr']
+						{{ reportData['2040_2069']['SON']['CCSM4']['rcp85']['pr']
 						}}<UnitWidget
 							variable="pr"
 							:units="units"
@@ -490,11 +462,11 @@
 							:past="
 								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
-							:future="reportData['2070_2100']['SON']['CCSM4']['rcp45']['pr']"
+							:future="reportData['2040_2069']['SON']['CCSM4']['rcp85']['pr']"
 						/>
 					</td>
 					<td>
-						{{ reportData['2070_2100']['SON']['MRI-CGCM3']['rcp85']['pr']
+						{{ reportData['2070_2099']['SON']['MRI-CGCM3']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
 							:units="units"
@@ -504,12 +476,12 @@
 								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
-								reportData['2070_2100']['SON']['MRI-CGCM3']['rcp85']['pr']
+								reportData['2070_2099']['SON']['MRI-CGCM3']['rcp45']['pr']
 							"
 						/>
 					</td>
 					<td>
-						{{ reportData['2070_2100']['SON']['CCSM4']['rcp85']['pr']
+						{{ reportData['2070_2099']['SON']['CCSM4']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
 							:units="units"
@@ -518,7 +490,35 @@
 							:past="
 								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
-							:future="reportData['2070_2100']['SON']['CCSM4']['rcp85']['pr']"
+							:future="reportData['2070_2099']['SON']['CCSM4']['rcp45']['pr']"
+						/>
+					</td>
+					<td>
+						{{ reportData['2070_2099']['SON']['MRI-CGCM3']['rcp85']['pr']
+						}}<UnitWidget
+							variable="pr"
+							:units="units"
+							type="light"
+						/><PrecipDiffWidget
+							:past="
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['pr']['mean']
+							"
+							:future="
+								reportData['2070_2099']['SON']['MRI-CGCM3']['rcp85']['pr']
+							"
+						/>
+					</td>
+					<td>
+						{{ reportData['2070_2099']['SON']['CCSM4']['rcp85']['pr']
+						}}<UnitWidget
+							variable="pr"
+							:units="units"
+							type="light"
+						/><PrecipDiffWidget
+							:past="
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['pr']['mean']
+							"
+							:future="reportData['2070_2099']['SON']['CCSM4']['rcp85']['pr']"
 						/>
 					</td>
 				</tr>

--- a/components/reports/precipitation/ReportPrecipTable.vue
+++ b/components/reports/precipitation/ReportPrecipTable.vue
@@ -46,9 +46,7 @@
 					<th scope="row">Winter</th>
 					<td class="left">
 						{{
-							reportData['1910-2009']['DJF']['CRU-TS31']['CRU_historical'][
-								'pr'
-							]
+							reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['pr']['mean']
 						}}<UnitWidget variable="pr" :units="units" type="light" />
 					</td>
 					<td>
@@ -59,9 +57,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['DJF']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
 								reportData['2040_2070']['DJF']['MRI-CGCM3']['rcp45']['pr']
@@ -76,9 +72,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['DJF']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="reportData['2040_2070']['DJF']['CCSM4']['rcp45']['pr']"
 						/>
@@ -91,9 +85,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['DJF']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
 								reportData['2040_2070']['DJF']['MRI-CGCM3']['rcp85']['pr']
@@ -108,9 +100,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['DJF']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="reportData['2040_2070']['DJF']['CCSM4']['rcp85']['pr']"
 						/>
@@ -123,9 +113,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['DJF']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
 								reportData['2070_2100']['DJF']['MRI-CGCM3']['rcp45']['pr']
@@ -140,9 +128,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['DJF']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="reportData['2070_2100']['DJF']['CCSM4']['rcp45']['pr']"
 						/>
@@ -155,9 +141,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['DJF']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
 								reportData['2070_2100']['DJF']['MRI-CGCM3']['rcp85']['pr']
@@ -172,9 +156,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['DJF']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="reportData['2070_2100']['DJF']['CCSM4']['rcp85']['pr']"
 						/>
@@ -184,9 +166,7 @@
 					<th scope="row">Spring</th>
 					<td class="left">
 						{{
-							reportData['1910-2009']['MAM']['CRU-TS31']['CRU_historical'][
-								'pr'
-							]
+							reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['pr']['mean']
 						}}<UnitWidget variable="pr" :units="units" type="light" />
 					</td>
 					<td>
@@ -197,9 +177,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['MAM']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
 								reportData['2040_2070']['MAM']['MRI-CGCM3']['rcp45']['pr']
@@ -214,9 +192,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['MAM']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="reportData['2040_2070']['MAM']['CCSM4']['rcp45']['pr']"
 						/>
@@ -229,9 +205,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['MAM']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
 								reportData['2040_2070']['MAM']['MRI-CGCM3']['rcp85']['pr']
@@ -246,9 +220,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['MAM']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="reportData['2040_2070']['MAM']['CCSM4']['rcp85']['pr']"
 						/>
@@ -261,9 +233,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['MAM']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
 								reportData['2070_2100']['MAM']['MRI-CGCM3']['rcp45']['pr']
@@ -278,9 +248,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['MAM']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="reportData['2070_2100']['MAM']['CCSM4']['rcp45']['pr']"
 						/>
@@ -293,9 +261,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['MAM']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
 								reportData['2070_2100']['MAM']['MRI-CGCM3']['rcp85']['pr']
@@ -310,9 +276,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['MAM']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="reportData['2070_2100']['MAM']['CCSM4']['rcp85']['pr']"
 						/>
@@ -322,9 +286,7 @@
 					<th scope="row">Summer</th>
 					<td class="left">
 						{{
-							reportData['1910-2009']['JJA']['CRU-TS31']['CRU_historical'][
-								'pr'
-							]
+							reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['pr']['mean']
 						}}<UnitWidget variable="pr" :units="units" type="light" />
 					</td>
 					<td>
@@ -335,9 +297,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['JJA']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
 								reportData['2040_2070']['JJA']['MRI-CGCM3']['rcp45']['pr']
@@ -352,9 +312,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['JJA']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="reportData['2040_2070']['JJA']['CCSM4']['rcp45']['pr']"
 						/>
@@ -367,9 +325,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['JJA']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
 								reportData['2040_2070']['JJA']['MRI-CGCM3']['rcp85']['pr']
@@ -384,9 +340,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['JJA']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="reportData['2040_2070']['JJA']['CCSM4']['rcp85']['pr']"
 						/>
@@ -399,9 +353,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['JJA']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
 								reportData['2070_2100']['JJA']['MRI-CGCM3']['rcp45']['pr']
@@ -416,9 +368,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['JJA']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="reportData['2070_2100']['JJA']['CCSM4']['rcp45']['pr']"
 						/>
@@ -431,9 +381,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['JJA']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
 								reportData['2070_2100']['JJA']['MRI-CGCM3']['rcp85']['pr']
@@ -448,9 +396,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['JJA']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="reportData['2070_2100']['JJA']['CCSM4']['rcp85']['pr']"
 						/>
@@ -460,9 +406,7 @@
 					<th scope="row">Fall</th>
 					<td class="left">
 						{{
-							reportData['1910-2009']['SON']['CRU-TS31']['CRU_historical'][
-								'pr'
-							]
+							reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['pr']['mean']
 						}}<UnitWidget variable="pr" :units="units" type="light" />
 					</td>
 					<td>
@@ -473,9 +417,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['SON']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
 								reportData['2040_2070']['SON']['MRI-CGCM3']['rcp45']['pr']
@@ -490,9 +432,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['SON']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="reportData['2040_2070']['SON']['CCSM4']['rcp45']['pr']"
 						/>
@@ -505,9 +445,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['SON']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
 								reportData['2040_2070']['SON']['MRI-CGCM3']['rcp85']['pr']
@@ -522,9 +460,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['SON']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="reportData['2040_2070']['SON']['CCSM4']['rcp85']['pr']"
 						/>
@@ -537,9 +473,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['SON']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
 								reportData['2070_2100']['SON']['MRI-CGCM3']['rcp45']['pr']
@@ -554,9 +488,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['SON']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="reportData['2070_2100']['SON']['CCSM4']['rcp45']['pr']"
 						/>
@@ -569,9 +501,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['SON']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="
 								reportData['2070_2100']['SON']['MRI-CGCM3']['rcp85']['pr']
@@ -586,9 +516,7 @@
 							type="light"
 						/><PrecipDiffWidget
 							:past="
-								reportData['1910-2009']['SON']['CRU-TS31']['CRU_historical'][
-									'pr'
-								]
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['pr']['mean']
 							"
 							:future="reportData['2070_2100']['SON']['CCSM4']['rcp85']['pr']"
 						/>

--- a/components/reports/temperature/ReportTempChart.vue
+++ b/components/reports/temperature/ReportTempChart.vue
@@ -83,6 +83,11 @@ export default {
 			}
 
 			let scatterTraces = {}
+			let symbols = {
+				'5modelAvg': 'circle',
+				'MRI-CGCM3': 'square',
+				'CCSM4': 'diamond',
+			}
 			models.forEach(model => {
 				scatterTraces[model] = {}
 				scenarios.forEach(scenario => {
@@ -92,6 +97,10 @@ export default {
 						name: traceLabels_lu[model][scenario],
 						hoverinfo: 'x+y+z+text',
 						hovertemplate: '%{y}' + units,
+						marker: {
+							symbol: Array(decades.length).fill(symbols[model]),
+							size: 8,
+						},
 						x: decades.slice(1),
 						y: [],
 					}

--- a/components/reports/temperature/ReportTempChart.vue
+++ b/components/reports/temperature/ReportTempChart.vue
@@ -90,9 +90,9 @@ export default {
 
 				if (decade === '1950_2009') {
 					let tasData = this.reportData[decade][this.season]['CRU-TS40']['CRU_historical']['tas']
-					historical['median'].push(tasData['mean'])
-					historical['q1'].push(tasData['lo_std'])
-					historical['q3'].push(tasData['hi_std'])
+					historical['median'].push(tasData['median'])
+					historical['q1'].push(tasData['q1'])
+					historical['q3'].push(tasData['q3'])
 					historical['lowerfence'].push(tasData['min'])
 					historical['upperfence'].push(tasData['max'])
 				} else {

--- a/components/reports/temperature/ReportTempChart.vue
+++ b/components/reports/temperature/ReportTempChart.vue
@@ -171,6 +171,7 @@ export default {
 						opacity: 0.2
 					},
 				],
+				hovermode: 'x unified',
 			}
 
 			// Draw freezing line only if it falls within range of displayed data to

--- a/components/reports/temperature/ReportTempChart.vue
+++ b/components/reports/temperature/ReportTempChart.vue
@@ -151,8 +151,9 @@ export default {
 					{
 						type: 'rect',
 						x0: 0,
+						x1: 1,
+						xref: 'paper',
 						y0: this.reportData['1950_2009'][this.season]['CRU-TS40']['CRU_historical']['tas']['q1'],
-						x1: decades.length - 1,
 						y1: this.reportData['1950_2009'][this.season]['CRU-TS40']['CRU_historical']['tas']['q3'],
 						line: {
 							width: 0

--- a/components/reports/temperature/ReportTempChart.vue
+++ b/components/reports/temperature/ReportTempChart.vue
@@ -55,21 +55,33 @@ export default {
 				upperfence: [],
 			}
 
-			let rcp45 = {
-				type: 'scatter',
-				mode: 'markers',
-				name: 'RCP 4.5',
-				x: decades.slice(1),
-				y: [],
+			let models = ['MRI-CGCM3', 'CCSM4']
+			let scenarios = ['rcp45', 'rcp85']
+
+			let traceLabels_lu = {
+				'MRI-CGCM3': {
+					'rcp45': 'RCP 4.5 (MRI)',
+					'rcp85': 'RCP 8.5 (MRI)',
+				},
+				'CCSM4': {
+					'rcp45': 'RCP 4.5 (NCAR)',
+					'rcp85': 'RCP 8.5 (NCAR)',
+				},
 			}
 
-			let rcp85 = {
-				type: 'scatter',
-				mode: 'markers',
-				name: 'RCP 8.5',
-				x: decades.slice(1),
-				y: [],
-			}
+			let scatterTraces = {}
+			models.forEach(model => {
+				scatterTraces[model] = {}
+				scenarios.forEach(scenario => {
+					scatterTraces[model][scenario] = {
+						type: 'scatter',
+						mode: 'markers',
+						name: traceLabels_lu[model][scenario],
+						x: decades.slice(1),
+						y: [],
+					}
+				})
+			})
 
 			decade_keys.forEach(decade => {
 				if (decade === '1950_2009') {
@@ -80,14 +92,21 @@ export default {
 					historical['lowerfence'].push(tasData['min'])
 					historical['upperfence'].push(tasData['max'])
 				} else {
-					let rcp45_mean = this.chartData[decade][this.season]['5modelAvg']['rcp45']['tas']
-					let rcp85_mean = this.chartData[decade][this.season]['5modelAvg']['rcp85']['tas']
-					rcp45['y'].push(rcp45_mean)
-					rcp85['y'].push(rcp85_mean)
+					models.forEach(model => {
+						scenarios.forEach(scenario => {
+							scatterTraces[model][scenario]['y'].push(this.chartData[decade][this.season][model][scenario]['tas'])
+						})
+					})
 				}
 			})
 
-			data_traces.push(historical, rcp45, rcp85)
+			data_traces.push(historical)
+
+			models.forEach(model => {
+				scenarios.forEach(scenario => {
+					data_traces.push(scatterTraces[model][scenario])
+				})
+			})
 
 			var layout = {
 				boxmode: 'group',

--- a/components/reports/temperature/ReportTempChart.vue
+++ b/components/reports/temperature/ReportTempChart.vue
@@ -98,7 +98,7 @@ export default {
 			})
 
 			decade_keys.forEach(decade => {
-				if (decade === '2040_2070' || decade === '2070_2100') {
+				if (decade === '2040_2069' || decade === '2070_2099') {
 					return
 				}
 

--- a/components/reports/temperature/ReportTempChart.vue
+++ b/components/reports/temperature/ReportTempChart.vue
@@ -60,16 +60,23 @@ export default {
 				upperfence: [],
 			}
 
-			let models = ['MRI-CGCM3', 'CCSM4']
-			let scenarios = ['rcp45', 'rcp85']
+			let models = ['5modelAvg', 'MRI-CGCM3', 'CCSM4']
+			let scenarios = ['rcp45', 'rcp60', 'rcp85']
 
 			let traceLabels_lu = {
+				'5modelAvg': {
+					'rcp45': 'RCP 4.5 (5 Model Avg.)',
+					'rcp60': 'RCP 6.0 (5 Model Avg.)',
+					'rcp85': 'RCP 8.5 (5 Model Avg.)',
+				},
 				'MRI-CGCM3': {
 					'rcp45': 'RCP 4.5 (MRI)',
+					'rcp60': 'RCP 6.0 (MRI)',
 					'rcp85': 'RCP 8.5 (MRI)',
 				},
 				'CCSM4': {
 					'rcp45': 'RCP 4.5 (NCAR)',
+					'rcp60': 'RCP 6.0 (NCAR)',
 					'rcp85': 'RCP 8.5 (NCAR)',
 				},
 			}
@@ -82,6 +89,8 @@ export default {
 						type: 'scatter',
 						mode: 'markers',
 						name: traceLabels_lu[model][scenario],
+						text: traceLabels_lu[model][scenario],
+						hoverinfo: 'x+y+z+text',
 						x: decades.slice(1),
 						y: [],
 					}

--- a/components/reports/temperature/ReportTempChart.vue
+++ b/components/reports/temperature/ReportTempChart.vue
@@ -33,6 +33,7 @@ export default {
 
 			let data_traces = []
 			let units = this.units == 'metric' ? 'ºC' : 'ºF'
+			let freezing = this.units == 'metric' ? 0 : 32
 
 			let season_lu = {
 				'DJF': 'December - February',
@@ -97,6 +98,7 @@ export default {
 				})
 			})
 
+			let allValues = []
 			decade_keys.forEach(decade => {
 				if (decade === '2040_2069' || decade === '2070_2099') {
 					return
@@ -109,10 +111,12 @@ export default {
 					historical['q3'].push(tasData['q3'])
 					historical['lowerfence'].push(tasData['min'])
 					historical['upperfence'].push(tasData['max'])
+					allValues.push(tasData['median'], tasData['q1'], tasData['q3'], tasData['min'], tasData['max'])
 				} else {
 					models.forEach(model => {
 						scenarios.forEach(scenario => {
 							scatterTraces[model][scenario]['y'].push(this.reportData[decade][this.season][model][scenario]['tas'])
+							allValues.push(this.reportData[decade][this.season][model][scenario]['tas'])
 						})
 					})
 				}
@@ -135,6 +139,7 @@ export default {
 							size: 18,
 						},
 					},
+					zeroline: false,
 				},
 				title: {
 					text: 'Historical and projected temperature (' + season_lu[this.season] + ')',
@@ -156,6 +161,24 @@ export default {
 						opacity: 0.2
 					},
 				],
+			}
+
+			// Draw freezing line only if it falls within range of displayed data to
+			// prevent it from extending the y-axis.
+			if (_.inRange(freezing, _.min(allValues), _.max(allValues))) {
+				layout.shapes.push({
+					type: 'line',
+					x0: 0,
+					x1: 1,
+					xref: 'paper',
+					y0: freezing,
+					y1: freezing,
+					yref: 'y',
+					line: {
+						width: 1,
+						color: 'rgb(175, 175, 175)',
+					},
+				})
 			}
 
 			this.$Plotly.newPlot('temp-chart', data_traces, layout, {

--- a/components/reports/temperature/ReportTempChart.vue
+++ b/components/reports/temperature/ReportTempChart.vue
@@ -90,8 +90,8 @@ export default {
 						type: 'scatter',
 						mode: 'markers',
 						name: traceLabels_lu[model][scenario],
-						text: traceLabels_lu[model][scenario],
 						hoverinfo: 'x+y+z+text',
+						hovertemplate: '%{y}' + units,
 						x: decades.slice(1),
 						y: [],
 					}

--- a/components/reports/temperature/ReportTempChart.vue
+++ b/components/reports/temperature/ReportTempChart.vue
@@ -142,6 +142,20 @@ export default {
 						size: 24,
 					},
 				},
+				shapes: [
+					{
+						type: 'rect',
+						x0: 0,
+						y0: this.reportData['1950_2009'][this.season]['CRU-TS40']['CRU_historical']['tas']['q1'],
+						x1: decades.length - 1,
+						y1: this.reportData['1950_2009'][this.season]['CRU-TS40']['CRU_historical']['tas']['q3'],
+						line: {
+							width: 0
+						},
+						fillcolor: '#cccccc',
+						opacity: 0.2
+					},
+				],
 			}
 
 			this.$Plotly.newPlot('temp-chart', data_traces, layout, {

--- a/components/reports/temperature/ReportTempChart.vue
+++ b/components/reports/temperature/ReportTempChart.vue
@@ -42,6 +42,11 @@ export default {
 			}
 
 			let decade_keys = Object.keys(this.reportData)
+			decade_keys = decade_keys.filter(value => {
+				if (value !== '2040_2069' && value !== '2070_2099') {
+					return value
+				}
+			})
 			let decades = decade_keys.map(x => x.replace('_', '-'))
 
 			let historical = {

--- a/components/reports/temperature/ReportTempChart.vue
+++ b/components/reports/temperature/ReportTempChart.vue
@@ -100,7 +100,7 @@ export default {
 					},
 				},
 				title: {
-					text: 'Historical and projected temperature ranges (' + season_lu[this.season] + ')',
+					text: 'Historical and projected temperature (' + season_lu[this.season] + ')',
 					font: {
 						size: 24,
 					},

--- a/components/reports/temperature/ReportTempChart.vue
+++ b/components/reports/temperature/ReportTempChart.vue
@@ -1,23 +1,26 @@
 <template>
-	<div style="display: none;" class="temp-chart-wrapper">
+	<div class="temp-chart-wrapper">
 		<div id="temp-chart" />
 	</div>
 </template>
 <style lang="scss" scoped>
 .temp-chart-wrapper {
-	padding-bottom: 6rem;
+	padding-bottom: 0rem;
 }
 </style>
 <script>
 import _ from 'lodash'
 export default {
 	name: 'ReportTempChart',
-	props: ['reportData', 'units'],
+	props: ['reportData', 'chartData', 'units', 'season'],
 	mounted() {
 		this.renderPlot()
 	},
 	watch: {
 		reportData: function () {
+			this.renderPlot()
+		},
+		season: function () {
 			this.renderPlot()
 		},
 	},
@@ -28,108 +31,66 @@ export default {
 				return
 			}
 
-			let seasons = ['DJF', 'MAM', 'JJA', 'SON']
-			let seasons_names = ['Winter', 'Spring', 'Summer', 'Fall']
 			let data_traces = []
-			let axisGroups = {
-				DJF: { x: 'x1', y: 'y1' },
-				MAM: { x: 'x2', y: 'y2' },
-				JJA: { x: 'x3', y: 'y3' },
-				SON: { x: 'x4', y: 'y4' },
-			}
 			let units = this.units == 'metric' ? 'ºC' : 'ºF'
-			function get_seasonal_subplot(season) {
-				let xAxisDef = [
-					'<b>2040-2070</b>, MRI-CGCM3',
-					'<b>2040-2070</b>, NCAR-CCSM4',
-					'<b>2070-2100</b>, MRI-CGCM3',
-					'<b>2070-2100</b>, NCAR-CCSM4',
-				]
 
-				let trace_rcp45 = {
-					x: xAxisDef,
-					y: [
-						reportData['2040_2070'][season]['MRI-CGCM3']['rcp45']['tas'],
-						reportData['2040_2070'][season]['CCSM4']['rcp45']['tas'],
-						reportData['2070_2100'][season]['MRI-CGCM3']['rcp45']['tas'],
-						reportData['2070_2100'][season]['CCSM4']['rcp45']['tas'],
-					],
-					xaxis: axisGroups[season]['x'],
-					yaxis: axisGroups[season]['y'],
-					type: 'scatter',
-					mode: 'markers',
-					showlegend: false,
-					marker: { color: '#999', size: 8, symbol: 'square' },
-				}
-
-				let trace_rcp85 = {
-					x: xAxisDef,
-					y: [
-						reportData['2040_2070'][season]['MRI-CGCM3']['rcp85']['tas'],
-						reportData['2040_2070'][season]['CCSM4']['rcp85']['tas'],
-						reportData['2070_2100'][season]['MRI-CGCM3']['rcp85']['tas'],
-						reportData['2070_2100'][season]['CCSM4']['rcp85']['tas'],
-					],
-					xaxis: axisGroups[season]['x'],
-					yaxis: axisGroups[season]['y'],
-					type: 'scatter',
-					mode: 'markers',
-					showlegend: false,
-					marker: { color: '#333', size: 8 },
-				}
-
-				let historical_temp =
-					reportData['1910-2009'][season]['CRU-TS31']['CRU_historical']['tas']
-				let trace_historical = {
-					x: xAxisDef,
-					y: [
-						historical_temp,
-						historical_temp,
-						historical_temp,
-						historical_temp,
-					],
-					xaxis: axisGroups[season]['x'],
-					yaxis: axisGroups[season]['y'],
-					name: 'cats',
-					type: 'scatter',
-					mode: 'lines+text',
-					showlegend: false,
-					text: [
-						'Historical (CRU TS 3.1), <b>' + historical_temp + units + '</b>',
-						'',
-						'',
-						'',
-					],
-					textposition: 'top right',
-				}
-
-				data_traces.push(trace_rcp45, trace_rcp85, trace_historical)
+			let season_lu = {
+				'DJF': 'December - February',
+				'MAM': 'March - May',
+				'JJA': 'June - August',
+				'SON': 'September - November',
 			}
 
-			seasons.forEach((season) => {
-				get_seasonal_subplot(season)
-			})
+			let decade_keys = Object.keys(this.chartData)
+			let decades = decade_keys.map(x => x.replace('_', '-'))
 
-			var annotations = _.map(seasons_names, (season, index) => {
-				return {
-					xref: 'paper',
-					yref: 'paper',
-					x: index * 0.25 + 0.015 * index, // wiggle a bit
-					y: 1.025,
-					xanchor: 'left',
-					yanchor: 'bottom',
-					text: season,
-					font: {
-						family: 'Arial',
-						size: 18,
-						color: 'rgb(37,37,37)',
-					},
-					showarrow: false,
+			let historical = {
+				type: 'box',
+				name: 'Historical',
+				x: decades.slice(0, 1),
+				q1: [],
+				median: [],
+				q3: [],
+				lowerfence: [],
+				upperfence: [],
+			}
+
+			let rcp45 = {
+				type: 'scatter',
+				mode: 'markers',
+				name: 'RCP 4.5',
+				x: decades.slice(1),
+				y: [],
+			}
+
+			let rcp85 = {
+				type: 'scatter',
+				mode: 'markers',
+				name: 'RCP 8.5',
+				x: decades.slice(1),
+				y: [],
+			}
+
+			decade_keys.forEach(decade => {
+				if (decade === '1950_2009') {
+					let tasData = this.chartData[decade][this.season]['CRU-TS40']['CRU_historical']['tas']
+					historical['median'].push(tasData['mean'])
+					historical['q1'].push(tasData['lo_std'])
+					historical['q3'].push(tasData['hi_std'])
+					historical['lowerfence'].push(tasData['min'])
+					historical['upperfence'].push(tasData['max'])
+				} else {
+					let rcp45_mean = this.chartData[decade][this.season]['5modelAvg']['rcp45']['tas']
+					let rcp85_mean = this.chartData[decade][this.season]['5modelAvg']['rcp85']['tas']
+					rcp45['y'].push(rcp45_mean)
+					rcp85['y'].push(rcp85_mean)
 				}
 			})
+
+			data_traces.push(historical, rcp45, rcp85)
 
 			var layout = {
-				grid: { rows: 1, columns: 4, pattern: 'independent' },
+				boxmode: 'group',
 				yaxis: {
 					title: {
 						text: 'Temperature ' + units,
@@ -139,13 +100,11 @@ export default {
 					},
 				},
 				title: {
-					text: 'Projected temperatures',
+					text: 'Historical and projected temperature ranges (' + season_lu[this.season] + ')',
 					font: {
 						size: 24,
 					},
 				},
-				annotations: annotations,
-				// showlegend: false,
 			}
 
 			this.$Plotly.newPlot('temp-chart', data_traces, layout, {

--- a/components/reports/temperature/ReportTempChart.vue
+++ b/components/reports/temperature/ReportTempChart.vue
@@ -12,7 +12,7 @@
 import _ from 'lodash'
 export default {
 	name: 'ReportTempChart',
-	props: ['reportData', 'chartData', 'units', 'season'],
+	props: ['reportData', 'units', 'season'],
 	mounted() {
 		this.renderPlot()
 	},
@@ -41,7 +41,7 @@ export default {
 				'SON': 'September - November',
 			}
 
-			let decade_keys = Object.keys(this.chartData)
+			let decade_keys = Object.keys(this.reportData)
 			let decades = decade_keys.map(x => x.replace('_', '-'))
 
 			let historical = {
@@ -84,8 +84,12 @@ export default {
 			})
 
 			decade_keys.forEach(decade => {
+				if (decade === '2040_2070' || decade === '2070_2100') {
+					return
+				}
+
 				if (decade === '1950_2009') {
-					let tasData = this.chartData[decade][this.season]['CRU-TS40']['CRU_historical']['tas']
+					let tasData = this.reportData[decade][this.season]['CRU-TS40']['CRU_historical']['tas']
 					historical['median'].push(tasData['mean'])
 					historical['q1'].push(tasData['lo_std'])
 					historical['q3'].push(tasData['hi_std'])
@@ -94,7 +98,7 @@ export default {
 				} else {
 					models.forEach(model => {
 						scenarios.forEach(scenario => {
-							scatterTraces[model][scenario]['y'].push(this.chartData[decade][this.season][model][scenario]['tas'])
+							scatterTraces[model][scenario]['y'].push(this.reportData[decade][this.season][model][scenario]['tas'])
 						})
 					})
 				}

--- a/components/reports/temperature/ReportTempTable.vue
+++ b/components/reports/temperature/ReportTempTable.vue
@@ -50,10 +50,10 @@
 						}}<UnitWidget :units="units" />
 					</td>
 					<td>
-						{{ reportData['2040_2070']['DJF']['MRI-CGCM3']['rcp45']['tas']
+						{{ reportData['2040_2069']['DJF']['MRI-CGCM3']['rcp45']['tas']
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="
-								reportData['2040_2070']['DJF']['MRI-CGCM3']['rcp45']['tas']
+								reportData['2040_2069']['DJF']['MRI-CGCM3']['rcp45']['tas']
 							"
 							:past="
 								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
@@ -61,39 +61,19 @@
 						/>
 					</td>
 					<td>
-						{{ reportData['2040_2070']['DJF']['CCSM4']['rcp45']['tas']
+						{{ reportData['2040_2069']['DJF']['CCSM4']['rcp45']['tas']
 						}}<UnitWidget :units="units" /><TempDiffWidget
-							:future="reportData['2040_2070']['DJF']['CCSM4']['rcp45']['tas']"
+							:future="reportData['2040_2069']['DJF']['CCSM4']['rcp45']['tas']"
 							:past="
 								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
 					<td>
-						{{ reportData['2040_2070']['DJF']['MRI-CGCM3']['rcp85']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
-							:future="
-								reportData['2040_2070']['DJF']['MRI-CGCM3']['rcp85']['tas']
-							"
-							:past="
-								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
-							"
-						/>
-					</td>
-					<td>
-						{{ reportData['2040_2070']['DJF']['CCSM4']['rcp85']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
-							:future="reportData['2040_2070']['DJF']['CCSM4']['rcp85']['tas']"
-							:past="
-								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
-							"
-						/>
-					</td>
-					<td>
-						{{ reportData['2070_2100']['DJF']['MRI-CGCM3']['rcp45']['tas']
+						{{ reportData['2040_2069']['DJF']['MRI-CGCM3']['rcp85']['tas']
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="
-								reportData['2070_2100']['DJF']['MRI-CGCM3']['rcp45']['tas']
+								reportData['2040_2069']['DJF']['MRI-CGCM3']['rcp85']['tas']
 							"
 							:past="
 								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
@@ -101,19 +81,19 @@
 						/>
 					</td>
 					<td>
-						{{ reportData['2070_2100']['DJF']['CCSM4']['rcp45']['tas']
+						{{ reportData['2040_2069']['DJF']['CCSM4']['rcp85']['tas']
 						}}<UnitWidget :units="units" /><TempDiffWidget
-							:future="reportData['2070_2100']['DJF']['CCSM4']['rcp45']['tas']"
+							:future="reportData['2040_2069']['DJF']['CCSM4']['rcp85']['tas']"
 							:past="
 								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
 					<td>
-						{{ reportData['2070_2100']['DJF']['MRI-CGCM3']['rcp85']['tas']
+						{{ reportData['2070_2099']['DJF']['MRI-CGCM3']['rcp45']['tas']
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="
-								reportData['2070_2100']['DJF']['MRI-CGCM3']['rcp85']['tas']
+								reportData['2070_2099']['DJF']['MRI-CGCM3']['rcp45']['tas']
 							"
 							:past="
 								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
@@ -121,9 +101,29 @@
 						/>
 					</td>
 					<td>
-						{{ reportData['2070_2100']['DJF']['CCSM4']['rcp85']['tas']
+						{{ reportData['2070_2099']['DJF']['CCSM4']['rcp45']['tas']
 						}}<UnitWidget :units="units" /><TempDiffWidget
-							:future="reportData['2070_2100']['DJF']['CCSM4']['rcp85']['tas']"
+							:future="reportData['2070_2099']['DJF']['CCSM4']['rcp45']['tas']"
+							:past="
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
+							"
+						/>
+					</td>
+					<td>
+						{{ reportData['2070_2099']['DJF']['MRI-CGCM3']['rcp85']['tas']
+						}}<UnitWidget :units="units" /><TempDiffWidget
+							:future="
+								reportData['2070_2099']['DJF']['MRI-CGCM3']['rcp85']['tas']
+							"
+							:past="
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
+							"
+						/>
+					</td>
+					<td>
+						{{ reportData['2070_2099']['DJF']['CCSM4']['rcp85']['tas']
+						}}<UnitWidget :units="units" /><TempDiffWidget
+							:future="reportData['2070_2099']['DJF']['CCSM4']['rcp85']['tas']"
 							:past="
 								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
@@ -138,10 +138,10 @@
 						}}<UnitWidget :units="units" />
 					</td>
 					<td>
-						{{ reportData['2040_2070']['MAM']['MRI-CGCM3']['rcp45']['tas']
+						{{ reportData['2040_2069']['MAM']['MRI-CGCM3']['rcp45']['tas']
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="
-								reportData['2040_2070']['MAM']['MRI-CGCM3']['rcp45']['tas']
+								reportData['2040_2069']['MAM']['MRI-CGCM3']['rcp45']['tas']
 							"
 							:past="
 								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
@@ -149,39 +149,19 @@
 						/>
 					</td>
 					<td>
-						{{ reportData['2040_2070']['MAM']['CCSM4']['rcp45']['tas']
+						{{ reportData['2040_2069']['MAM']['CCSM4']['rcp45']['tas']
 						}}<UnitWidget :units="units" /><TempDiffWidget
-							:future="reportData['2040_2070']['MAM']['CCSM4']['rcp45']['tas']"
+							:future="reportData['2040_2069']['MAM']['CCSM4']['rcp45']['tas']"
 							:past="
 								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
 					<td>
-						{{ reportData['2040_2070']['MAM']['MRI-CGCM3']['rcp85']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
-							:future="
-								reportData['2040_2070']['MAM']['MRI-CGCM3']['rcp85']['tas']
-							"
-							:past="
-								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
-							"
-						/>
-					</td>
-					<td>
-						{{ reportData['2040_2070']['MAM']['CCSM4']['rcp85']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
-							:future="reportData['2040_2070']['MAM']['CCSM4']['rcp85']['tas']"
-							:past="
-								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
-							"
-						/>
-					</td>
-					<td>
-						{{ reportData['2070_2100']['MAM']['MRI-CGCM3']['rcp45']['tas']
+						{{ reportData['2040_2069']['MAM']['MRI-CGCM3']['rcp85']['tas']
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="
-								reportData['2070_2100']['MAM']['MRI-CGCM3']['rcp45']['tas']
+								reportData['2040_2069']['MAM']['MRI-CGCM3']['rcp85']['tas']
 							"
 							:past="
 								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
@@ -189,19 +169,19 @@
 						/>
 					</td>
 					<td>
-						{{ reportData['2070_2100']['MAM']['CCSM4']['rcp45']['tas']
+						{{ reportData['2040_2069']['MAM']['CCSM4']['rcp85']['tas']
 						}}<UnitWidget :units="units" /><TempDiffWidget
-							:future="reportData['2070_2100']['MAM']['CCSM4']['rcp45']['tas']"
+							:future="reportData['2040_2069']['MAM']['CCSM4']['rcp85']['tas']"
 							:past="
 								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
 					<td>
-						{{ reportData['2070_2100']['MAM']['MRI-CGCM3']['rcp85']['tas']
+						{{ reportData['2070_2099']['MAM']['MRI-CGCM3']['rcp45']['tas']
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="
-								reportData['2070_2100']['MAM']['MRI-CGCM3']['rcp85']['tas']
+								reportData['2070_2099']['MAM']['MRI-CGCM3']['rcp45']['tas']
 							"
 							:past="
 								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
@@ -209,9 +189,29 @@
 						/>
 					</td>
 					<td>
-						{{ reportData['2070_2100']['MAM']['CCSM4']['rcp85']['tas']
+						{{ reportData['2070_2099']['MAM']['CCSM4']['rcp45']['tas']
 						}}<UnitWidget :units="units" /><TempDiffWidget
-							:future="reportData['2070_2100']['MAM']['CCSM4']['rcp85']['tas']"
+							:future="reportData['2070_2099']['MAM']['CCSM4']['rcp45']['tas']"
+							:past="
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
+							"
+						/>
+					</td>
+					<td>
+						{{ reportData['2070_2099']['MAM']['MRI-CGCM3']['rcp85']['tas']
+						}}<UnitWidget :units="units" /><TempDiffWidget
+							:future="
+								reportData['2070_2099']['MAM']['MRI-CGCM3']['rcp85']['tas']
+							"
+							:past="
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
+							"
+						/>
+					</td>
+					<td>
+						{{ reportData['2070_2099']['MAM']['CCSM4']['rcp85']['tas']
+						}}<UnitWidget :units="units" /><TempDiffWidget
+							:future="reportData['2070_2099']['MAM']['CCSM4']['rcp85']['tas']"
 							:past="
 								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
@@ -226,10 +226,10 @@
 						}}<UnitWidget :units="units" />
 					</td>
 					<td>
-						{{ reportData['2040_2070']['JJA']['MRI-CGCM3']['rcp45']['tas']
+						{{ reportData['2040_2069']['JJA']['MRI-CGCM3']['rcp45']['tas']
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="
-								reportData['2040_2070']['JJA']['MRI-CGCM3']['rcp45']['tas']
+								reportData['2040_2069']['JJA']['MRI-CGCM3']['rcp45']['tas']
 							"
 							:past="
 								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
@@ -237,39 +237,19 @@
 						/>
 					</td>
 					<td>
-						{{ reportData['2040_2070']['JJA']['CCSM4']['rcp45']['tas']
+						{{ reportData['2040_2069']['JJA']['CCSM4']['rcp45']['tas']
 						}}<UnitWidget :units="units" /><TempDiffWidget
-							:future="reportData['2040_2070']['JJA']['CCSM4']['rcp45']['tas']"
+							:future="reportData['2040_2069']['JJA']['CCSM4']['rcp45']['tas']"
 							:past="
 								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
 					<td>
-						{{ reportData['2040_2070']['JJA']['MRI-CGCM3']['rcp85']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
-							:future="
-								reportData['2040_2070']['JJA']['MRI-CGCM3']['rcp85']['tas']
-							"
-							:past="
-								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
-							"
-						/>
-					</td>
-					<td>
-						{{ reportData['2040_2070']['JJA']['CCSM4']['rcp85']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
-							:future="reportData['2040_2070']['JJA']['CCSM4']['rcp85']['tas']"
-							:past="
-								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
-							"
-						/>
-					</td>
-					<td>
-						{{ reportData['2070_2100']['JJA']['MRI-CGCM3']['rcp45']['tas']
+						{{ reportData['2040_2069']['JJA']['MRI-CGCM3']['rcp85']['tas']
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="
-								reportData['2070_2100']['JJA']['MRI-CGCM3']['rcp45']['tas']
+								reportData['2040_2069']['JJA']['MRI-CGCM3']['rcp85']['tas']
 							"
 							:past="
 								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
@@ -277,19 +257,19 @@
 						/>
 					</td>
 					<td>
-						{{ reportData['2070_2100']['JJA']['CCSM4']['rcp45']['tas']
+						{{ reportData['2040_2069']['JJA']['CCSM4']['rcp85']['tas']
 						}}<UnitWidget :units="units" /><TempDiffWidget
-							:future="reportData['2070_2100']['JJA']['CCSM4']['rcp45']['tas']"
+							:future="reportData['2040_2069']['JJA']['CCSM4']['rcp85']['tas']"
 							:past="
 								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
 					<td>
-						{{ reportData['2070_2100']['JJA']['MRI-CGCM3']['rcp85']['tas']
+						{{ reportData['2070_2099']['JJA']['MRI-CGCM3']['rcp45']['tas']
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="
-								reportData['2070_2100']['JJA']['MRI-CGCM3']['rcp85']['tas']
+								reportData['2070_2099']['JJA']['MRI-CGCM3']['rcp45']['tas']
 							"
 							:past="
 								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
@@ -297,9 +277,29 @@
 						/>
 					</td>
 					<td>
-						{{ reportData['2070_2100']['JJA']['CCSM4']['rcp85']['tas']
+						{{ reportData['2070_2099']['JJA']['CCSM4']['rcp45']['tas']
 						}}<UnitWidget :units="units" /><TempDiffWidget
-							:future="reportData['2070_2100']['JJA']['CCSM4']['rcp85']['tas']"
+							:future="reportData['2070_2099']['JJA']['CCSM4']['rcp45']['tas']"
+							:past="
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
+							"
+						/>
+					</td>
+					<td>
+						{{ reportData['2070_2099']['JJA']['MRI-CGCM3']['rcp85']['tas']
+						}}<UnitWidget :units="units" /><TempDiffWidget
+							:future="
+								reportData['2070_2099']['JJA']['MRI-CGCM3']['rcp85']['tas']
+							"
+							:past="
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
+							"
+						/>
+					</td>
+					<td>
+						{{ reportData['2070_2099']['JJA']['CCSM4']['rcp85']['tas']
+						}}<UnitWidget :units="units" /><TempDiffWidget
+							:future="reportData['2070_2099']['JJA']['CCSM4']['rcp85']['tas']"
 							:past="
 								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
@@ -314,10 +314,10 @@
 						}}<UnitWidget :units="units" />
 					</td>
 					<td>
-						{{ reportData['2040_2070']['SON']['MRI-CGCM3']['rcp45']['tas']
+						{{ reportData['2040_2069']['SON']['MRI-CGCM3']['rcp45']['tas']
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="
-								reportData['2040_2070']['SON']['MRI-CGCM3']['rcp45']['tas']
+								reportData['2040_2069']['SON']['MRI-CGCM3']['rcp45']['tas']
 							"
 							:past="
 								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
@@ -325,39 +325,19 @@
 						/>
 					</td>
 					<td>
-						{{ reportData['2040_2070']['SON']['CCSM4']['rcp45']['tas']
+						{{ reportData['2040_2069']['SON']['CCSM4']['rcp45']['tas']
 						}}<UnitWidget :units="units" /><TempDiffWidget
-							:future="reportData['2040_2070']['SON']['CCSM4']['rcp45']['tas']"
+							:future="reportData['2040_2069']['SON']['CCSM4']['rcp45']['tas']"
 							:past="
 								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
 					<td>
-						{{ reportData['2040_2070']['SON']['MRI-CGCM3']['rcp85']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
-							:future="
-								reportData['2040_2070']['SON']['MRI-CGCM3']['rcp85']['tas']
-							"
-							:past="
-								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
-							"
-						/>
-					</td>
-					<td>
-						{{ reportData['2040_2070']['SON']['CCSM4']['rcp85']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
-							:future="reportData['2040_2070']['SON']['CCSM4']['rcp85']['tas']"
-							:past="
-								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
-							"
-						/>
-					</td>
-					<td>
-						{{ reportData['2070_2100']['SON']['MRI-CGCM3']['rcp45']['tas']
+						{{ reportData['2040_2069']['SON']['MRI-CGCM3']['rcp85']['tas']
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="
-								reportData['2070_2100']['SON']['MRI-CGCM3']['rcp45']['tas']
+								reportData['2040_2069']['SON']['MRI-CGCM3']['rcp85']['tas']
 							"
 							:past="
 								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
@@ -365,19 +345,19 @@
 						/>
 					</td>
 					<td>
-						{{ reportData['2070_2100']['SON']['CCSM4']['rcp45']['tas']
+						{{ reportData['2040_2069']['SON']['CCSM4']['rcp85']['tas']
 						}}<UnitWidget :units="units" /><TempDiffWidget
-							:future="reportData['2070_2100']['SON']['CCSM4']['rcp45']['tas']"
+							:future="reportData['2040_2069']['SON']['CCSM4']['rcp85']['tas']"
 							:past="
 								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
 					<td>
-						{{ reportData['2070_2100']['SON']['MRI-CGCM3']['rcp85']['tas']
+						{{ reportData['2070_2099']['SON']['MRI-CGCM3']['rcp45']['tas']
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="
-								reportData['2070_2100']['SON']['MRI-CGCM3']['rcp85']['tas']
+								reportData['2070_2099']['SON']['MRI-CGCM3']['rcp45']['tas']
 							"
 							:past="
 								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
@@ -385,9 +365,29 @@
 						/>
 					</td>
 					<td>
-						{{ reportData['2070_2100']['SON']['CCSM4']['rcp85']['tas']
+						{{ reportData['2070_2099']['SON']['CCSM4']['rcp45']['tas']
 						}}<UnitWidget :units="units" /><TempDiffWidget
-							:future="reportData['2070_2100']['SON']['CCSM4']['rcp85']['tas']"
+							:future="reportData['2070_2099']['SON']['CCSM4']['rcp45']['tas']"
+							:past="
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
+							"
+						/>
+					</td>
+					<td>
+						{{ reportData['2070_2099']['SON']['MRI-CGCM3']['rcp85']['tas']
+						}}<UnitWidget :units="units" /><TempDiffWidget
+							:future="
+								reportData['2070_2099']['SON']['MRI-CGCM3']['rcp85']['tas']
+							"
+							:past="
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
+							"
+						/>
+					</td>
+					<td>
+						{{ reportData['2070_2099']['SON']['CCSM4']['rcp85']['tas']
+						}}<UnitWidget :units="units" /><TempDiffWidget
+							:future="reportData['2070_2099']['SON']['CCSM4']['rcp85']['tas']"
 							:past="
 								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"

--- a/components/reports/temperature/ReportTempTable.vue
+++ b/components/reports/temperature/ReportTempTable.vue
@@ -46,9 +46,7 @@
 					<th scope="row">Winter</th>
 					<td class="left">
 						{{
-							reportData['1910-2009']['DJF']['CRU-TS31']['CRU_historical'][
-								'tas'
-							]
+							reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
 						}}<UnitWidget :units="units" />
 					</td>
 					<td>
@@ -58,9 +56,7 @@
 								reportData['2040_2070']['DJF']['MRI-CGCM3']['rcp45']['tas']
 							"
 							:past="
-								reportData['1910-2009']['DJF']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -69,9 +65,7 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2040_2070']['DJF']['CCSM4']['rcp45']['tas']"
 							:past="
-								reportData['1910-2009']['DJF']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -82,9 +76,7 @@
 								reportData['2040_2070']['DJF']['MRI-CGCM3']['rcp85']['tas']
 							"
 							:past="
-								reportData['1910-2009']['DJF']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -93,9 +85,7 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2040_2070']['DJF']['CCSM4']['rcp85']['tas']"
 							:past="
-								reportData['1910-2009']['DJF']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -106,9 +96,7 @@
 								reportData['2070_2100']['DJF']['MRI-CGCM3']['rcp45']['tas']
 							"
 							:past="
-								reportData['1910-2009']['DJF']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -117,9 +105,7 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2070_2100']['DJF']['CCSM4']['rcp45']['tas']"
 							:past="
-								reportData['1910-2009']['DJF']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -130,9 +116,7 @@
 								reportData['2070_2100']['DJF']['MRI-CGCM3']['rcp85']['tas']
 							"
 							:past="
-								reportData['1910-2009']['DJF']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -141,9 +125,7 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2070_2100']['DJF']['CCSM4']['rcp85']['tas']"
 							:past="
-								reportData['1910-2009']['DJF']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -152,9 +134,7 @@
 					<th scope="row">Spring</th>
 					<td class="left">
 						{{
-							reportData['1910-2009']['MAM']['CRU-TS31']['CRU_historical'][
-								'tas'
-							]
+							reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
 						}}<UnitWidget :units="units" />
 					</td>
 					<td>
@@ -164,9 +144,7 @@
 								reportData['2040_2070']['MAM']['MRI-CGCM3']['rcp45']['tas']
 							"
 							:past="
-								reportData['1910-2009']['MAM']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -175,9 +153,7 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2040_2070']['MAM']['CCSM4']['rcp45']['tas']"
 							:past="
-								reportData['1910-2009']['MAM']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -188,9 +164,7 @@
 								reportData['2040_2070']['MAM']['MRI-CGCM3']['rcp85']['tas']
 							"
 							:past="
-								reportData['1910-2009']['MAM']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -199,9 +173,7 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2040_2070']['MAM']['CCSM4']['rcp85']['tas']"
 							:past="
-								reportData['1910-2009']['MAM']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -212,9 +184,7 @@
 								reportData['2070_2100']['MAM']['MRI-CGCM3']['rcp45']['tas']
 							"
 							:past="
-								reportData['1910-2009']['MAM']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -223,9 +193,7 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2070_2100']['MAM']['CCSM4']['rcp45']['tas']"
 							:past="
-								reportData['1910-2009']['MAM']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -236,9 +204,7 @@
 								reportData['2070_2100']['MAM']['MRI-CGCM3']['rcp85']['tas']
 							"
 							:past="
-								reportData['1910-2009']['MAM']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -247,9 +213,7 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2070_2100']['MAM']['CCSM4']['rcp85']['tas']"
 							:past="
-								reportData['1910-2009']['MAM']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -258,9 +222,7 @@
 					<th scope="row">Summer</th>
 					<td class="left">
 						{{
-							reportData['1910-2009']['JJA']['CRU-TS31']['CRU_historical'][
-								'tas'
-							]
+							reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
 						}}<UnitWidget :units="units" />
 					</td>
 					<td>
@@ -270,9 +232,7 @@
 								reportData['2040_2070']['JJA']['MRI-CGCM3']['rcp45']['tas']
 							"
 							:past="
-								reportData['1910-2009']['JJA']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -281,9 +241,7 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2040_2070']['JJA']['CCSM4']['rcp45']['tas']"
 							:past="
-								reportData['1910-2009']['JJA']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -294,9 +252,7 @@
 								reportData['2040_2070']['JJA']['MRI-CGCM3']['rcp85']['tas']
 							"
 							:past="
-								reportData['1910-2009']['JJA']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -305,9 +261,7 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2040_2070']['JJA']['CCSM4']['rcp85']['tas']"
 							:past="
-								reportData['1910-2009']['JJA']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -318,9 +272,7 @@
 								reportData['2070_2100']['JJA']['MRI-CGCM3']['rcp45']['tas']
 							"
 							:past="
-								reportData['1910-2009']['JJA']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -329,9 +281,7 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2070_2100']['JJA']['CCSM4']['rcp45']['tas']"
 							:past="
-								reportData['1910-2009']['JJA']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -342,9 +292,7 @@
 								reportData['2070_2100']['JJA']['MRI-CGCM3']['rcp85']['tas']
 							"
 							:past="
-								reportData['1910-2009']['JJA']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -353,9 +301,7 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2070_2100']['JJA']['CCSM4']['rcp85']['tas']"
 							:past="
-								reportData['1910-2009']['JJA']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -364,9 +310,7 @@
 					<th scope="row">Fall</th>
 					<td class="left">
 						{{
-							reportData['1910-2009']['SON']['CRU-TS31']['CRU_historical'][
-								'tas'
-							]
+							reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
 						}}<UnitWidget :units="units" />
 					</td>
 					<td>
@@ -376,9 +320,7 @@
 								reportData['2040_2070']['SON']['MRI-CGCM3']['rcp45']['tas']
 							"
 							:past="
-								reportData['1910-2009']['SON']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -387,9 +329,7 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2040_2070']['SON']['CCSM4']['rcp45']['tas']"
 							:past="
-								reportData['1910-2009']['SON']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -400,9 +340,7 @@
 								reportData['2040_2070']['SON']['MRI-CGCM3']['rcp85']['tas']
 							"
 							:past="
-								reportData['1910-2009']['SON']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -411,9 +349,7 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2040_2070']['SON']['CCSM4']['rcp85']['tas']"
 							:past="
-								reportData['1910-2009']['SON']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -424,9 +360,7 @@
 								reportData['2070_2100']['SON']['MRI-CGCM3']['rcp45']['tas']
 							"
 							:past="
-								reportData['1910-2009']['SON']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -435,9 +369,7 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2070_2100']['SON']['CCSM4']['rcp45']['tas']"
 							:past="
-								reportData['1910-2009']['SON']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -448,9 +380,7 @@
 								reportData['2070_2100']['SON']['MRI-CGCM3']['rcp85']['tas']
 							"
 							:past="
-								reportData['1910-2009']['SON']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>
@@ -459,9 +389,7 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2070_2100']['SON']['CCSM4']['rcp85']['tas']"
 							:past="
-								reportData['1910-2009']['SON']['CRU-TS31']['CRU_historical'][
-									'tas'
-								]
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
 							"
 						/>
 					</td>

--- a/components/reports/temperature/TempReport.vue
+++ b/components/reports/temperature/TempReport.vue
@@ -27,7 +27,7 @@
 				<b-radio v-model="temp_season" name="temp_season" native-value="JJA">Summer</b-radio>
 				<b-radio v-model="temp_season" name="temp_season" native-value="SON">Fall</b-radio>
 			</b-field>
-			<ReportTempChart :reportData="reportData" :chartData="chartData" :units="units" :season="temp_season" />
+			<ReportTempChart :reportData="reportData" :units="units" :season="temp_season" />
 		</div>
 		<div class="table-wrapper">
 			<reportTempTable :reportData="reportData" :units="units" />
@@ -47,7 +47,7 @@ import ReportTempChart from './ReportTempChart'
 import ReportTempTable from './ReportTempTable'
 export default {
 	name: 'ReportTable',
-	props: ['reportData', 'chartData', 'units'],
+	props: ['reportData', 'units'],
 	components: { ReportTempChart, ReportTempTable },
 	data() {
 		return {

--- a/components/reports/temperature/TempReport.vue
+++ b/components/reports/temperature/TempReport.vue
@@ -21,7 +21,13 @@
 			</p>
 		</div>
 		<div class="chart-wrapper">
-			<ReportTempChart :reportData="reportData" :units="units" />
+			<b-field label="Season">
+				<b-radio v-model="temp_season" name="temp_season" native-value="DJF">Winter</b-radio>
+				<b-radio v-model="temp_season" name="temp_season" native-value="MAM">Spring</b-radio>
+				<b-radio v-model="temp_season" name="temp_season" native-value="JJA">Summer</b-radio>
+				<b-radio v-model="temp_season" name="temp_season" native-value="SON">Fall</b-radio>
+			</b-field>
+			<ReportTempChart :reportData="reportData" :chartData="chartData" :units="units" :season="temp_season" />
 		</div>
 		<div class="table-wrapper">
 			<reportTempTable :reportData="reportData" :units="units" />
@@ -41,7 +47,12 @@ import ReportTempChart from './ReportTempChart'
 import ReportTempTable from './ReportTempTable'
 export default {
 	name: 'ReportTable',
-	props: ['reportData', 'units'],
+	props: ['reportData', 'chartData', 'units'],
 	components: { ReportTempChart, ReportTempTable },
+	data() {
+		return {
+			temp_season: 'DJF'
+		}
+	},
 }
 </script>


### PR DESCRIPTION
Closes #19.
Closes #52.
Closes #68.
Closes #77.
Closes #89.
Closes #90.

This PR replaces the previous (hidden) iteration of the temp/precip charts. The new charts show the historical data as a box plot, and decadal projected data as single points. A season selector radio button menu has also been implemented above the charts.

Test this PR against the `iem_taspr_2km` branch of the data-api. These charts use data from the new `taspr` endpoint, which provides data from CRU TS 4.0 from 1950-2009 as the historical baseline instead of CRU TS 3.1 data from 1910-2009. Some historical values differ considerably vs. the previous historical baseline, with affects many of the difference calculations throughout the report. Compare the before & after differences to the Fairbanks report for example.

JavaScript code has also been added to combine and average decades 2040-2069 and 2070-2099 for use with the temp/precip tables. These combined decade values had been provided through the API's `iem` endpoint previously, but adding client code to do this allows us to keep the new `taspr` API endpoint clean and application agnostic, so it seems reasonable to do these calculations in the web app itself.