### PR TITLE
Add additional deliberate line break in dynamic text blurb for transitional seasons

### DIFF
--- a/components/reports/QualitativeText.vue
+++ b/components/reports/QualitativeText.vue
@@ -238,7 +238,7 @@ export default {
         }
         returnedString +=
           transitioningSeasons +
-          ' may transition from below freezing to <strong>above freezing</strong> in the future.</p>'
+          ' may transition from below freezing<br/>to <strong>above freezing</strong> in the future.</p>'
       }
       returnedString +=
         '<p>Models have higher uncertainty with regard to precipitation,<br/> but <strong>' +


### PR DESCRIPTION
Closes #51

Check in the app that there's a forced line break in the dynamic text section, after "...may transition from below freezing" so it reads,

[seasons] may transition from below freezing /
to above freezing in the future.