### PR TITLE
Disable click & drag zoom on charts

### DIFF
--- a/components/reports/precipitation/ReportPrecipChart.vue
+++ b/components/reports/precipitation/ReportPrecipChart.vue
@@ -221,6 +221,7 @@ export default {
 					b: 120
 				},
 				height: 500,
+				dragmode: false,
 			}
 
 			let footer_y = -0.25

--- a/components/reports/temperature/ReportTempChart.vue
+++ b/components/reports/temperature/ReportTempChart.vue
@@ -227,6 +227,7 @@ export default {
 					b: 120
 				},
 				height: 500,
+				dragmode: false,
 			}
 
 			let footer_y = -0.25


### PR DESCRIPTION
Closes #112.

STR:
- View a report for any location.
- Attempt to click & drag on both the temperature and precipitation charts. The charts should no longer allow you to zoom in this way.

Note that the cursor is still displayed as a crosshair despite this functionality being disable, but I think that's a Plotly design decision. I think the intention behind the crosshair is to make it easier to precisely hover over chart markers, not that we need that amount of cursor precision for our charts, but defaults are defaults!