### PR TITLE
Add permafrost active layer thickness chart, ground freeze depth chart, and qualitative text to location reports

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -36,10 +36,12 @@ label.label {
   padding: 1.25rem;
 }
 
-.chart-wrapper {
-  &.permafrost {
-    width: 70%;
-    margin: 0 auto;
+@media (min-width: 768px) {
+  .chart-wrapper {
+    &.permafrost {
+      width: 70%;
+      margin: 0 auto;
+    }
   }
 }
 

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -36,6 +36,13 @@ label.label {
   padding: 1.25rem;
 }
 
+.chart-wrapper {
+  &.permafrost {
+    width: 70%;
+    margin: 0 auto;
+  }
+}
+
 // Formatting common for both report tables.
 table.table.report-table {
   width: 100%;

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -84,8 +84,11 @@
 				<div class="report-type-wrapper">
 					<PrecipReport :reportData="results"></PrecipReport>
 				</div>
-				<div class="report-type-wrapper" v-show="showPermafrost">
-					<PermafrostReport :altThawData="altThawData" :altFreezeData="altFreezeData" :showThawChart="showThawChart" :showFreezeChart="showFreezeChart"></PermafrostReport>
+				<div class="report-type-wrapper">
+					<PermafrostReport :altThawData="altThawData" :altFreezeData="altFreezeData" :showThawChart="showThawChart" :showFreezeChart="showFreezeChart" v-show="showPermafrost"></PermafrostReport>
+					<p v-show="!showPermafrost" class="is-size-5">
+						Permafrost data are not available for this location.
+					</p>
 				</div>
 				<div class="content is-size-5">
 					<p>

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -85,7 +85,7 @@
 					<PrecipReport :reportData="results"></PrecipReport>
 				</div>
 				<div class="report-type-wrapper">
-					<PermafrostReport :reportData="permafrostResults"></PermafrostReport>
+					<PermafrostReport :permafrostData="permafrostResults"></PermafrostReport>
 				</div>
 				<div class="content is-size-5">
 					<p>

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -280,7 +280,9 @@ export default {
 			return _.mapValuesDeep(
 				data,
 				(value, key, context) => {
-					if (key == 'alt') {
+					if (value == -9999) {
+						return null
+					} else if (key == 'alt') {
 						// Convert to inches!
 						return parseFloat((value * 39.37008).toFixed(1))
 					} else if (key == 'magt') {
@@ -392,7 +394,7 @@ export default {
 		},
 		checkPermafrost() {
 			let historicalAlt = this.permafrostResults['gipl']['1995']['cruts31']['historical']['alt']
-			this.showPermafrost = historicalAlt == -9999 ? false : true
+			this.showPermafrost = historicalAlt == null ? false : true
 			if (!this.showThawChart && !this.showFreezeChart) {
 				this.showPermafrost = false
 			}

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -85,7 +85,7 @@
 					<PrecipReport :reportData="results"></PrecipReport>
 				</div>
 				<div class="report-type-wrapper">
-					<PermafrostReport :altThawData="altThawData" :altFreezeData="altFreezeData" :showThawChart="showThawChart" :showFreezeChart="showFreezeChart" v-show="showPermafrost"></PermafrostReport>
+					<PermafrostReport :altThawData="altThawData" :altFreezeData="altFreezeData" v-show="showPermafrost"></PermafrostReport>
 					<p v-show="!showPermafrost" class="is-size-5">
 						Permafrost data are not available for this location.
 					</p>
@@ -177,8 +177,8 @@ export default {
 			units: 'imperial',
 			altThawData: undefined,
 			altFreezeData: undefined,
-			showThawChart: undefined,
-			showFreezeChart: undefined,
+			permafrostPresent: undefined,
+			permafrostDisappears: undefined,
 		}
 	},
 	computed: {
@@ -320,6 +320,7 @@ export default {
 				})
 			})
 
+			this.permafrostPresent = false
 			models.forEach(model => {
 				scenarios.forEach(scenario => {
 					let previousMagt = historicalMagt
@@ -327,7 +328,7 @@ export default {
 						let scenarioAlt = this.permafrostResults['gipl'][year][model][scenario]['alt']
 						if (previousMagt < freezing) {
 							thawData[year][model][scenario] = scenarioAlt
-							this.showThawChart = true
+							this.permafrostPresent = true
 						} else {
 							thawData[year][model][scenario] = null
 						}
@@ -335,6 +336,7 @@ export default {
 					})
 				})
 			})
+			this.$store.commit('setPermafrostPresent', this.permafrostPresent)
 
 			return thawData
 		},
@@ -361,6 +363,7 @@ export default {
 				})
 			})
 
+			this.permafrostDisappears = false
 			models.forEach(model => {
 				scenarios.forEach(scenario => {
 					let previousMagt = historicalMagt
@@ -372,7 +375,7 @@ export default {
 							freezeData[year][model][scenario] = null
 						} else if (previousMagt > freezing) {
 							freezeData[year][model][scenario] = scenarioAlt
-							this.showFreezeChart = true
+							this.permafrostDisappears = true
 						} else {
 							freezeData[year][model][scenario] = null
 						}
@@ -380,6 +383,7 @@ export default {
 					})
 				})
 			})
+			this.$store.commit('setPermafrostDisappears', this.permafrostDisappears)
 
 			return freezeData
 		},
@@ -398,7 +402,7 @@ export default {
 		checkPermafrost() {
 			let historicalAlt = this.permafrostResults['gipl']['1995']['cruts31']['historical']['alt']
 			this.showPermafrost = historicalAlt == null ? false : true
-			if (!this.showThawChart && !this.showFreezeChart) {
+			if (!this.permafrostPresent && !this.permafrostDisappears) {
 				this.showPermafrost = false
 			}
 		},

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -37,7 +37,7 @@
 				<h3 class="title is-3 centered">
 					Projected Conditions for <span v-html="place"></span>
 				</h3>
-				<QualitativeText :reportData="results" />
+				<QualitativeText :reportData="results" :permafrostData="permafrostResults" />
 			</section>
 			<section class="section">
 				<div class="columns">

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -84,7 +84,7 @@
 				<div class="report-type-wrapper">
 					<PrecipReport :reportData="results"></PrecipReport>
 				</div>
-				<div class="report-type-wrapper">
+				<div class="report-type-wrapper" v-show="showPermafrost">
 					<PermafrostReport :permafrostData="permafrostResults"></PermafrostReport>
 				</div>
 				<div class="content is-size-5">
@@ -170,6 +170,7 @@ export default {
 			originalData: undefined, // for the raw stuff back from API
 			results: undefined, // may be metric or imperial
 			permafrostResults: undefined,
+			showPermafrost: undefined,
 			units: 'imperial',
 		}
 	},
@@ -205,6 +206,8 @@ export default {
 		this.originalPermafrostData = _.cloneDeep(this.permafrostResults)
 
 		this.units = 'imperial'
+
+		this.checkPermafrost()
 		this.convertReportData()
 	},
 	created() {
@@ -292,6 +295,10 @@ export default {
 			Object.keys(this.permafrostResults['gipl']).forEach(year => {
 				this.permafrostResults['gipl'][year] = this.convertPermafrostMeans(this.permafrostResults['gipl'][year])
 			})
+		},
+		checkPermafrost() {
+			let historicalAlt = this.permafrostResults['gipl']['1995']['cruts31']['historical']['alt']
+			this.showPermafrost = historicalAlt == -9999 ? false : true
 		},
 	},
 }

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -274,7 +274,7 @@ export default {
 			return _.mapValuesDeep(
 				data,
 				(value, key, context) => {
-					if (key == 'alt') {
+					if (key == 'alt' || key == 'magt') {
 						// Convert to inches!
 						return parseFloat((value * 39.37008).toFixed(1))
 					}

--- a/components/reports/QualitativeText.vue
+++ b/components/reports/QualitativeText.vue
@@ -41,9 +41,12 @@
 import { mapGetters } from 'vuex'
 export default {
   name: 'QualitativeText',
-  props: ['reportData'],
+  props: ['reportData', 'permafrostData'],
   watch: {
     reportData: function () {
+      this.generateText()
+    },
+    permafrostData: function () {
       this.generateText()
     },
   },
@@ -133,6 +136,19 @@ export default {
       }
 
       return seasonMetrics
+    },
+    permafrostChange() {
+      let thicknesses = []
+      let models = ['gfdlcm3', 'gisse2r', 'ipslcm5alr', 'mricgcm3', 'ncarccsm4']
+      let scenarios = ['rcp45', 'rcp85']
+      models.forEach(model => {
+        scenarios.forEach(scenario => {
+          thicknesses.push(this.permafrostData['gipl']['2095'][model][scenario]['alt'])
+        })
+      })
+      let thicknessMax = _.max(thicknesses)
+      let thicknessHistorical = this.permafrostData['gipl']['1995']['cruts31']['historical']['alt']
+      return Math.round(thicknessMax / thicknessHistorical * 100 - 100)
     },
     // Subfunction: Generate annual metrics HTML string
     // Input: None. (Uses constant seasons)
@@ -246,6 +262,16 @@ export default {
         '</strong> is likely to have more precipitation (<strong>+' +
         annualHighestPrecipPercentChange +
         '%</strong>).</p>'
+
+      let permafrostChange = this.permafrostChange()
+      if (permafrostChange > 0) {
+        returnedString += '<p>By the late century, the active layer permafrost thickness may '
+        if (permafrostChange < 100) {
+          returnedString += 'decrease by <strong>' + permafrostChange + '%</strong>.</p>'
+        } else {
+          returnedString += 'disappear.</p>'
+        }
+      }
 
       return returnedString
     },

--- a/components/reports/QualitativeText.vue
+++ b/components/reports/QualitativeText.vue
@@ -138,6 +138,12 @@ export default {
       return seasonMetrics
     },
     permafrostChange() {
+      let thicknessHistorical = this.permafrostData['gipl']['1995']['cruts31']['historical']['alt']
+
+      if (thicknessHistorical == -9999) {
+        return 0
+      }
+
       let thicknesses = []
       let models = ['gfdlcm3', 'gisse2r', 'ipslcm5alr', 'mricgcm3', 'ncarccsm4']
       let scenarios = ['rcp45', 'rcp85']
@@ -146,9 +152,9 @@ export default {
           thicknesses.push(this.permafrostData['gipl']['2095'][model][scenario]['alt'])
         })
       })
-      let thicknessMax = _.max(thicknesses)
-      let thicknessHistorical = this.permafrostData['gipl']['1995']['cruts31']['historical']['alt']
-      return Math.round(thicknessMax / thicknessHistorical * 100 - 100)
+      let thicknessMean = _.mean(thicknesses)
+
+      return Math.round(thicknessMean / thicknessHistorical * 100 - 100)
     },
     // Subfunction: Generate annual metrics HTML string
     // Input: None. (Uses constant seasons)
@@ -264,12 +270,12 @@ export default {
         '%</strong>).</p>'
 
       let permafrostChange = this.permafrostChange()
-      if (permafrostChange > 0) {
+      if (permafrostChange < 0) {
         returnedString += '<p>By the late century, the active layer permafrost thickness may '
-        if (permafrostChange < 100) {
-          returnedString += 'decrease by <strong>' + permafrostChange + '%</strong>.</p>'
-        } else {
+        if (permafrostChange == -100) {
           returnedString += 'disappear.</p>'
+        } else {
+          returnedString += 'decrease by <strong>' + Math.abs(permafrostChange) + '%</strong>.</p>'
         }
       }
 

--- a/components/reports/QualitativeText.vue
+++ b/components/reports/QualitativeText.vue
@@ -66,6 +66,8 @@ export default {
       hucName: 'getRawHucName',
       place: 'getPlaceName',
       units: 'units',
+      permafrostPresent: 'permafrostPresent',
+      permafrostDisappears: 'permafrostDisappears',
     }),
     unitsText() {
       if (this.units) {
@@ -151,22 +153,13 @@ export default {
       let models = ['gfdlcm3', 'gisse2r', 'ipslcm5alr', 'mricgcm3', 'ncarccsm4']
       let scenarios = ['rcp45', 'rcp85']
 
-      let permafrostLost = false
       models.forEach(model => {
         scenarios.forEach(scenario => {
           let value = this.altThawData[lastYear][model][scenario]
-          if (value == null) {
-            permafrostLost = true
-          }
           thicknesses.push(value)
         })
       })
       let thicknessMax = _.max(thicknesses)
-
-      if (permafrostLost) {
-        // Active layer has increased 100%. Permafrost has disappeared.
-        return 100
-      }
 
       return Math.round(thicknessMax / thicknessHistorical * 100 - 100)
     },
@@ -284,13 +277,10 @@ export default {
         '%</strong>).</p>'
 
       let permafrostChange = this.permafrostChange()
-      if (permafrostChange > 0) {
-        returnedString += '<p>By the late century, '
-        if (permafrostChange == 100) {
-          returnedString += 'permafrost may <strong>disappear</strong>.</p>'
-        } else {
-          returnedString += 'active layer permafrost thickness may increase by <strong>' + Math.abs(permafrostChange) + '%</strong>.</p>'
-        }
+      if (this.permafrostPresent && this.permafrostDisappears) {
+        returnedString += '<p>By the late century, permafrost may <strong>disappear</strong>.</p>'
+      } else if (permafrostChange > 0) {
+        returnedString += '<p>By the late century, active layer permafrost thickness may increase by <strong>' + Math.abs(permafrostChange) + '%</strong>.</p>'
       }
 
       return returnedString

--- a/components/reports/QualitativeText.vue
+++ b/components/reports/QualitativeText.vue
@@ -278,7 +278,7 @@ export default {
 
       let permafrostChange = this.permafrostChange()
       if (this.permafrostPresent && this.permafrostDisappears) {
-        returnedString += '<p>By the late century, permafrost may <strong>disappear</strong>.</p>'
+        returnedString += '<p>By the late century, permafrost up to 3 meters below ground may <strong>disappear</strong>.</p>'
       } else if (permafrostChange > 0) {
         returnedString += '<p>By the late century, active layer permafrost thickness may increase by <strong>' + Math.abs(permafrostChange) + '%</strong>.</p>'
       }

--- a/components/reports/permafrost/PermafrostReport.vue
+++ b/components/reports/permafrost/PermafrostReport.vue
@@ -19,7 +19,7 @@
 			>
 		</div>
 		<div class="chart-wrapper">
-			<ReportPermafrostChart :reportData="reportData" />
+			<ReportPermafrostChart :permafrostData="permafrostData" />
 		</div>
 	</div>
 </template>
@@ -30,7 +30,7 @@ import { mapGetters } from 'vuex'
 
 export default {
 	name: 'PermafrostReport',
-	props: ['reportData'],
+	props: ['permafrostData'],
 	components: { ReportPermafrostChart },
 	computed: {
 		...mapGetters({

--- a/components/reports/permafrost/PermafrostReport.vue
+++ b/components/reports/permafrost/PermafrostReport.vue
@@ -8,17 +8,17 @@
 			</span>
 		</h4>
 		<div class="content is-size-5">
-			<span v-show="showThawChart && showFreezeChart">
+			<span v-show="permafrostPresent && permafrostDisappears">
 				Projected permafrost active layer thickness and ground freeze depth
 				through the end of the century. The active layer is the layer of soil
 				above permafrost that thaws seasonally.
 			</span>
-			<span v-show="showThawChart && !showFreezeChart">
+			<span v-show="permafrostPresent && !permafrostDisappears">
 				Projected permafrost active layer thickness through the end of the
 				century. The active layer is the layer of soil above permafrost that
 				thaws seasonally.
 			</span>
-			<span v-show="!showThawChart && showFreezeChart">
+			<span v-show="!permafrostPresent && permafrostDisappears">
 				Projected ground freeze depth through the end of the century.
 			</span>
 			Results were produced by the GIPL 2.0 permafrost model using five separate
@@ -29,10 +29,10 @@
 				>Read more about models and RCPs.</nuxt-link
 			>
 		</div>
-		<div class="chart-wrapper permafrost" v-show="showThawChart">
+		<div class="chart-wrapper permafrost" v-show="this.permafrostPresent">
 			<ReportAltThawChart :altThawData="altThawData" />
 		</div>
-		<div class="chart-wrapper permafrost" v-show="showFreezeChart">
+		<div class="chart-wrapper permafrost" v-show="this.permafrostDisappears">
 			<ReportAltFreezeChart :altFreezeData="altFreezeData" />
 		</div>
 	</div>
@@ -45,11 +45,13 @@ import { mapGetters } from 'vuex'
 
 export default {
 	name: 'PermafrostReport',
-	props: ['altThawData', 'altFreezeData', 'showThawChart', 'showFreezeChart'],
+	props: ['altThawData', 'altFreezeData'],
 	components: { ReportAltThawChart, ReportAltFreezeChart },
 	computed: {
 		...mapGetters({
 			units: 'units',
+			permafrostPresent: 'permafrostPresent',
+			permafrostDisappears: 'permafrostDisappears',
 		})
 	},
 }

--- a/components/reports/permafrost/PermafrostReport.vue
+++ b/components/reports/permafrost/PermafrostReport.vue
@@ -1,0 +1,41 @@
+<template>
+	<div>
+		<h4 class="subtitle is-4">
+			Permafrost
+			<span class="units">
+				<span v-if="units == 'imperial'">(inches)</span>
+				<span v-if="units == 'metric'">(meters)</span>
+			</span>
+		</h4>
+		<div class="content is-size-5">
+			Projected permafrost active layer thickness through 2095 compared with a
+			historical value from 1995. Results were produced by the GIPL 2.0
+			permafrost model using five separate climate models and two different
+			greenhouse gas scenarios or Representative Concentration Pathways (RCPs).
+			RCP4.5 is an optimistic future, and RCP8.5 is more pessimistic but also
+			more likely.
+			<nuxt-link :to="{ name: 'about' }"
+				>Read more about models and RCPs.</nuxt-link
+			>
+		</div>
+		<div class="chart-wrapper">
+			<ReportPermafrostChart :reportData="reportData" />
+		</div>
+	</div>
+</template>
+<style></style>
+<script>
+import ReportPermafrostChart from './ReportPermafrostChart'
+import { mapGetters } from 'vuex'
+
+export default {
+	name: 'PermafrostReport',
+	props: ['reportData'],
+	components: { ReportPermafrostChart },
+	computed: {
+		...mapGetters({
+			units: 'units',
+		})
+	}
+}
+</script>

--- a/components/reports/permafrost/PermafrostReport.vue
+++ b/components/reports/permafrost/PermafrostReport.vue
@@ -8,30 +8,29 @@
 			</span>
 		</h4>
 		<div class="content is-size-5">
-			Projected permafrost active layer thickness through 2095 compared with a
-			historical value from 1995. Results were produced by the GIPL 2.0
-			permafrost model using five separate climate models and two different
-			greenhouse gas scenarios or Representative Concentration Pathways (RCPs).
-			RCP4.5 is an optimistic future, and RCP8.5 is more pessimistic but also
-			more likely.
+			Explanation text goes here.
 			<nuxt-link :to="{ name: 'about' }"
 				>Read more about models and RCPs.</nuxt-link
 			>
 		</div>
 		<div class="chart-wrapper permafrost">
-			<ReportPermafrostChart :permafrostData="permafrostData" />
+			<ReportAltThawChart :permafrostData="permafrostData" />
+		</div>
+		<div class="chart-wrapper permafrost">
+			<ReportAltFreezeChart :permafrostData="permafrostData" />
 		</div>
 	</div>
 </template>
 <style></style>
 <script>
-import ReportPermafrostChart from './ReportPermafrostChart'
+import ReportAltThawChart from './ReportAltThawChart'
+import ReportAltFreezeChart from './ReportAltFreezeChart'
 import { mapGetters } from 'vuex'
 
 export default {
 	name: 'PermafrostReport',
 	props: ['permafrostData'],
-	components: { ReportPermafrostChart },
+	components: { ReportAltThawChart, ReportAltFreezeChart },
 	computed: {
 		...mapGetters({
 			units: 'units',

--- a/components/reports/permafrost/PermafrostReport.vue
+++ b/components/reports/permafrost/PermafrostReport.vue
@@ -18,7 +18,7 @@
 				>Read more about models and RCPs.</nuxt-link
 			>
 		</div>
-		<div class="chart-wrapper">
+		<div class="chart-wrapper permafrost">
 			<ReportPermafrostChart :permafrostData="permafrostData" />
 		</div>
 	</div>

--- a/components/reports/permafrost/PermafrostReport.vue
+++ b/components/reports/permafrost/PermafrostReport.vue
@@ -8,7 +8,13 @@
 			</span>
 		</h4>
 		<div class="content is-size-5">
-			Explanation text goes here.
+			Projected permafrost active layer thickness and ground freeze depth
+			through the end of the century. The active layer is the layer of soil
+			above permafrost that thaws seasonally. Results were produced by the
+			GIPL 2.0 permafrost model using five separate climate models and two
+			different greenhouse gas scenarios or Representative Concentration
+			Pathways (RCPs). RCP4.5 is an optimistic future, and RCP8.5 is more
+			pessimistic but also more likely.
 			<nuxt-link :to="{ name: 'about' }"
 				>Read more about models and RCPs.</nuxt-link
 			>

--- a/components/reports/permafrost/PermafrostReport.vue
+++ b/components/reports/permafrost/PermafrostReport.vue
@@ -8,13 +8,23 @@
 			</span>
 		</h4>
 		<div class="content is-size-5">
-			Projected permafrost active layer thickness and ground freeze depth
-			through the end of the century. The active layer is the layer of soil
-			above permafrost that thaws seasonally. Results were produced by the
-			GIPL 2.0 permafrost model using five separate climate models and two
-			different greenhouse gas scenarios or Representative Concentration
-			Pathways (RCPs). RCP4.5 is an optimistic future, and RCP8.5 is more
-			pessimistic but also more likely.
+			<span v-show="showThawChart && showFreezeChart">
+				Projected permafrost active layer thickness and ground freeze depth
+				through the end of the century. The active layer is the layer of soil
+				above permafrost that thaws seasonally.
+			</span>
+			<span v-show="showThawChart && !showFreezeChart">
+				Projected permafrost active layer thickness through the end of the
+				century. The active layer is the layer of soil above permafrost that
+				thaws seasonally.
+			</span>
+			<span v-show="!showThawChart && showFreezeChart">
+				Projected ground freeze depth through the end of the century.
+			</span>
+			Results were produced by the GIPL 2.0 permafrost model using five separate
+			climate models and two different greenhouse gas scenarios or
+			Representative Concentration Pathways (RCPs). RCP4.5 is an optimistic
+			future, and RCP8.5 is more pessimistic but also more likely.
 			<nuxt-link :to="{ name: 'about' }"
 				>Read more about models and RCPs.</nuxt-link
 			>

--- a/components/reports/permafrost/PermafrostReport.vue
+++ b/components/reports/permafrost/PermafrostReport.vue
@@ -19,11 +19,11 @@
 				>Read more about models and RCPs.</nuxt-link
 			>
 		</div>
-		<div class="chart-wrapper permafrost">
-			<ReportAltThawChart :permafrostData="permafrostData" />
+		<div class="chart-wrapper permafrost" v-show="showThawChart">
+			<ReportAltThawChart :altThawData="altThawData" />
 		</div>
-		<div class="chart-wrapper permafrost">
-			<ReportAltFreezeChart :permafrostData="permafrostData" />
+		<div class="chart-wrapper permafrost" v-show="showFreezeChart">
+			<ReportAltFreezeChart :altFreezeData="altFreezeData" />
 		</div>
 	</div>
 </template>
@@ -35,12 +35,12 @@ import { mapGetters } from 'vuex'
 
 export default {
 	name: 'PermafrostReport',
-	props: ['permafrostData'],
+	props: ['altThawData', 'altFreezeData', 'showThawChart', 'showFreezeChart'],
 	components: { ReportAltThawChart, ReportAltFreezeChart },
 	computed: {
 		...mapGetters({
 			units: 'units',
 		})
-	}
+	},
 }
 </script>

--- a/components/reports/permafrost/ReportAltFreezeChart.vue
+++ b/components/reports/permafrost/ReportAltFreezeChart.vue
@@ -13,7 +13,7 @@ import _ from 'lodash'
 import { mapGetters } from 'vuex'
 export default {
 	name: 'ReportAltFreezeChart',
-	props: ['permafrostData'],
+	props: ['altFreezeData'],
 	mounted() {
 		this.renderPlot()
 	},
@@ -23,7 +23,7 @@ export default {
 		})
 	},
 	watch: {
-		permafrostData: function () {
+		altFreezeData: function () {
 			this.renderPlot()
 		},
 		units: function () {
@@ -32,8 +32,8 @@ export default {
 	},
 	methods: {
 		renderPlot: function () {
-			let permafrostData = this.permafrostData
-			if (!permafrostData) {
+			let altFreezeData = this.altFreezeData
+			if (!altFreezeData) {
 				return
 			}
 
@@ -128,25 +128,12 @@ export default {
 				})
 			})
 
-			let historicalAlt = this.permafrostData['gipl']['1995']['cruts31']['historical']['alt']
-			let historicalMagt = this.permafrostData['gipl']['1995']['cruts31']['historical']['magt']
-			let showChart = false
+			let historicalYear = Object.keys(altFreezeData).slice(0, 1)
+			let projectedYears = Object.keys(altFreezeData).slice(1)
 			models.forEach(model => {
 				scenarios.forEach(scenario => {
-					let previousMagt = historicalMagt
-					years.forEach(year => {
-						let scenarioAlt = this.permafrostData['gipl'][year][model][scenario]['alt']
-						if (this.units == 'metric' && scenarioAlt <= 0.07) {
-							scatterTraces[model][scenario]['y'].push(null)
-						} else if (this.units == 'imperial' && scenarioAlt <= 2.8) {
-							scatterTraces[model][scenario]['y'].push(null)
-						} else if (previousMagt > 0) {
-							scatterTraces[model][scenario]['y'].push(scenarioAlt)
-							showChart = true
-						} else {
-							scatterTraces[model][scenario]['y'].push(null)
-						}
-						previousMagt = this.permafrostData['gipl'][year][model][scenario]['magt']
+					projectedYears.forEach(year => {
+						scatterTraces[model][scenario]['y'].push(altFreezeData[year][model][scenario])
 					})
 				})
 			})
@@ -196,14 +183,14 @@ export default {
 
 			let footerText = 'Projected values are taken from GIPL 2.0 model output.'
 
-			if (historicalMagt > 0) {
+			if (altFreezeData[historicalYear]) {
 				layout.shapes.push({
 					type: 'rect',
 					x0: 0,
 					x1: 1,
 					xref: 'paper',
-					y0: historicalAlt,
-					y1: historicalAlt,
+					y0: altFreezeData[historicalYear],
+					y1: altFreezeData[historicalYear],
 					yref: 'y',
 					line: {
 						width: 2
@@ -214,7 +201,7 @@ export default {
 
 				layout.annotations.push({
 					x: 1,
-					y: historicalAlt,
+					y: altFreezeData[historicalYear],
 					xref: 'paper',
 					yref: 'y',
 					text: '1995',
@@ -250,21 +237,19 @@ export default {
 				text: footerText,
 			})
 
-			if (showChart) {
-				this.$Plotly.newPlot('permafrost-alt-freeze-chart', data_traces, layout, {
-					displaylogo: false,
-					modeBarButtonsToRemove: [
-						'zoom2d',
-						'pan2d',
-						'select2d',
-						'lasso2d',
-						'zoomIn2d',
-						'zoomOut2d',
-						'autoScale2d',
-						'resetScale2d',
-					],
-				})
-			}
+			this.$Plotly.newPlot('permafrost-alt-freeze-chart', data_traces, layout, {
+				displaylogo: false,
+				modeBarButtonsToRemove: [
+					'zoom2d',
+					'pan2d',
+					'select2d',
+					'lasso2d',
+					'zoomIn2d',
+					'zoomOut2d',
+					'autoScale2d',
+					'resetScale2d',
+				],
+			})
 		},
 	},
 }

--- a/components/reports/permafrost/ReportAltFreezeChart.vue
+++ b/components/reports/permafrost/ReportAltFreezeChart.vue
@@ -136,7 +136,11 @@ export default {
 					let previousMagt = historicalMagt
 					years.forEach(year => {
 						let scenarioAlt = this.permafrostData['gipl'][year][model][scenario]['alt']
-						if (previousMagt > 0) {
+						if (this.units == 'metric' && scenarioAlt <= 0.07) {
+							scatterTraces[model][scenario]['y'].push(null)
+						} else if (this.units == 'imperial' && scenarioAlt <= 2.8) {
+							scatterTraces[model][scenario]['y'].push(null)
+						} else if (previousMagt > 0) {
 							scatterTraces[model][scenario]['y'].push(scenarioAlt)
 							showChart = true
 						} else {

--- a/components/reports/permafrost/ReportAltThawChart.vue
+++ b/components/reports/permafrost/ReportAltThawChart.vue
@@ -158,7 +158,7 @@ export default {
 				boxmode: 'group',
 				yaxis: {
 					title: {
-						text: 'Depth (' + units + ')',
+						text: 'Thickness (' + units + ')',
 						font: {
 							size: 18,
 						},

--- a/components/reports/permafrost/ReportAltThawChart.vue
+++ b/components/reports/permafrost/ReportAltThawChart.vue
@@ -1,0 +1,267 @@
+<template>
+	<div class="permafrost-chart-wrapper">
+		<div id="permafrost-alt-thaw-chart" />
+	</div>
+</template>
+<style lang="scss" scoped>
+.permafrost-chart-wrapper {
+	padding-bottom: 0rem;
+}
+</style>
+<script>
+import _ from 'lodash'
+import { mapGetters } from 'vuex'
+export default {
+	name: 'ReportAltThawChart',
+	props: ['permafrostData'],
+	mounted() {
+		this.renderPlot()
+	},
+	computed: {
+		...mapGetters({
+			units: 'units',
+		})
+	},
+	watch: {
+		permafrostData: function () {
+			this.renderPlot()
+		},
+		units: function () {
+			this.renderPlot()
+		},
+	},
+	methods: {
+		renderPlot: function () {
+			let permafrostData = this.permafrostData
+			if (!permafrostData) {
+				return
+			}
+
+			let data_traces = []
+			let units = this.units == 'metric' ? 'm' : 'in'
+
+			let eras_lu = {
+				'2025': '2011 - 2040',
+				'2050': '2036 - 2065',
+				'2075': '2061 – 2090',
+				'2095': '2086 – 2100',
+			}
+
+			let years = Object.keys(eras_lu)
+			let eras = Object.values(eras_lu)
+			let models = ['gfdlcm3', 'gisse2r', 'ipslcm5alr', 'mricgcm3', 'ncarccsm4']
+			let scenarios = ['rcp45', 'rcp85']
+
+			let traceLabels_lu = {
+				'gfdlcm3': {
+					'rcp45': 'RCP 4.5 (gfdlcm3)',
+					'rcp85': 'RCP 8.5 (gfdlcm3)',
+				},
+				'gisse2r': {
+					'rcp45': 'RCP 4.5 (gisse2r)',
+					'rcp85': 'RCP 8.5 (gisse2r)',
+				},
+				'ipslcm5alr': {
+					'rcp45': 'RCP 4.5 (ipslcm5alr)',
+					'rcp85': 'RCP 8.5 (ipslcm5alr)',
+				},
+				'mricgcm3': {
+					'rcp45': 'RCP 4.5 (mricgcm3)',
+					'rcp85': 'RCP 8.5 (mricgcm3)',
+				},
+				'ncarccsm4': {
+					'rcp45': 'RCP 4.5 (ncarccsm4)',
+					'rcp85': 'RCP 8.5 (ncarccsm4)',
+				},
+			}
+
+			let scatterTraces = {}
+
+			let symbols = {
+				'gfdlcm3': 'circle',
+				'gisse2r': 'square',
+				'ipslcm5alr': 'diamond',
+				'mricgcm3': 'cross',
+				'ncarccsm4': 'x',
+			}
+
+			let colors = {
+				'gfdlcm3': {
+					'rcp45': 'rgb(230, 150, 150)',
+					'rcp85': 'rgb(190, 30, 30)',
+				},
+				'gisse2r': {
+					'rcp45': 'rgb(150, 150, 230)',
+					'rcp85': 'rgb(30, 30, 190)',
+				},
+				'ipslcm5alr': {
+					'rcp45': 'rgb(210, 210, 150)',
+					'rcp85': 'rgb(140, 140, 30)',
+				},
+				'mricgcm3': {
+					'rcp45': 'rgb(250, 150, 30)',
+					'rcp85': 'rgb(210, 120, 30)',
+				},
+				'ncarccsm4': {
+					'rcp45': 'rgb(210, 150, 210)',
+					'rcp85': 'rgb(140, 30, 140)',
+				},
+			}
+
+			models.forEach(model => {
+				scatterTraces[model] = {}
+				scenarios.forEach(scenario => {
+					scatterTraces[model][scenario] = {
+						type: 'scatter',
+						mode: 'markers',
+						name: traceLabels_lu[model][scenario],
+						hoverinfo: 'x+y+z+text',
+						hovertemplate: '%{y}' + units,
+						marker: {
+							symbol: Array(eras.length).fill(symbols[model]),
+							size: 8,
+							color: colors[model][scenario],
+						},
+						x: eras,
+						y: [],
+					}
+				})
+			})
+
+			let historicalAlt = this.permafrostData['gipl']['1995']['cruts31']['historical']['alt']
+			let historicalMagt = this.permafrostData['gipl']['1995']['cruts31']['historical']['magt']
+			let showChart = false
+			models.forEach(model => {
+				scenarios.forEach(scenario => {
+					let previousMagt = historicalMagt
+					years.forEach(year => {
+						let scenarioAlt = this.permafrostData['gipl'][year][model][scenario]['alt']
+						if (previousMagt < 0) {
+							scatterTraces[model][scenario]['y'].push(scenarioAlt)
+							showChart = true
+						} else {
+							scatterTraces[model][scenario]['y'].push(null)
+						}
+						previousMagt = this.permafrostData['gipl'][year][model][scenario]['magt']
+					})
+				})
+			})
+
+			models.forEach(model => {
+				scenarios.forEach(scenario => {
+					data_traces.push(scatterTraces[model][scenario])
+				})
+			})
+
+			let hoverformat = '.1f'
+			let layout = {
+				boxmode: 'group',
+				yaxis: {
+					title: {
+						text: 'Depth (' + units + ')',
+						font: {
+							size: 18,
+						},
+					},
+					hoverformat: hoverformat,
+				},
+				title: {
+					text: 'Projected permafrost thaw depth',
+					font: {
+						size: 24,
+					},
+				},
+				shapes: [],
+				hovermode: 'x unified',
+				hoverlabel: {
+					namelength: -1,
+				},
+				annotations: [],
+				legend: {
+					x: 1.03
+				},
+				margin: {
+					b: 40
+				},
+				margin: {
+					b: 120
+				},
+				height: 500,
+				dragmode: false,
+			}
+
+			let footerText = 'Projected values are taken from GIPL 2.0 model output.'
+
+			if (historicalMagt < 0) {
+				layout.shapes.push({
+					type: 'rect',
+					x0: 0,
+					x1: 1,
+					xref: 'paper',
+					y0: historicalAlt,
+					y1: historicalAlt,
+					yref: 'y',
+					line: {
+						width: 2
+					},
+					fillcolor: '#cccccc',
+					opacity: 0.2
+				})
+
+				layout.annotations.push({
+					x: 1,
+					y: historicalAlt,
+					xref: 'paper',
+					yref: 'y',
+					text: '1995',
+					showarrow: true,
+					arrowcolor: '#aaaaaa',
+					arrowhead: 6,
+					ax: 0,
+					ay: -12,
+					font: {
+						color: '#888888',
+					}
+				})
+
+				footerText = 'Historical value is taken from the CRU TS 3.1 dataset.' +
+					'<br />' + footerText
+			}
+
+			let footer_y = -0.25
+			if (window.innerWidth < 1250) {
+				layout['xaxis'] = {
+					tickangle: 45,
+				}
+				layout['margin']['b'] = 160
+				footer_y = -0.50
+			}
+
+			layout.annotations.push({
+				x: 0.5,
+				y: footer_y,
+				xref: 'paper',
+				yref: 'paper',
+				showarrow: false,
+				text: footerText,
+			})
+
+			if (showChart) {
+				this.$Plotly.newPlot('permafrost-alt-thaw-chart', data_traces, layout, {
+					displaylogo: false,
+					modeBarButtonsToRemove: [
+						'zoom2d',
+						'pan2d',
+						'select2d',
+						'lasso2d',
+						'zoomIn2d',
+						'zoomOut2d',
+						'autoScale2d',
+						'resetScale2d',
+					],
+				})
+			}
+		},
+	},
+}
+</script>

--- a/components/reports/permafrost/ReportAltThawChart.vue
+++ b/components/reports/permafrost/ReportAltThawChart.vue
@@ -13,7 +13,7 @@ import _ from 'lodash'
 import { mapGetters } from 'vuex'
 export default {
 	name: 'ReportAltThawChart',
-	props: ['permafrostData'],
+	props: ['altThawData'],
 	mounted() {
 		this.renderPlot()
 	},
@@ -23,7 +23,7 @@ export default {
 		})
 	},
 	watch: {
-		permafrostData: function () {
+		altThawData: function () {
 			this.renderPlot()
 		},
 		units: function () {
@@ -32,8 +32,8 @@ export default {
 	},
 	methods: {
 		renderPlot: function () {
-			let permafrostData = this.permafrostData
-			if (!permafrostData) {
+			let altThawData = this.altThawData
+			if (!altThawData) {
 				return
 			}
 
@@ -128,21 +128,12 @@ export default {
 				})
 			})
 
-			let historicalAlt = this.permafrostData['gipl']['1995']['cruts31']['historical']['alt']
-			let historicalMagt = this.permafrostData['gipl']['1995']['cruts31']['historical']['magt']
-			let showChart = false
+			let historicalYear = Object.keys(altThawData).slice(0, 1)
+			let projectedYears = Object.keys(altThawData).slice(1)
 			models.forEach(model => {
 				scenarios.forEach(scenario => {
-					let previousMagt = historicalMagt
-					years.forEach(year => {
-						let scenarioAlt = this.permafrostData['gipl'][year][model][scenario]['alt']
-						if (previousMagt < 0) {
-							scatterTraces[model][scenario]['y'].push(scenarioAlt)
-							showChart = true
-						} else {
-							scatterTraces[model][scenario]['y'].push(null)
-						}
-						previousMagt = this.permafrostData['gipl'][year][model][scenario]['magt']
+					projectedYears.forEach(year => {
+						scatterTraces[model][scenario]['y'].push(altThawData[year][model][scenario])
 					})
 				})
 			})
@@ -192,14 +183,14 @@ export default {
 
 			let footerText = 'Projected values are taken from GIPL 2.0 model output.'
 
-			if (historicalMagt < 0) {
+			if (altThawData[historicalYear]) {
 				layout.shapes.push({
 					type: 'rect',
 					x0: 0,
 					x1: 1,
 					xref: 'paper',
-					y0: historicalAlt,
-					y1: historicalAlt,
+					y0: altThawData[historicalYear],
+					y1: altThawData[historicalYear],
 					yref: 'y',
 					line: {
 						width: 2
@@ -210,7 +201,7 @@ export default {
 
 				layout.annotations.push({
 					x: 1,
-					y: historicalAlt,
+					y: altThawData[historicalYear],
 					xref: 'paper',
 					yref: 'y',
 					text: '1995',
@@ -246,21 +237,19 @@ export default {
 				text: footerText,
 			})
 
-			if (showChart) {
-				this.$Plotly.newPlot('permafrost-alt-thaw-chart', data_traces, layout, {
-					displaylogo: false,
-					modeBarButtonsToRemove: [
-						'zoom2d',
-						'pan2d',
-						'select2d',
-						'lasso2d',
-						'zoomIn2d',
-						'zoomOut2d',
-						'autoScale2d',
-						'resetScale2d',
-					],
-				})
-			}
+			this.$Plotly.newPlot('permafrost-alt-thaw-chart', data_traces, layout, {
+				displaylogo: false,
+				modeBarButtonsToRemove: [
+					'zoom2d',
+					'pan2d',
+					'select2d',
+					'lasso2d',
+					'zoomIn2d',
+					'zoomOut2d',
+					'autoScale2d',
+					'resetScale2d',
+				],
+			})
 		},
 	},
 }

--- a/components/reports/permafrost/ReportAltThawChart.vue
+++ b/components/reports/permafrost/ReportAltThawChart.vue
@@ -166,7 +166,7 @@ export default {
 					hoverformat: hoverformat,
 				},
 				title: {
-					text: 'Projected permafrost thaw depth',
+					text: 'Projected active layer thickness',
 					font: {
 						size: 24,
 					},

--- a/components/reports/permafrost/ReportPermafrostChart.vue
+++ b/components/reports/permafrost/ReportPermafrostChart.vue
@@ -41,7 +41,6 @@ export default {
 			let units = this.units == 'metric' ? 'm' : 'in'
 
 			let eras_lu = {
-				'1995': '1995',
 				'2025': '2011 - 2040',
 				'2050': '2036 - 2065',
 				'2075': '2061 – 2090',
@@ -50,25 +49,6 @@ export default {
 
 			let years = Object.keys(eras_lu)
 			let eras = Object.values(eras_lu)
-
-			let historical_y = Array(eras.length).fill(null)
-			historical_y[0] = this.permafrostData['gipl']['1995']['cruts31']['historical']['alt']
-
-			let historical = {
-				type: 'scatter',
-				mode: 'markers',
-				name: 'Historical (1995)',
-				hoverinfo: 'x+y+z+text',
-				hovertemplate: '%{y}' + units,
-				marker: {
-					symbol: Array(eras.length).fill('star'),
-					size: 9,
-					color: '#888888',
-				},
-				x: eras,
-				y: historical_y,
-			}
-
 			let models = ['gfdlcm3', 'gisse2r', 'ipslcm5alr', 'mricgcm3', 'ncarccsm4']
 			let scenarios = ['rcp45', 'rcp85']
 
@@ -143,23 +123,19 @@ export default {
 							color: colors[model][scenario],
 						},
 						x: eras,
-						y: [null],
+						y: [],
 					}
 				})
 			})
 
 			models.forEach(model => {
 				years.forEach(year => {
-					if (year != '1995') {
-						scenarios.forEach(scenario => {
-							let scenarioAlt = this.permafrostData['gipl'][year][model][scenario]['alt']
-							scatterTraces[model][scenario]['y'].push(scenarioAlt)
-						})
-					}
+					scenarios.forEach(scenario => {
+						let scenarioAlt = this.permafrostData['gipl'][year][model][scenario]['alt']
+						scatterTraces[model][scenario]['y'].push(scenarioAlt)
+					})
 				})
 			})
-
-			data_traces.push(historical)
 
 			models.forEach(model => {
 				scenarios.forEach(scenario => {
@@ -188,12 +164,41 @@ export default {
 						size: 24,
 					},
 				},
-				shapes: [],
+				shapes: [
+					{
+						type: 'rect',
+						x0: 0,
+						x1: 1,
+						xref: 'paper',
+						y0: this.permafrostData['gipl']['1995']['cruts31']['historical']['alt'],
+						y1: this.permafrostData['gipl']['1995']['cruts31']['historical']['alt'],
+						yref: 'y',
+						line: {
+							width: 2
+						},
+						fillcolor: '#cccccc',
+						opacity: 0.2
+					},
+				],
 				hovermode: 'x unified',
 				hoverlabel: {
 					namelength: -1,
 				},
-				annotations: [],
+				annotations: [{
+					x: 1,
+					y: this.permafrostData['gipl']['1995']['cruts31']['historical']['alt'],
+					xref: 'paper',
+					yref: 'y',
+					text: '1995',
+					showarrow: true,
+					arrowcolor: '#aaaaaa',
+					arrowhead: 6,
+					ax: 0,
+					ay: -12,
+					font: {
+						color: '#888888',
+					}
+				}],
 				legend: {
 					x: 1.03
 				},

--- a/components/reports/permafrost/ReportPermafrostChart.vue
+++ b/components/reports/permafrost/ReportPermafrostChart.vue
@@ -143,6 +143,7 @@ export default {
 				})
 			})
 
+			let historicalAlt = this.permafrostData['gipl']['1995']['cruts31']['historical']['alt']
 			let hoverformat = '.1f'
 			let layout = {
 				boxmode: 'group',
@@ -170,8 +171,8 @@ export default {
 						x0: 0,
 						x1: 1,
 						xref: 'paper',
-						y0: this.permafrostData['gipl']['1995']['cruts31']['historical']['alt'],
-						y1: this.permafrostData['gipl']['1995']['cruts31']['historical']['alt'],
+						y0: historicalAlt,
+						y1: historicalAlt,
 						yref: 'y',
 						line: {
 							width: 2
@@ -186,7 +187,7 @@ export default {
 				},
 				annotations: [{
 					x: 1,
-					y: this.permafrostData['gipl']['1995']['cruts31']['historical']['alt'],
+					y: historicalAlt,
 					xref: 'paper',
 					yref: 'y',
 					text: '1995',

--- a/components/reports/permafrost/ReportPermafrostChart.vue
+++ b/components/reports/permafrost/ReportPermafrostChart.vue
@@ -152,7 +152,7 @@ export default {
 				},
 				yaxis: {
 					title: {
-						text: 'Permafrost ' + units,
+						text: 'Thickness ' + units,
 						font: {
 							size: 18,
 						},

--- a/components/reports/permafrost/ReportPermafrostChart.vue
+++ b/components/reports/permafrost/ReportPermafrostChart.vue
@@ -206,9 +206,31 @@ export default {
 				margin: {
 					b: 40
 				},
-				height: 400,
+				margin: {
+					b: 120
+				},
+				height: 500,
 				dragmode: false,
 			}
+
+			let footer_y = -0.25
+			if (window.innerWidth < 1250) {
+				layout['xaxis'] = {
+					tickangle: 45,
+				}
+				layout['margin']['b'] = 160
+				footer_y = -0.50
+			}
+
+			layout.annotations.push({
+				x: 0.5,
+				y: footer_y,
+				xref: 'paper',
+				yref: 'paper',
+				showarrow: false,
+				text: 'Historical active layer thickness is taken from the CRU TS 3.1 ' +
+					'dataset.<br />Projected values are taken from GIPL 2.0 model output.',
+			})
 
 			this.$Plotly.newPlot('permafrost-chart', data_traces, layout, {
 				displaylogo: false,

--- a/components/reports/permafrost/ReportPermafrostChart.vue
+++ b/components/reports/permafrost/ReportPermafrostChart.vue
@@ -152,7 +152,7 @@ export default {
 				},
 				yaxis: {
 					title: {
-						text: 'Thickness ' + units,
+						text: 'Thickness (' + units + ')',
 						font: {
 							size: 18,
 						},

--- a/components/reports/permafrost/ReportPermafrostChart.vue
+++ b/components/reports/permafrost/ReportPermafrostChart.vue
@@ -13,7 +13,7 @@ import _ from 'lodash'
 import { mapGetters } from 'vuex'
 export default {
 	name: 'ReportPermafrostChart',
-	props: ['reportData'],
+	props: ['permafrostData'],
 	mounted() {
 		this.renderPlot()
 	},
@@ -23,7 +23,7 @@ export default {
 		})
 	},
 	watch: {
-		reportData: function () {
+		permafrostData: function () {
 			this.renderPlot()
 		},
 		units: function () {
@@ -32,8 +32,8 @@ export default {
 	},
 	methods: {
 		renderPlot: function () {
-			let reportData = this.reportData
-			if (!reportData) {
+			let permafrostData = this.permafrostData
+			if (!permafrostData) {
 				return
 			}
 
@@ -52,7 +52,7 @@ export default {
 			let eras = Object.values(eras_lu)
 
 			let historical_y = Array(eras.length).fill(null)
-			historical_y[0] = this.reportData['gipl']['1995']['cruts31']['historical']['alt']
+			historical_y[0] = this.permafrostData['gipl']['1995']['cruts31']['historical']['alt']
 
 			let historical = {
 				type: 'scatter',
@@ -152,7 +152,7 @@ export default {
 				years.forEach(year => {
 					if (year != '1995') {
 						scenarios.forEach(scenario => {
-							let scenarioAlt = this.reportData['gipl'][year][model][scenario]['alt']
+							let scenarioAlt = this.permafrostData['gipl'][year][model][scenario]['alt']
 							scatterTraces[model][scenario]['y'].push(scenarioAlt)
 						})
 					}

--- a/components/reports/permafrost/ReportPermafrostChart.vue
+++ b/components/reports/permafrost/ReportPermafrostChart.vue
@@ -1,0 +1,223 @@
+<template>
+	<div class="Permafrost-chart-wrapper">
+		<div id="Permafrost-chart" />
+	</div>
+</template>
+<style lang="scss" scoped>
+.Permafrost-chart-wrapper {
+	padding-bottom: 0rem;
+}
+</style>
+<script>
+import _ from 'lodash'
+import { mapGetters } from 'vuex'
+export default {
+	name: 'ReportPermafrostChart',
+	props: ['reportData'],
+	mounted() {
+		this.renderPlot()
+	},
+	computed: {
+		...mapGetters({
+			units: 'units',
+		})
+	},
+	watch: {
+		reportData: function () {
+			this.renderPlot()
+		},
+		units: function () {
+			this.renderPlot()
+		},
+	},
+	methods: {
+		renderPlot: function () {
+			let reportData = this.reportData
+			if (!reportData) {
+				return
+			}
+
+			let data_traces = []
+			let units = this.units == 'metric' ? 'm' : 'in'
+
+			let eras_lu = {
+				'1995': '1995',
+				'2025': '2011 - 2040',
+				'2050': '2036 - 2065',
+				'2075': '2061 – 2090',
+				'2095': '2086 – 2100',
+			}
+
+			let years = Object.keys(eras_lu)
+			let eras = Object.values(eras_lu)
+
+			let historical_y = Array(eras.length).fill(null)
+			historical_y[0] = this.reportData['gipl']['1995']['cruts31']['historical']['alt']
+
+			let historical = {
+				type: 'scatter',
+				mode: 'markers',
+				name: 'Historical (1995)',
+				hoverinfo: 'x+y+z+text',
+				hovertemplate: '%{y}' + units,
+				marker: {
+					symbol: Array(eras.length).fill('star'),
+					size: 9,
+					color: '#888888',
+				},
+				x: eras,
+				y: historical_y,
+			}
+
+			let models = ['gfdlcm3', 'gisse2r', 'ipslcm5alr', 'mricgcm3', 'ncarccsm4']
+			let scenarios = ['rcp45', 'rcp85']
+
+			let traceLabels_lu = {
+				'gfdlcm3': {
+					'rcp45': 'RCP 4.5 (gfdlcm3)',
+					'rcp85': 'RCP 8.5 (gfdlcm3)',
+				},
+				'gisse2r': {
+					'rcp45': 'RCP 4.5 (gisse2r)',
+					'rcp85': 'RCP 8.5 (gisse2r)',
+				},
+				'ipslcm5alr': {
+					'rcp45': 'RCP 4.5 (ipslcm5alr)',
+					'rcp85': 'RCP 8.5 (ipslcm5alr)',
+				},
+				'mricgcm3': {
+					'rcp45': 'RCP 4.5 (mricgcm3)',
+					'rcp85': 'RCP 8.5 (mricgcm3)',
+				},
+				'ncarccsm4': {
+					'rcp45': 'RCP 4.5 (ncarccsm4)',
+					'rcp85': 'RCP 8.5 (ncarccsm4)',
+				},
+			}
+
+			let scatterTraces = {}
+
+			let symbols = {
+				'gfdlcm3': 'circle',
+				'gisse2r': 'square',
+				'ipslcm5alr': 'diamond',
+				'mricgcm3': 'cross',
+				'ncarccsm4': 'x',
+			}
+
+			let colors = {
+				'gfdlcm3': {
+					'rcp45': 'rgb(230, 150, 150)',
+					'rcp85': 'rgb(190, 30, 30)',
+				},
+				'gisse2r': {
+					'rcp45': 'rgb(150, 150, 230)',
+					'rcp85': 'rgb(30, 30, 190)',
+				},
+				'ipslcm5alr': {
+					'rcp45': 'rgb(210, 210, 150)',
+					'rcp85': 'rgb(140, 140, 30)',
+				},
+				'mricgcm3': {
+					'rcp45': 'rgb(250, 150, 30)',
+					'rcp85': 'rgb(210, 120, 30)',
+				},
+				'ncarccsm4': {
+					'rcp45': 'rgb(210, 150, 210)',
+					'rcp85': 'rgb(140, 30, 140)',
+				},
+			}
+
+			models.forEach(model => {
+				scatterTraces[model] = {}
+				scenarios.forEach(scenario => {
+					scatterTraces[model][scenario] = {
+						type: 'scatter',
+						mode: 'markers',
+						name: traceLabels_lu[model][scenario],
+						hoverinfo: 'x+y+z+text',
+						hovertemplate: '%{y}' + units,
+						marker: {
+							symbol: Array(eras.length).fill(symbols[model]),
+							size: 8,
+							color: colors[model][scenario],
+						},
+						x: eras,
+						y: [null],
+					}
+				})
+			})
+
+			models.forEach(model => {
+				years.forEach(year => {
+					if (year != '1995') {
+						scenarios.forEach(scenario => {
+							let scenarioAlt = this.reportData['gipl'][year][model][scenario]['alt']
+							scatterTraces[model][scenario]['y'].push(scenarioAlt)
+						})
+					}
+				})
+			})
+
+			data_traces.push(historical)
+
+			models.forEach(model => {
+				scenarios.forEach(scenario => {
+					data_traces.push(scatterTraces[model][scenario])
+				})
+			})
+
+			let hoverformat = '.1f'
+			let layout = {
+				boxmode: 'group',
+				xaxis: {
+					type: 'category'
+				},
+				yaxis: {
+					title: {
+						text: 'Permafrost ' + units,
+						font: {
+							size: 18,
+						},
+					},
+					hoverformat: hoverformat,
+				},
+				title: {
+					text: 'Historical and projected active layer permafrost thickness',
+					font: {
+						size: 24,
+					},
+				},
+				shapes: [],
+				hovermode: 'x unified',
+				hoverlabel: {
+					namelength: -1,
+				},
+				annotations: [],
+				legend: {
+					x: 1.03
+				},
+				margin: {
+					b: 40
+				},
+				height: 400,
+				dragmode: false,
+			}
+
+			this.$Plotly.newPlot('Permafrost-chart', data_traces, layout, {
+				displaylogo: false,
+				modeBarButtonsToRemove: [
+					'zoom2d',
+					'pan2d',
+					'select2d',
+					'lasso2d',
+					'zoomIn2d',
+					'zoomOut2d',
+					'autoScale2d',
+					'resetScale2d',
+				],
+			})
+		},
+	},
+}
+</script>

--- a/components/reports/permafrost/ReportPermafrostChart.vue
+++ b/components/reports/permafrost/ReportPermafrostChart.vue
@@ -1,10 +1,10 @@
 <template>
-	<div class="Permafrost-chart-wrapper">
-		<div id="Permafrost-chart" />
+	<div class="permafrost-chart-wrapper">
+		<div id="permafrost-chart" />
 	</div>
 </template>
 <style lang="scss" scoped>
-.Permafrost-chart-wrapper {
+.permafrost-chart-wrapper {
 	padding-bottom: 0rem;
 }
 </style>
@@ -210,7 +210,7 @@ export default {
 				dragmode: false,
 			}
 
-			this.$Plotly.newPlot('Permafrost-chart', data_traces, layout, {
+			this.$Plotly.newPlot('permafrost-chart', data_traces, layout, {
 				displaylogo: false,
 				modeBarButtonsToRemove: [
 					'zoom2d',

--- a/components/reports/precipitation/ReportPrecipChart.vue
+++ b/components/reports/precipitation/ReportPrecipChart.vue
@@ -183,7 +183,7 @@ export default {
 				boxmode: 'group',
 				yaxis: {
 					title: {
-						text: 'Precipitation ' + units,
+						text: 'Precipitation (' + units + ')',
 						font: {
 							size: 18,
 						},

--- a/components/reports/temperature/ReportTempChart.vue
+++ b/components/reports/temperature/ReportTempChart.vue
@@ -189,7 +189,7 @@ export default {
 				},
 				yaxis: {
 					title: {
-						text: 'Temperature ' + units,
+						text: 'Temperature (' + units + ')',
 						font: {
 							size: 18,
 						},

--- a/store/index.js
+++ b/store/index.js
@@ -3,7 +3,9 @@ import communities from '~/assets/communities'
 import hucs from '~/assets/hucs'
 
 export const state = () => ({
-  units: 'imperial'
+  units: 'imperial',
+  permafrostPresent: false,
+  permafrostDisappears: false,
 })
 
 export const mutations = {
@@ -12,6 +14,12 @@ export const mutations = {
   },
   setImperial (state) {
     state.units = 'imperial'
+  },
+  setPermafrostPresent(state, value) {
+    state.permafrostPresent = value
+  },
+  setPermafrostDisappears (state, value) {
+    state.permafrostDisappears = value
   }
 }
 
@@ -20,6 +28,13 @@ export const mutations = {
 export const getters = {
   units: (state) => {
     return state.units
+  },
+
+  permafrostPresent: (state) => {
+    return state.permafrostPresent
+  },
+  permafrostDisappears: (state) => {
+    return state.permafrostDisappears
   },
 
   // Boolean if any combo of place identifiers are active,


### PR DESCRIPTION
Closes #61 (potentially).
Closes #125.
Closes #126.
Closes #140.

Regarding #61: Add permafrost data to the app

We are using GIPL ALT (active layer thickness) and MAGT (mean annual ground temperature) data to display:

- A permafrost active layer thickness chart when permafrost is present at the location
- A ground freeze depth chart if the projected data show permafrost disappearing at the location

Implementing a table for permafrost (like we do for temperature and precipitation) did not seem appropriate since permafrost data is not divided into seasons, so we would have only one row for the table, and that's not much of a table.

Regarding #126: Handle condition where permafrost active layer thickness is zero

If no ALT data is available, the entire permafrost section of the report is replaced with the statement "Permafrost data are not available for this location." When there is ALT data, the explanation text introducing the charts changes depending on which (or both) of the charts are available.

Regarding #125: Add dynamic text blurb for permafrost

The code to generate dynamic text for permafrost data is slightly different from how is described in #125, and more consistent with how the temperature and precipitation dynamic text is generated. Instead of taking the mean across models, it's taking the maximum ALT value (after stripping out the no-permafrost ALT values) to determine how much permafrost may be lost. In other words, we are using the most extreme value to convey what __may__ happen, similar to what we do for temperature and precipitation.

If MAGT switches from negative to positive, this indicates that permafrost at 3 meters depth may disappear entirely, which is what triggers the display of the "ground freeze chart". If "ground freeze depth" chart is visible, this means the location may lose its permafrost. The qualitative text now agrees with this logic.