### PR TITLE
Update temp/precip charts with units from store and remove remaining unit prop artifacts

### DIFF
--- a/components/reports/precipitation/ReportPrecipChart.vue
+++ b/components/reports/precipitation/ReportPrecipChart.vue
@@ -10,11 +10,17 @@
 </style>
 <script>
 import _ from 'lodash'
+import { mapGetters } from 'vuex'
 export default {
 	name: 'ReportPrecipChart',
-	props: ['reportData', 'units', 'season'],
+	props: ['reportData', 'season'],
 	mounted() {
 		this.renderPlot()
+	},
+	computed: {
+		...mapGetters({
+			units: 'units',
+		})
 	},
 	watch: {
 		reportData: function () {

--- a/components/reports/precipitation/ReportPrecipTable.vue
+++ b/components/reports/precipitation/ReportPrecipTable.vue
@@ -3,7 +3,7 @@
 		<table class="table report-table" v-if="reportData">
 			<caption>
 				Projected Precipitation
-				<UnitWidget variable="pr" :units="units" type="heavy" />
+				<UnitWidget variable="pr" type="heavy" />
 			</caption>
 			<thead>
 				<tr>
@@ -47,13 +47,12 @@
 					<td class="left">
 						{{
 							reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical']['pr']['mean']
-						}}<UnitWidget variable="pr" :units="units" type="light" />
+						}}<UnitWidget variable="pr" type="light" />
 					</td>
 					<td>
 						{{ reportData['2040_2069']['DJF']['MRI-CGCM3']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -68,7 +67,6 @@
 						{{ reportData['2040_2069']['DJF']['CCSM4']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -81,7 +79,6 @@
 						{{ reportData['2040_2069']['DJF']['MRI-CGCM3']['rcp85']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -96,7 +93,6 @@
 						{{ reportData['2040_2069']['DJF']['CCSM4']['rcp85']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -109,7 +105,6 @@
 						{{ reportData['2070_2099']['DJF']['MRI-CGCM3']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -124,7 +119,6 @@
 						{{ reportData['2070_2099']['DJF']['CCSM4']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -137,7 +131,6 @@
 						{{ reportData['2070_2099']['DJF']['MRI-CGCM3']['rcp85']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -152,7 +145,6 @@
 						{{ reportData['2070_2099']['DJF']['CCSM4']['rcp85']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -167,13 +159,12 @@
 					<td class="left">
 						{{
 							reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical']['pr']['mean']
-						}}<UnitWidget variable="pr" :units="units" type="light" />
+						}}<UnitWidget variable="pr" type="light" />
 					</td>
 					<td>
 						{{ reportData['2040_2069']['MAM']['MRI-CGCM3']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -188,7 +179,6 @@
 						{{ reportData['2040_2069']['MAM']['CCSM4']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -201,7 +191,6 @@
 						{{ reportData['2040_2069']['MAM']['MRI-CGCM3']['rcp85']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -216,7 +205,6 @@
 						{{ reportData['2040_2069']['MAM']['CCSM4']['rcp85']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -229,7 +217,6 @@
 						{{ reportData['2070_2099']['MAM']['MRI-CGCM3']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -244,7 +231,6 @@
 						{{ reportData['2070_2099']['MAM']['CCSM4']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -257,7 +243,6 @@
 						{{ reportData['2070_2099']['MAM']['MRI-CGCM3']['rcp85']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -272,7 +257,6 @@
 						{{ reportData['2070_2099']['MAM']['CCSM4']['rcp85']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -287,13 +271,12 @@
 					<td class="left">
 						{{
 							reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical']['pr']['mean']
-						}}<UnitWidget variable="pr" :units="units" type="light" />
+						}}<UnitWidget variable="pr" type="light" />
 					</td>
 					<td>
 						{{ reportData['2040_2069']['JJA']['MRI-CGCM3']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -308,7 +291,6 @@
 						{{ reportData['2040_2069']['JJA']['CCSM4']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -321,7 +303,6 @@
 						{{ reportData['2040_2069']['JJA']['MRI-CGCM3']['rcp85']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -336,7 +317,6 @@
 						{{ reportData['2040_2069']['JJA']['CCSM4']['rcp85']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -349,7 +329,6 @@
 						{{ reportData['2070_2099']['JJA']['MRI-CGCM3']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -364,7 +343,6 @@
 						{{ reportData['2070_2099']['JJA']['CCSM4']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -377,7 +355,6 @@
 						{{ reportData['2070_2099']['JJA']['MRI-CGCM3']['rcp85']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -392,7 +369,6 @@
 						{{ reportData['2070_2099']['JJA']['CCSM4']['rcp85']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -407,13 +383,12 @@
 					<td class="left">
 						{{
 							reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical']['pr']['mean']
-						}}<UnitWidget variable="pr" :units="units" type="light" />
+						}}<UnitWidget variable="pr" type="light" />
 					</td>
 					<td>
 						{{ reportData['2040_2069']['SON']['MRI-CGCM3']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -428,7 +403,6 @@
 						{{ reportData['2040_2069']['SON']['CCSM4']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -441,7 +415,6 @@
 						{{ reportData['2040_2069']['SON']['MRI-CGCM3']['rcp85']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -456,7 +429,6 @@
 						{{ reportData['2040_2069']['SON']['CCSM4']['rcp85']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -469,7 +441,6 @@
 						{{ reportData['2070_2099']['SON']['MRI-CGCM3']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -484,7 +455,6 @@
 						{{ reportData['2070_2099']['SON']['CCSM4']['rcp45']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -497,7 +467,6 @@
 						{{ reportData['2070_2099']['SON']['MRI-CGCM3']['rcp85']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -512,7 +481,6 @@
 						{{ reportData['2070_2099']['SON']['CCSM4']['rcp85']['pr']
 						}}<UnitWidget
 							variable="pr"
-							:units="units"
 							type="light"
 						/><PrecipDiffWidget
 							:past="
@@ -542,9 +510,10 @@
 <script>
 import UnitWidget from '~/components/UnitWidget'
 import PrecipDiffWidget from './PrecipDiffWidget'
+import { mapGetters } from 'vuex'
 export default {
 	name: 'PrecipReportTable',
-	props: ['reportData', 'units'],
+	props: ['reportData'],
 	components: { PrecipDiffWidget, UnitWidget },
 }
 </script>

--- a/components/reports/temperature/ReportTempChart.vue
+++ b/components/reports/temperature/ReportTempChart.vue
@@ -10,11 +10,17 @@
 </style>
 <script>
 import _ from 'lodash'
+import { mapGetters } from 'vuex'
 export default {
 	name: 'ReportTempChart',
-	props: ['reportData', 'units', 'season'],
+	props: ['reportData', 'season'],
 	mounted() {
 		this.renderPlot()
+	},
+	computed: {
+		...mapGetters({
+			units: 'units',
+		})
 	},
 	watch: {
 		reportData: function () {

--- a/components/reports/temperature/ReportTempTable.vue
+++ b/components/reports/temperature/ReportTempTable.vue
@@ -3,7 +3,7 @@
 		<table class="table report-table" v-if="reportData">
 			<caption>
 				Projected Temperatures
-				<UnitWidget :units="units" type="heavy" />
+				<UnitWidget type="heavy" />
 			</caption>
 			<thead>
 				<tr>
@@ -51,11 +51,11 @@
 							reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
 								'tas'
 							]['mean']
-						}}<UnitWidget :units="units" />
+						}}<UnitWidget />
 					</td>
 					<td>
 						{{ reportData['2040_2069']['DJF']['MRI-CGCM3']['rcp45']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="
 								reportData['2040_2069']['DJF']['MRI-CGCM3']['rcp45']['tas']
 							"
@@ -68,7 +68,7 @@
 					</td>
 					<td>
 						{{ reportData['2040_2069']['DJF']['CCSM4']['rcp45']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="reportData['2040_2069']['DJF']['CCSM4']['rcp45']['tas']"
 							:past="
 								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
@@ -79,7 +79,7 @@
 					</td>
 					<td>
 						{{ reportData['2040_2069']['DJF']['MRI-CGCM3']['rcp85']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="
 								reportData['2040_2069']['DJF']['MRI-CGCM3']['rcp85']['tas']
 							"
@@ -92,7 +92,7 @@
 					</td>
 					<td>
 						{{ reportData['2040_2069']['DJF']['CCSM4']['rcp85']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="reportData['2040_2069']['DJF']['CCSM4']['rcp85']['tas']"
 							:past="
 								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
@@ -103,7 +103,7 @@
 					</td>
 					<td>
 						{{ reportData['2070_2099']['DJF']['MRI-CGCM3']['rcp45']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="
 								reportData['2070_2099']['DJF']['MRI-CGCM3']['rcp45']['tas']
 							"
@@ -116,7 +116,7 @@
 					</td>
 					<td>
 						{{ reportData['2070_2099']['DJF']['CCSM4']['rcp45']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="reportData['2070_2099']['DJF']['CCSM4']['rcp45']['tas']"
 							:past="
 								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
@@ -127,7 +127,7 @@
 					</td>
 					<td>
 						{{ reportData['2070_2099']['DJF']['MRI-CGCM3']['rcp85']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="
 								reportData['2070_2099']['DJF']['MRI-CGCM3']['rcp85']['tas']
 							"
@@ -140,7 +140,7 @@
 					</td>
 					<td>
 						{{ reportData['2070_2099']['DJF']['CCSM4']['rcp85']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="reportData['2070_2099']['DJF']['CCSM4']['rcp85']['tas']"
 							:past="
 								reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
@@ -157,11 +157,11 @@
 							reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
 								'tas'
 							]['mean']
-						}}<UnitWidget :units="units" />
+						}}<UnitWidget />
 					</td>
 					<td>
 						{{ reportData['2040_2069']['MAM']['MRI-CGCM3']['rcp45']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="
 								reportData['2040_2069']['MAM']['MRI-CGCM3']['rcp45']['tas']
 							"
@@ -174,7 +174,7 @@
 					</td>
 					<td>
 						{{ reportData['2040_2069']['MAM']['CCSM4']['rcp45']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="reportData['2040_2069']['MAM']['CCSM4']['rcp45']['tas']"
 							:past="
 								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
@@ -185,7 +185,7 @@
 					</td>
 					<td>
 						{{ reportData['2040_2069']['MAM']['MRI-CGCM3']['rcp85']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="
 								reportData['2040_2069']['MAM']['MRI-CGCM3']['rcp85']['tas']
 							"
@@ -198,7 +198,7 @@
 					</td>
 					<td>
 						{{ reportData['2040_2069']['MAM']['CCSM4']['rcp85']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="reportData['2040_2069']['MAM']['CCSM4']['rcp85']['tas']"
 							:past="
 								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
@@ -209,7 +209,7 @@
 					</td>
 					<td>
 						{{ reportData['2070_2099']['MAM']['MRI-CGCM3']['rcp45']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="
 								reportData['2070_2099']['MAM']['MRI-CGCM3']['rcp45']['tas']
 							"
@@ -222,7 +222,7 @@
 					</td>
 					<td>
 						{{ reportData['2070_2099']['MAM']['CCSM4']['rcp45']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="reportData['2070_2099']['MAM']['CCSM4']['rcp45']['tas']"
 							:past="
 								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
@@ -233,7 +233,7 @@
 					</td>
 					<td>
 						{{ reportData['2070_2099']['MAM']['MRI-CGCM3']['rcp85']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="
 								reportData['2070_2099']['MAM']['MRI-CGCM3']['rcp85']['tas']
 							"
@@ -246,7 +246,7 @@
 					</td>
 					<td>
 						{{ reportData['2070_2099']['MAM']['CCSM4']['rcp85']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="reportData['2070_2099']['MAM']['CCSM4']['rcp85']['tas']"
 							:past="
 								reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
@@ -263,11 +263,11 @@
 							reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
 								'tas'
 							]['mean']
-						}}<UnitWidget :units="units" />
+						}}<UnitWidget />
 					</td>
 					<td>
 						{{ reportData['2040_2069']['JJA']['MRI-CGCM3']['rcp45']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="
 								reportData['2040_2069']['JJA']['MRI-CGCM3']['rcp45']['tas']
 							"
@@ -280,7 +280,7 @@
 					</td>
 					<td>
 						{{ reportData['2040_2069']['JJA']['CCSM4']['rcp45']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="reportData['2040_2069']['JJA']['CCSM4']['rcp45']['tas']"
 							:past="
 								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
@@ -291,7 +291,7 @@
 					</td>
 					<td>
 						{{ reportData['2040_2069']['JJA']['MRI-CGCM3']['rcp85']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="
 								reportData['2040_2069']['JJA']['MRI-CGCM3']['rcp85']['tas']
 							"
@@ -304,7 +304,7 @@
 					</td>
 					<td>
 						{{ reportData['2040_2069']['JJA']['CCSM4']['rcp85']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="reportData['2040_2069']['JJA']['CCSM4']['rcp85']['tas']"
 							:past="
 								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
@@ -315,7 +315,7 @@
 					</td>
 					<td>
 						{{ reportData['2070_2099']['JJA']['MRI-CGCM3']['rcp45']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="
 								reportData['2070_2099']['JJA']['MRI-CGCM3']['rcp45']['tas']
 							"
@@ -328,7 +328,7 @@
 					</td>
 					<td>
 						{{ reportData['2070_2099']['JJA']['CCSM4']['rcp45']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="reportData['2070_2099']['JJA']['CCSM4']['rcp45']['tas']"
 							:past="
 								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
@@ -339,7 +339,7 @@
 					</td>
 					<td>
 						{{ reportData['2070_2099']['JJA']['MRI-CGCM3']['rcp85']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="
 								reportData['2070_2099']['JJA']['MRI-CGCM3']['rcp85']['tas']
 							"
@@ -352,7 +352,7 @@
 					</td>
 					<td>
 						{{ reportData['2070_2099']['JJA']['CCSM4']['rcp85']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="reportData['2070_2099']['JJA']['CCSM4']['rcp85']['tas']"
 							:past="
 								reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
@@ -369,11 +369,11 @@
 							reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
 								'tas'
 							]['mean']
-						}}<UnitWidget :units="units" />
+						}}<UnitWidget />
 					</td>
 					<td>
 						{{ reportData['2040_2069']['SON']['MRI-CGCM3']['rcp45']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="
 								reportData['2040_2069']['SON']['MRI-CGCM3']['rcp45']['tas']
 							"
@@ -386,7 +386,7 @@
 					</td>
 					<td>
 						{{ reportData['2040_2069']['SON']['CCSM4']['rcp45']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="reportData['2040_2069']['SON']['CCSM4']['rcp45']['tas']"
 							:past="
 								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
@@ -397,7 +397,7 @@
 					</td>
 					<td>
 						{{ reportData['2040_2069']['SON']['MRI-CGCM3']['rcp85']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="
 								reportData['2040_2069']['SON']['MRI-CGCM3']['rcp85']['tas']
 							"
@@ -410,7 +410,7 @@
 					</td>
 					<td>
 						{{ reportData['2040_2069']['SON']['CCSM4']['rcp85']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="reportData['2040_2069']['SON']['CCSM4']['rcp85']['tas']"
 							:past="
 								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
@@ -421,7 +421,7 @@
 					</td>
 					<td>
 						{{ reportData['2070_2099']['SON']['MRI-CGCM3']['rcp45']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="
 								reportData['2070_2099']['SON']['MRI-CGCM3']['rcp45']['tas']
 							"
@@ -434,7 +434,7 @@
 					</td>
 					<td>
 						{{ reportData['2070_2099']['SON']['CCSM4']['rcp45']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="reportData['2070_2099']['SON']['CCSM4']['rcp45']['tas']"
 							:past="
 								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
@@ -445,7 +445,7 @@
 					</td>
 					<td>
 						{{ reportData['2070_2099']['SON']['MRI-CGCM3']['rcp85']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="
 								reportData['2070_2099']['SON']['MRI-CGCM3']['rcp85']['tas']
 							"
@@ -458,7 +458,7 @@
 					</td>
 					<td>
 						{{ reportData['2070_2099']['SON']['CCSM4']['rcp85']['tas']
-						}}<UnitWidget :units="units" /><TempDiffWidget
+						}}<UnitWidget /><TempDiffWidget
 							:future="reportData['2070_2099']['SON']['CCSM4']['rcp85']['tas']"
 							:past="
 								reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
@@ -490,7 +490,7 @@ import UnitWidget from '~/components/UnitWidget'
 import TempDiffWidget from './TempDiffWidget'
 export default {
 	name: 'ReportTempTable',
-	props: ['reportData', 'units'],
+	props: ['reportData'],
 	components: { UnitWidget, TempDiffWidget },
 }
 </script>


### PR DESCRIPTION
This fixes a problem that was related to #108.

STR:
- View a report for a location.
- Switch back and forth between Imperial and Metric units, and make sure the temp/precip charts are updated to reflect the current setting.