### PR TITLE
Adds draft "table of contents" to app

### DIFF
--- a/components/Report.vue
+++ b/components/Report.vue
@@ -39,7 +39,7 @@
 				</h3>
 				<QualitativeText :reportData="results" :altThawData="altThawData" />
 			</section>
-			<section class="section">
+			<section class="section" id="toc">
 				<div class="columns">
 					<div class="column is-one-quarter">
 						<MiniMap />
@@ -76,18 +76,44 @@
 				</div>
 			</section>
 			<section class="section">
-				<div class="report-type-wrapper">
+				<h4 class="title is-4">Contents</h4>
+				<div class="content is-size-5">
+				<ul>
+					<li><a href="#temperature">Temperature</a> charts and tables with multiple models and scenarios, grouped decadally and into mid/late century</li>
+					<li><a href="#precipitation">Precipitation</a> charts and tables with multiple models and scenarios, grouped decadally and into mid/late century</li>
+					<li><a href="#permafrost">Permafrost</a> with specific visualizations depending on the presence or absence of permafrost</li>
+					<li>
+						<a href="#data-overview-download">Data overview &amp; download</a> with notes on interpreting these visualizations and a button to click to get a CSV of data
+					</li>
+				</ul>
+			</div>
+			</section>
+			<section class="section">
+				<div class="report-type-wrapper" id="temperature">
 					<TempReport :reportData="results"></TempReport>
 				</div>
-				<div class="report-type-wrapper">
+				<BackToTopButton />
+			</section>
+			<section class="section">
+				<div class="report-type-wrapper" id="precipitation">
 					<PrecipReport :reportData="results"></PrecipReport>
 				</div>
-				<div class="report-type-wrapper">
-					<PermafrostReport :altThawData="altThawData" :altFreezeData="altFreezeData" v-show="showPermafrost"></PermafrostReport>
+				<BackToTopButton />
+			</section>
+			<section class="section">
+				<div class="report-type-wrapper" id="permafrost">
+					<PermafrostReport
+						:altThawData="altThawData"
+						:altFreezeData="altFreezeData"
+						v-show="showPermafrost"
+					></PermafrostReport>
 					<p v-show="!showPermafrost" class="is-size-5">
 						Permafrost data are not available for this location.
 					</p>
 				</div>
+				<BackToTopButton />
+			</section>
+			<section class="section" id="data-overview-download">
 				<div class="content is-size-5">
 					<p>
 						Comparing projections with historical data in the first column
@@ -116,6 +142,7 @@
 						<DownloadCsvButton />
 					</p>
 				</div>
+				<BackToTopButton />
 			</section>
 			<hr />
 			<div class="back">
@@ -157,6 +184,7 @@ import PermafrostReport from '~/components/reports/permafrost/PermafrostReport'
 import MiniMap from '~/components/reports/MiniMap'
 import QualitativeText from '~/components/reports/QualitativeText'
 import DownloadCsvButton from '~/components/reports/DownloadCsvButton'
+import BackToTopButton from '~/components/reports/BackToTopButton'
 import { mapGetters } from 'vuex'
 import lodash from 'lodash'
 import deepdash from 'deepdash'
@@ -172,7 +200,9 @@ export default {
 		MiniMap,
 		QualitativeText,
 		DownloadCsvButton,
-	},	data() {
+		BackToTopButton,
+	},
+	data() {
 		return {
 			originalData: undefined, // for the raw stuff back from API
 			results: undefined, // may be metric or imperial
@@ -314,8 +344,12 @@ export default {
 			let scenarios = ['rcp45', 'rcp85']
 			let projectedYears = Object.keys(this.permafrostResults['gipl']).slice(1)
 
-			let historicalAlt = this.permafrostResults['gipl']['1995']['cruts31']['historical']['alt']
-			let historicalMagt = this.permafrostResults['gipl']['1995']['cruts31']['historical']['magt']
+			let historicalAlt = this.permafrostResults['gipl']['1995']['cruts31'][
+				'historical'
+			]['alt']
+			let historicalMagt = this.permafrostResults['gipl']['1995']['cruts31'][
+				'historical'
+			]['magt']
 
 			if (historicalMagt < freezing) {
 				thawData['1995'] = historicalAlt
@@ -323,26 +357,30 @@ export default {
 				thawData['1995'] = null
 			}
 
-			projectedYears.forEach(year => {
+			projectedYears.forEach((year) => {
 				thawData[year] = {}
-				models.forEach(model => {
-					thawData[year][model] ={}
+				models.forEach((model) => {
+					thawData[year][model] = {}
 				})
 			})
 
 			this.permafrostPresent = false
-			models.forEach(model => {
-				scenarios.forEach(scenario => {
+			models.forEach((model) => {
+				scenarios.forEach((scenario) => {
 					let previousMagt = historicalMagt
-					projectedYears.forEach(year => {
-						let scenarioAlt = this.permafrostResults['gipl'][year][model][scenario]['alt']
+					projectedYears.forEach((year) => {
+						let scenarioAlt = this.permafrostResults['gipl'][year][model][
+							scenario
+						]['alt']
 						if (previousMagt < freezing) {
 							thawData[year][model][scenario] = scenarioAlt
 							this.permafrostPresent = true
 						} else {
 							thawData[year][model][scenario] = null
 						}
-						previousMagt = this.permafrostResults['gipl'][year][model][scenario]['magt']
+						previousMagt = this.permafrostResults['gipl'][year][model][
+							scenario
+						]['magt']
 					})
 				})
 			})
@@ -357,8 +395,12 @@ export default {
 			let scenarios = ['rcp45', 'rcp85']
 			let projectedYears = Object.keys(this.permafrostResults['gipl']).slice(1)
 
-			let historicalAlt = this.permafrostResults['gipl']['1995']['cruts31']['historical']['alt']
-			let historicalMagt = this.permafrostResults['gipl']['1995']['cruts31']['historical']['magt']
+			let historicalAlt = this.permafrostResults['gipl']['1995']['cruts31'][
+				'historical'
+			]['alt']
+			let historicalMagt = this.permafrostResults['gipl']['1995']['cruts31'][
+				'historical'
+			]['magt']
 
 			if (historicalMagt > freezing) {
 				freezeData['1995'] = historicalAlt
@@ -366,19 +408,21 @@ export default {
 				freezeData['1995'] = null
 			}
 
-			projectedYears.forEach(year => {
+			projectedYears.forEach((year) => {
 				freezeData[year] = {}
-				models.forEach(model => {
-					freezeData[year][model] ={}
+				models.forEach((model) => {
+					freezeData[year][model] = {}
 				})
 			})
 
 			this.permafrostDisappears = false
-			models.forEach(model => {
-				scenarios.forEach(scenario => {
+			models.forEach((model) => {
+				scenarios.forEach((scenario) => {
 					let previousMagt = historicalMagt
-					projectedYears.forEach(year => {
-						let scenarioAlt = this.permafrostResults['gipl'][year][model][scenario]['alt']
+					projectedYears.forEach((year) => {
+						let scenarioAlt = this.permafrostResults['gipl'][year][model][
+							scenario
+						]['alt']
 						if (this.units == 'metric' && scenarioAlt <= 0.07) {
 							freezeData[year][model][scenario] = null
 						} else if (this.units == 'imperial' && scenarioAlt <= 2.8) {
@@ -389,7 +433,9 @@ export default {
 						} else {
 							freezeData[year][model][scenario] = null
 						}
-						previousMagt = this.permafrostResults['gipl'][year][model][scenario]['magt']
+						previousMagt = this.permafrostResults['gipl'][year][model][
+							scenario
+						]['magt']
 					})
 				})
 			})
@@ -400,19 +446,25 @@ export default {
 		convertReportData() {
 			Object.keys(this.results).forEach((decade) => {
 				if (decade === '1950_2009') {
-					this.results[decade] = this.convertTasPrHistorical(this.results[decade])
+					this.results[decade] = this.convertTasPrHistorical(
+						this.results[decade]
+					)
 				} else {
 					this.results[decade] = this.convertTasPrMeans(this.results[decade])
 				}
 			})
 			if (this.showPermafrost) {
-				Object.keys(this.permafrostResults['gipl']).forEach(year => {
-					this.permafrostResults['gipl'][year] = this.convertPermafrostMeans(this.permafrostResults['gipl'][year])
+				Object.keys(this.permafrostResults['gipl']).forEach((year) => {
+					this.permafrostResults['gipl'][year] = this.convertPermafrostMeans(
+						this.permafrostResults['gipl'][year]
+					)
 				})
 			}
 		},
 		checkPermafrost() {
-			let historicalAlt = this.permafrostResults['gipl']['1995']['cruts31']['historical']['alt']
+			let historicalAlt = this.permafrostResults['gipl']['1995']['cruts31'][
+				'historical'
+			]['alt']
 			this.showPermafrost = historicalAlt == null ? false : true
 			if (this.permafrostPresent || this.permafrostDisappears) {
 				this.showPermafrost = true

--- a/components/reports/BackToTopButton.vue
+++ b/components/reports/BackToTopButton.vue
@@ -1,0 +1,11 @@
+<template>
+	<p>
+		<a href="#toc">Back to top</a>
+	</p>
+</template>
+
+<script>
+export default {
+	name: 'BackToTopButton',
+}
+</script>

--- a/components/reports/DownloadCsvButton.vue
+++ b/components/reports/DownloadCsvButton.vue
@@ -1,5 +1,5 @@
 <template>
-	<a :href="downloadTarget" class="button">Download data as CSV</a>
+	<a :href="downloadTarget" class="button is-link">Download data as CSV</a>
 </template>
 <style lang="scss" scoped></style>
 <script>

--- a/components/reports/permafrost/PermafrostReport.vue
+++ b/components/reports/permafrost/PermafrostReport.vue
@@ -1,12 +1,6 @@
 <template>
 	<div>
-		<h4 class="subtitle is-4">
-			Permafrost
-			<span class="units">
-				<span v-if="units == 'imperial'">(inches)</span>
-				<span v-if="units == 'metric'">(meters)</span>
-			</span>
-		</h4>
+		<h4 class="title is-3">Permafrost</h4>
 		<div class="content is-size-5">
 			<span v-show="permafrostPresent && permafrostDisappears">
 				Projected permafrost active layer thickness and ground freeze depth
@@ -52,7 +46,7 @@ export default {
 			units: 'units',
 			permafrostPresent: 'permafrostPresent',
 			permafrostDisappears: 'permafrostDisappears',
-		})
+		}),
 	},
 }
 </script>

--- a/components/reports/precipitation/PrecipReport.vue
+++ b/components/reports/precipitation/PrecipReport.vue
@@ -1,12 +1,6 @@
 <template>
 	<div>
-		<h4 class="subtitle is-4">
-			Precipitation
-			<span class="units">
-				<span v-if="units == 'imperial'">(inches)</span>
-				<span v-if="units == 'metric'">(mm)</span>
-			</span>
-		</h4>
+		<h4 class="title is-3">Precipitation</h4>
 		<div class="content is-size-5">
 			Projections for each decade through the end of the century are shown for
 			average (mean) precipitation, compared with a historical range. Results
@@ -22,10 +16,18 @@
 		</div>
 		<div class="chart-wrapper">
 			<b-field label="Season">
-				<b-radio v-model="precip_season" name="precip_season" native-value="DJF">Winter</b-radio>
-				<b-radio v-model="precip_season" name="precip_season" native-value="MAM">Spring</b-radio>
-				<b-radio v-model="precip_season" name="precip_season" native-value="JJA">Summer</b-radio>
-				<b-radio v-model="precip_season" name="precip_season" native-value="SON">Fall</b-radio>
+				<b-radio v-model="precip_season" name="precip_season" native-value="DJF"
+					>Winter</b-radio
+				>
+				<b-radio v-model="precip_season" name="precip_season" native-value="MAM"
+					>Spring</b-radio
+				>
+				<b-radio v-model="precip_season" name="precip_season" native-value="JJA"
+					>Summer</b-radio
+				>
+				<b-radio v-model="precip_season" name="precip_season" native-value="SON"
+					>Fall</b-radio
+				>
 			</b-field>
 			<ReportPrecipChart :reportData="reportData" :season="precip_season" />
 		</div>
@@ -46,13 +48,13 @@ export default {
 	components: { ReportPrecipChart, ReportPrecipTable },
 	data() {
 		return {
-			precip_season: 'DJF'
+			precip_season: 'DJF',
 		}
 	},
 	computed: {
 		...mapGetters({
 			units: 'units',
-		})
-	}
+		}),
+	},
 }
 </script>

--- a/components/reports/temperature/TempReport.vue
+++ b/components/reports/temperature/TempReport.vue
@@ -1,12 +1,6 @@
 <template>
 	<div class="report--temperature">
-		<h4 class="subtitle is-4">
-			Temperature
-			<span class="units">
-				<span v-if="units == 'imperial'">(&deg;F)</span>
-				<span v-if="units == 'metric'">(&deg;C)</span>
-			</span>
-		</h4>
+		<h4 class="title is-3">Temperature</h4>
 		<div class="content is-size-5">
 			<p>
 				Projections for each decade through the end of the century are shown for
@@ -14,9 +8,9 @@
 				are averaged by season (three month averages) for two specific climate
 				models (MRI-CGCM3 and NCAR-CCSM4) as well as a 5-model average. Three
 				different greenhouse gas scenarios or Representative Concentration
-				Pathways (RCPs) are shown for each model. RCP4.5 is an optimistic future,
-				and RCP8.5 is more pessimistic but also more likely. RCP6.0 is an
-				emissions scenario between RCP4.5 and RCP8.5.
+				Pathways (RCPs) are shown for each model. RCP4.5 is an optimistic
+				future, and RCP8.5 is more pessimistic but also more likely. RCP6.0 is
+				an emissions scenario between RCP4.5 and RCP8.5.
 				<nuxt-link :to="{ name: 'about' }"
 					>Read more about models and RCPs.</nuxt-link
 				>
@@ -24,10 +18,18 @@
 		</div>
 		<div class="chart-wrapper">
 			<b-field label="Season">
-				<b-radio v-model="temp_season" name="temp_season" native-value="DJF">Winter</b-radio>
-				<b-radio v-model="temp_season" name="temp_season" native-value="MAM">Spring</b-radio>
-				<b-radio v-model="temp_season" name="temp_season" native-value="JJA">Summer</b-radio>
-				<b-radio v-model="temp_season" name="temp_season" native-value="SON">Fall</b-radio>
+				<b-radio v-model="temp_season" name="temp_season" native-value="DJF"
+					>Winter</b-radio
+				>
+				<b-radio v-model="temp_season" name="temp_season" native-value="MAM"
+					>Spring</b-radio
+				>
+				<b-radio v-model="temp_season" name="temp_season" native-value="JJA"
+					>Summer</b-radio
+				>
+				<b-radio v-model="temp_season" name="temp_season" native-value="SON"
+					>Fall</b-radio
+				>
 			</b-field>
 			<ReportTempChart :reportData="reportData" :season="temp_season" />
 		</div>
@@ -54,13 +56,13 @@ export default {
 	components: { ReportTempChart, ReportTempTable },
 	data() {
 		return {
-			temp_season: 'DJF'
+			temp_season: 'DJF',
 		}
 	},
 	computed: {
 		...mapGetters({
 			units: 'units',
-		})
-	}
+		}),
+	},
 }
 </script>


### PR DESCRIPTION
Closes #122 

There's too many whitespace changes in here, sorry about that, we need to sync our formatters.

Testing:

 * Load a report.
 * Scroll below the minimal and see the "Contents" section.  Click to bounce down to the Precipitation section.  Scroll down and see a "Back To Top" link.  Click it.  You should go to the top of the MiniMap (that's intentional).
 * This PR also cranks the size of the headers for each section (Temperature, etc) and removes the units from those headers (it did not seem meaningful to have it there since it's everywhere).

Experimentally, I made the "table of contents" more than just the title of the sections, which is why there's goofy language with them.  I think having Carolyn/Mike review that would be swell.  I didn't really do any formatting here either.
