### PR TITLE
Fix value mismatches between temp/precip tables and qualitative text

### DIFF
--- a/components/reports/QualitativeText.vue
+++ b/components/reports/QualitativeText.vue
@@ -98,21 +98,13 @@ export default {
 
       // Take an average of both temperature and precipitation for the same season and RCP from both models.
       let tempMax = Math.max(
-      this.reportData['2070_2079'][season]['MRI-CGCM3']['rcp85']['tas'],
-      this.reportData['2080_2089'][season]['MRI-CGCM3']['rcp85']['tas'],
-      this.reportData['2090_2099'][season]['MRI-CGCM3']['rcp85']['tas'],
-      this.reportData['2070_2079'][season]['CCSM4']['rcp85']['tas'],
-      this.reportData['2080_2089'][season]['CCSM4']['rcp85']['tas'],
-      this.reportData['2090_2099'][season]['CCSM4']['rcp85']['tas']
+      this.reportData['2070_2099'][season]['MRI-CGCM3']['rcp85']['tas'],
+      this.reportData['2070_2099'][season]['CCSM4']['rcp85']['tas'],
       )
 
       let precipMax = Math.max(
-        this.reportData['2070_2079'][season]['MRI-CGCM3']['rcp85']['pr'],
-        this.reportData['2080_2089'][season]['MRI-CGCM3']['rcp85']['pr'],
-        this.reportData['2090_2099'][season]['MRI-CGCM3']['rcp85']['pr'],
-        this.reportData['2070_2079'][season]['CCSM4']['rcp85']['pr'],
-        this.reportData['2080_2089'][season]['CCSM4']['rcp85']['pr'],
-        this.reportData['2090_2099'][season]['CCSM4']['rcp85']['pr']
+        this.reportData['2070_2099'][season]['MRI-CGCM3']['rcp85']['pr'],
+        this.reportData['2070_2099'][season]['CCSM4']['rcp85']['pr'],
       )
 
       // If the maximum temperature difference is less than the current temperature difference,


### PR DESCRIPTION
Closes #107.

STR:
- View a report for any location.
- Confirm that the the numbers that appear in the qualitative text near the top of the page correspond to values found in the temp/precip tables further down the page (after rounding).
- To validate the value that appears in "average annual temperatures may increase" text, take the maximum difference value for each season from the table, add them together, and divide by 4.