### PR TITLE
Fetch data when accessing report URL directly from static site hosted through S3

### DIFF
--- a/components/Report.vue
+++ b/components/Report.vue
@@ -195,6 +195,12 @@ export default {
 		this.units = 'imperial'
 	},
 	created() {
+		// Switch back to clean URL after S3 redirect. Adapted from here:
+		// https://via.studio/journal/hosting-a-reactjs-app-with-routing-on-aws-s3
+		const path = (/#!(\/.*)$/.exec(this.$route.fullPath) || [])[1]
+		if (path) {
+			this.$router.push({ path: path })
+		}
 		this.$fetch()
 	},
 	watch: {

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -194,6 +194,9 @@ export default {
 		this.originalData = this.results // save a copy!
 		this.units = 'imperial'
 	},
+	created() {
+		this.$fetch()
+	},
 	watch: {
 		units: function () {
 			if (this.units == 'metric') {


### PR DESCRIPTION
Closes #38.

Without this change, the Report component's `fetch()` method is only called during router transitions. This PR calls the `fetch()` method manually when the Report component is created, not only during router transitions. This makes it so the report fetches the data it needs regardless of how the report was accessed, including directly by URL. For example:

http://iem-test-2.s3-website-us-west-2.amazonaws.com/report/huc/19010106

STR (using a test S3 bucket named `iem-test-2` and the AWS CLI):
1. Generate a static version of the site using `npm run generate`
1. Enable website hosting on the S3 bucket: `aws s3 website s3://iem-test-2/ --index-document index.html --error-document index.html`
1. Upload the `dist` folder to an AWS bucket: `aws s3 cp dist s3://iem-test-2/ --acl public-read --recursive`

Add the following chunk of JSON to the S3 bucket's "Redirection rules" section, under the "Properties" tab:

```
[
    {
        "Condition": {
            "HttpErrorCodeReturnedEquals": "404"
        },
        "Redirect": {
            "ReplaceKeyPrefixWith": "#!/"
        }
    }
]
```

Make sure reports populate when you access them via direct URL. These should populate properly, for example:

http://iem-test-2.s3-website-us-west-2.amazonaws.com/report/huc/19010106
http://iem-test-2.s3-website-us-west-2.amazonaws.com/report/community/172
http://iem-test-2.s3-website-us-west-2.amazonaws.com/report/64.54/-165.33