### PR TITLE
Add a note to temp/precip charts explaining that boxplot shows the median

### DIFF
--- a/components/reports/precipitation/ReportPrecipChart.vue
+++ b/components/reports/precipitation/ReportPrecipChart.vue
@@ -242,7 +242,8 @@ export default {
 				text: 'The boxplot represents the interquartile range (IQR) of ' +
 					'historical means for the season, from 1950-2009.<br />The shaded ' +
 					'gray region shows the extent of common variation for the ' +
-					'historical period.',
+					'historical period.<br />The line inside the boxplot represents ' +
+					'the median historical precipitation.',
 			})
 
 			this.$Plotly.newPlot('precip-chart', data_traces, layout, {

--- a/components/reports/temperature/ReportTempChart.vue
+++ b/components/reports/temperature/ReportTempChart.vue
@@ -248,7 +248,8 @@ export default {
 				text: 'The boxplot represents the interquartile range (IQR) of ' +
 					'historical means for the season, from 1950-2009.<br />The shaded ' +
 					'gray region shows the extent of common variation for the ' +
-					'historical period.',
+					'historical period.<br />The line inside the boxplot represents ' +
+					'the median historical temperature.',
 			})
 
 			// Draw freezing line only if it falls within range of displayed data to


### PR DESCRIPTION
Closes #120.

This PR simply adds a note to the footers of both the temperature and precipitation charts that the boxplot shows the median, not the mean.

An open question from our previous meeting was whether we should update the hovertext deltas to show the difference from the mean, not the median, since all of the other delta calculations on the web app use the mean (as described in #120), but I don't think this makes sense in the context of the charts. Since the data tables and qualitative text use 30-year ranges for their delta calculations, these values do not match any of the values from the decadal charts anyway, so there is little or nothing to be gained from calculating from the mean for chart hovertext deltas.