### PR TITLE
Show deltas for each map marker in temp/precip chart hovertext

### DIFF
--- a/components/Report.vue
+++ b/components/Report.vue
@@ -192,6 +192,7 @@ export default {
 		this.results = await this.$http.$get(queryUrl)
 		this.originalData = _.cloneDeep(this.results) // save a copy!
 		this.units = 'imperial'
+		this.convertReportData()
 	},
 	created() {
 		// Switch back to clean URL after S3 redirect. Adapted from here:

--- a/components/reports/precipitation/ReportPrecipChart.vue
+++ b/components/reports/precipitation/ReportPrecipChart.vue
@@ -126,7 +126,7 @@ export default {
 						mode: 'markers',
 						name: traceLabels_lu[model][scenario],
 						hoverinfo: 'x+y+z+text',
-						hovertemplate: '%{y}' + units,
+						hovertemplate: '%{y}' + units + ' <b>(%{customdata}' + units + ')</b>',
 						marker: {
 							symbol: Array(decades.length).fill(symbols[model]),
 							size: 8,
@@ -134,6 +134,7 @@ export default {
 						},
 						x: decades.slice(1),
 						y: [],
+						customdata: [],
 					}
 				})
 			})
@@ -153,7 +154,17 @@ export default {
 				} else {
 					models.forEach(model => {
 						scenarios.forEach(scenario => {
-							scatterTraces[model][scenario]['y'].push(this.reportData[decade][this.season][model][scenario]['pr'])
+							let scenarioPr = this.reportData[decade][this.season][model][scenario]['pr']
+							let historicalPr = this.reportData['1950_2009'][this.season]['CRU-TS40']['CRU_historical']['pr']['median']
+							let prDiff = scenarioPr - historicalPr
+							let precision = this.units == 'metric' ? 0 : 1
+							if (prDiff > 0) {
+								prDiff = '+' + prDiff.toFixed(precision)
+							} else {
+								prDiff = prDiff.toFixed(precision)
+							}
+							scatterTraces[model][scenario]['y'].push(scenarioPr)
+							scatterTraces[model][scenario]['customdata'].push(prDiff)
 						})
 					})
 				}

--- a/components/reports/temperature/ReportTempChart.vue
+++ b/components/reports/temperature/ReportTempChart.vue
@@ -127,7 +127,7 @@ export default {
 						mode: 'markers',
 						name: traceLabels_lu[model][scenario],
 						hoverinfo: 'x+y+z+text',
-						hovertemplate: '%{y}' + units,
+						hovertemplate: '%{y}' + units + ' <b>(%{customdata}' + units + ')</b>',
 						marker: {
 							symbol: Array(decades.length).fill(symbols[model]),
 							size: 8,
@@ -135,6 +135,7 @@ export default {
 						},
 						x: decades.slice(1),
 						y: [],
+						customdata: [],
 					}
 				})
 			})
@@ -156,7 +157,16 @@ export default {
 				} else {
 					models.forEach(model => {
 						scenarios.forEach(scenario => {
-							scatterTraces[model][scenario]['y'].push(this.reportData[decade][this.season][model][scenario]['tas'])
+							let scenarioTas = this.reportData[decade][this.season][model][scenario]['tas']
+							let historicalTas = this.reportData['1950_2009'][this.season]['CRU-TS40']['CRU_historical']['tas']['median']
+							let tasDiff = scenarioTas - historicalTas
+							if (tasDiff > 0) {
+								tasDiff = '+' + tasDiff.toFixed(1)
+							} else {
+								tasDiff = tasDiff.toFixed(1)
+							}
+							scatterTraces[model][scenario]['y'].push(scenarioTas)
+							scatterTraces[model][scenario]['customdata'].push(tasDiff)
 							allValues.push(this.reportData[decade][this.season][model][scenario]['tas'])
 						})
 					})


### PR DESCRIPTION
Closes #103.

STR:
- Load the report for a location.
- Hover over some map markers in both the temp and precip charts. The hover text should now display the difference from the historical median, alongside the absolute value for the marker. Like this for example: "RCP 8.5 (NCAR): 3.2in (+0.8in)"
- Switch between imperial/metric. Fahrenheit, Celsius, and inches should all show as one decimal of precision. Millimeters should show with no decimals of precision.

This PR also fixes a bug that was introduced when we decided to default to imperial units instead of metric. It now converts the metric data to imperial when the data is first fetched.