### PR TITLE
Add date ranges to historical column in tables, small explainer blurb

### DIFF
--- a/components/reports/precipitation/ReportPrecipTable.vue
+++ b/components/reports/precipitation/ReportPrecipTable.vue
@@ -8,7 +8,7 @@
 			<thead>
 				<tr>
 					<th scope="col" rowspan="3" class="left">Season</th>
-					<th scope="col" rowspan="3" class="left">Historical Average</th>
+					<th scope="col" rowspan="3" class="left">Historical (1950&ndash;2009)</th>
 					<th scope="col" colspan="4" class="light-border">
 						Mid&ndash;Century (2040&ndash;2069)
 					</th>
@@ -526,7 +526,7 @@
 			<tfoot>
 				<tr>
 					<td colspan="10" class="about">
-						<nuxt-link :to="{ name: 'about' }"
+						Values show averages for the indicated date ranges.  <nuxt-link :to="{ name: 'about' }"
 							>Read more about models (MRI-CGCM3 and NCAR-CCSM4) and emissions
 							scenarios (RCPs).</nuxt-link
 						>

--- a/components/reports/temperature/ReportTempTable.vue
+++ b/components/reports/temperature/ReportTempTable.vue
@@ -8,7 +8,9 @@
 			<thead>
 				<tr>
 					<th scope="col" rowspan="3" class="left">Season</th>
-					<th scope="col" rowspan="3" class="left">Historical Average</th>
+					<th scope="col" rowspan="3" class="left">
+						Historical (1950&ndash;2009)
+					</th>
 					<th scope="col" colspan="4" class="light-border">
 						Mid&ndash;Century (2040&ndash;2069)
 					</th>
@@ -46,7 +48,9 @@
 					<th scope="row">Winter</th>
 					<td class="left">
 						{{
-							reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
+							reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
+								'tas'
+							]['mean']
 						}}<UnitWidget :units="units" />
 					</td>
 					<td>
@@ -56,7 +60,9 @@
 								reportData['2040_2069']['DJF']['MRI-CGCM3']['rcp45']['tas']
 							"
 							:past="
-								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -65,7 +71,9 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2040_2069']['DJF']['CCSM4']['rcp45']['tas']"
 							:past="
-								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -76,7 +84,9 @@
 								reportData['2040_2069']['DJF']['MRI-CGCM3']['rcp85']['tas']
 							"
 							:past="
-								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -85,7 +95,9 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2040_2069']['DJF']['CCSM4']['rcp85']['tas']"
 							:past="
-								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -96,7 +108,9 @@
 								reportData['2070_2099']['DJF']['MRI-CGCM3']['rcp45']['tas']
 							"
 							:past="
-								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -105,7 +119,9 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2070_2099']['DJF']['CCSM4']['rcp45']['tas']"
 							:past="
-								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -116,7 +132,9 @@
 								reportData['2070_2099']['DJF']['MRI-CGCM3']['rcp85']['tas']
 							"
 							:past="
-								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -125,7 +143,9 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2070_2099']['DJF']['CCSM4']['rcp85']['tas']"
 							:past="
-								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -134,7 +154,9 @@
 					<th scope="row">Spring</th>
 					<td class="left">
 						{{
-							reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
+							reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
+								'tas'
+							]['mean']
 						}}<UnitWidget :units="units" />
 					</td>
 					<td>
@@ -144,7 +166,9 @@
 								reportData['2040_2069']['MAM']['MRI-CGCM3']['rcp45']['tas']
 							"
 							:past="
-								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -153,7 +177,9 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2040_2069']['MAM']['CCSM4']['rcp45']['tas']"
 							:past="
-								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -164,7 +190,9 @@
 								reportData['2040_2069']['MAM']['MRI-CGCM3']['rcp85']['tas']
 							"
 							:past="
-								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -173,7 +201,9 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2040_2069']['MAM']['CCSM4']['rcp85']['tas']"
 							:past="
-								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -184,7 +214,9 @@
 								reportData['2070_2099']['MAM']['MRI-CGCM3']['rcp45']['tas']
 							"
 							:past="
-								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -193,7 +225,9 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2070_2099']['MAM']['CCSM4']['rcp45']['tas']"
 							:past="
-								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -204,7 +238,9 @@
 								reportData['2070_2099']['MAM']['MRI-CGCM3']['rcp85']['tas']
 							"
 							:past="
-								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -213,7 +249,9 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2070_2099']['MAM']['CCSM4']['rcp85']['tas']"
 							:past="
-								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -222,7 +260,9 @@
 					<th scope="row">Summer</th>
 					<td class="left">
 						{{
-							reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
+							reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
+								'tas'
+							]['mean']
 						}}<UnitWidget :units="units" />
 					</td>
 					<td>
@@ -232,7 +272,9 @@
 								reportData['2040_2069']['JJA']['MRI-CGCM3']['rcp45']['tas']
 							"
 							:past="
-								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -241,7 +283,9 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2040_2069']['JJA']['CCSM4']['rcp45']['tas']"
 							:past="
-								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -252,7 +296,9 @@
 								reportData['2040_2069']['JJA']['MRI-CGCM3']['rcp85']['tas']
 							"
 							:past="
-								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -261,7 +307,9 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2040_2069']['JJA']['CCSM4']['rcp85']['tas']"
 							:past="
-								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -272,7 +320,9 @@
 								reportData['2070_2099']['JJA']['MRI-CGCM3']['rcp45']['tas']
 							"
 							:past="
-								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -281,7 +331,9 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2070_2099']['JJA']['CCSM4']['rcp45']['tas']"
 							:past="
-								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -292,7 +344,9 @@
 								reportData['2070_2099']['JJA']['MRI-CGCM3']['rcp85']['tas']
 							"
 							:past="
-								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -301,7 +355,9 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2070_2099']['JJA']['CCSM4']['rcp85']['tas']"
 							:past="
-								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -310,7 +366,9 @@
 					<th scope="row">Fall</th>
 					<td class="left">
 						{{
-							reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
+							reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
+								'tas'
+							]['mean']
 						}}<UnitWidget :units="units" />
 					</td>
 					<td>
@@ -320,7 +378,9 @@
 								reportData['2040_2069']['SON']['MRI-CGCM3']['rcp45']['tas']
 							"
 							:past="
-								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -329,7 +389,9 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2040_2069']['SON']['CCSM4']['rcp45']['tas']"
 							:past="
-								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -340,7 +402,9 @@
 								reportData['2040_2069']['SON']['MRI-CGCM3']['rcp85']['tas']
 							"
 							:past="
-								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -349,7 +413,9 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2040_2069']['SON']['CCSM4']['rcp85']['tas']"
 							:past="
-								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -360,7 +426,9 @@
 								reportData['2070_2099']['SON']['MRI-CGCM3']['rcp45']['tas']
 							"
 							:past="
-								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -369,7 +437,9 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2070_2099']['SON']['CCSM4']['rcp45']['tas']"
 							:past="
-								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -380,7 +450,9 @@
 								reportData['2070_2099']['SON']['MRI-CGCM3']['rcp85']['tas']
 							"
 							:past="
-								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -389,7 +461,9 @@
 						}}<UnitWidget :units="units" /><TempDiffWidget
 							:future="reportData['2070_2099']['SON']['CCSM4']['rcp85']['tas']"
 							:past="
-								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['tas']['mean']
+								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
+									'tas'
+								]['mean']
 							"
 						/>
 					</td>
@@ -399,8 +473,9 @@
 				<tr>
 					<td colspan="10" class="about">
 						<nuxt-link :to="{ name: 'about' }"
-							>Read more about models (MRI-CGCM3 and NCAR-CCSM4) and emissions
-							scenarios (RCPs).</nuxt-link
+							>Values show averages for the indicated date ranges. Read more
+							about models (MRI-CGCM3 and NCAR-CCSM4) and emissions scenarios
+							(RCPs).</nuxt-link
 						>
 					</td>
 				</tr>

--- a/components/reports/temperature/ReportTempTable.vue
+++ b/components/reports/temperature/ReportTempTable.vue
@@ -472,9 +472,8 @@
 			<tfoot>
 				<tr>
 					<td colspan="10" class="about">
-						<nuxt-link :to="{ name: 'about' }"
-							>Values show averages for the indicated date ranges. Read more
-							about models (MRI-CGCM3 and NCAR-CCSM4) and emissions scenarios
+						Values show averages for the indicated date ranges. <nuxt-link :to="{ name: 'about' }"
+							>Read more about models (MRI-CGCM3 and NCAR-CCSM4) and emissions scenarios
 							(RCPs).</nuxt-link
 						>
 					</td>


### PR DESCRIPTION
Closes #57 

To test -- pick a point, then for both temp and precip tables, ensure that the Historical column shows the date span (1950-2009) and the footer of the table has a small explainer blurb that these are averages.