### PR TITLE
Fix Twitter preview by using absolute URL for image

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -30,7 +30,7 @@ export default {
       { name: 'twitter:title', content: metas.title },
       { name: 'twitter:description', content: metas.description },
       { name: 'twitter:creator', content: '@SNAPandACCAP' },
-      { name: 'twitter:image:src', content: metas.preview },
+      { name: 'twitter:image', content: metas.url + metas.preview },
       { property: 'og:title', content: metas.title },
       { property: 'og:type', content: 'website' },
       { property: 'og:url', content: metas.url },


### PR DESCRIPTION
Related to #8.

The OpenGraph / Facebook preview works now that we have HTTPS set up, but the Twitter preview was still having issues. This fixes the Twitter preview by using an absolute URL for the preview image. I've also switched from using the `twitter:image:src` meta tag to `twitter:image` to be consistent with the current documentation:

https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image