### PR TITLE
updates browserlist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4853,9 +4853,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001198",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001198.tgz",
-      "integrity": "sha512-r5GGgESqOPZzwvdLVER374FpQu2WluCF1Z2DSiFJ89KSmGjT0LVKjgv4NcAqHmGWF9ihNpqRI9KXO9Ex4sKsgA=="
+      "version": "1.0.30001305",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001305.tgz",
+      "integrity": "sha512-p7d9YQMji8haf0f+5rbcv9WlQ+N5jMPfRAnUmZRlNxsNeBO3Yr7RYG6M2uTY1h9tCVdlkJg6YNNc4kiAiBLdWA=="
     },
     "capital-case": {
       "version": "1.0.4",


### PR DESCRIPTION
Refs #162 

I'm not really sure how to test or examine this.  When I ran the `npx` command to update the `caniuse-lite` registry, it did emit a significantly updated list of browsers but I don't quite know where/how those fit. 