### PR TITLE
Updates footer, data page to include info on the data license.

### DIFF
--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -37,6 +37,9 @@
 						to see our full suite of interactive web tools.
 					</p>
 					<p>
+						Data available through this tool are subject to the <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0</a> license.
+					</p>
+					<p>
 						Copyright &copy; {{ year }} University of Alaska Fairbanks. All
 						rights reserved.
 					</p>

--- a/pages/data.vue
+++ b/pages/data.vue
@@ -15,6 +15,13 @@
           IEM project. If you are looking for models or scenarios not present on
           this site, you can download source data.
         </p>
+        <p>
+          Data available through this tool are subject to the
+          <a href="https://creativecommons.org/licenses/by/4.0/"
+            >Creative Commons Attribution 4.0</a
+          >
+          license.
+        </p>
         <h2 class="title is-3">How to obtain source data</h2>
         <p>
           Data used on this site is distributed from the data repository at the
@@ -22,35 +29,47 @@
         </p>
         <ul>
           <li>
-            <a href="http://ckan.snap.uaf.edu/dataset?tags=IEM-Input">Model inputs</a>. These data were prepared specifically to support
-            modelling runs used in the IEM project.
+            <a href="http://ckan.snap.uaf.edu/dataset?tags=IEM-Input"
+              >Model inputs</a
+            >. These data were prepared specifically to support modelling runs
+            used in the IEM project.
           </li>
           <li>
-            <a href="http://ckan.snap.uaf.edu/dataset?tags=IEM-Output">Model outputs</a>. These data consist of outputs from the model runs
-            performed through the IEM project.
+            <a href="http://ckan.snap.uaf.edu/dataset?tags=IEM-Output"
+              >Model outputs</a
+            >. These data consist of outputs from the model runs performed
+            through the IEM project.
           </li>
         </ul>
         <p>
           There, you can filter and search for specific datasets and variables
           of interest to download the full range of model and scenario options.
-          These data generally offered as gridded multiband GeoTIFF products.
+          These data are generally offered as gridded multiband GeoTIFF
+          products.
+        </p>
+        <h2 class="title is-3">Data API access</h2>
+        <p>
+          In addition to downloading source data as GeoTIFFs, all the data that
+          are used in this web tool may be accessed via an API. Documentation
+          and examples are provided on the API site.
+        </p>
+        <p>
+          <a class="button is-link" href="https://earthmaps.io"
+            >Visit the Data API</a
+          >
         </p>
         <h2 class="title is-3">Code examples</h2>
         <code
           >Placeholder for a link to a Python notebook doing a point extraction
           from a stack of GeoTIFFs (say, GIPL).</code
         >
-        <h2 class="title is-3">Data API access</h2>
-        <p>
-          In addition to downloading source data as GeoTIFFs, all the data that
-          are used in this web tool may be accessed via an API. Links to API
-          endpoints are listed below.
-        </p>
-        <code>[tbd]</code>
         <h2 class="title is-3">Contact us if you have any questions</h2>
         <p>
-          Email us at <a href="mailto:uaf-snap-data-tools@alaska.edu">uaf-snap-data-tools@alaska.edu</a> if you have any questions
-          about these data.
+          Email us at
+          <a href="mailto:uaf-snap-data-tools@alaska.edu"
+            >uaf-snap-data-tools@alaska.edu</a
+          >
+          if you have any questions about these data.
         </p>
       </div>
     </div>


### PR DESCRIPTION
Also Adds a real link to the data API.

Closes #115 .

To test,
 * Open app, look in the footer, note the new license language, test the link to make sure it's correct.
 * Go to the `/data` page (manually via URL is easiest) and look for the added section in the first part of that page.
 * Also on the `/data` page, under the "Data API access" header, observe there's now a Visit the Data API button.  Click it to verify that it works!