### PR TITLE
Access API over HTTPS

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -86,7 +86,7 @@ export default {
   env: {
     geoserverUrl:
       process.env.GEOSERVER_URL || 'https://gs.mapventure.org/geoserver/wms',
-    apiUrl: process.env.SNAP_API_URL || 'http://earthmaps.io',
+    apiUrl: process.env.SNAP_API_URL || 'https://earthmaps.io',
   },
 
   // Router customizations


### PR DESCRIPTION
Related to #116.

Chrome (and probably all browsers) refuse to load the API over HTTP now that the web app is served over HTTPS. The API has been set up to serve over HTTPS, so we need the code to access the API from https://earthmaps.io/ now.