### PR TITLE
Refactors "what kind of place?" into one place

### DIFF
--- a/components/Report.vue
+++ b/components/Report.vue
@@ -177,7 +177,7 @@ export default {
 	},
 	computed: {
 		...mapGetters({
-			place: 'placeName',
+			place: 'place/name',
 		}),
 	},
 	// This component initiates the data fetching so that

--- a/components/reports/DownloadCsvButton.vue
+++ b/components/reports/DownloadCsvButton.vue
@@ -3,30 +3,17 @@
 </template>
 <style lang="scss" scoped></style>
 <script>
-import { mapGetters } from 'vuex'
 export default {
 	name: 'DownloadCsvButton',
 	computed: {
 		downloadTarget() {
-			let urlFragment
-			let latLng = this.$store.getters.getLatLng
-
-			if (this.latLng) {
-				// Community or direct lat/lng
-				urlFragment = 'point/' + this.latLng[0] + '/' + this.latLng[1]
-			} else if (this.hucId) {
-				// HUC.
-				urlFragment = 'huc/' + this.hucId
-			} else if (this.protectedAreaId) {
-				urlFragment = 'protectedarea/' + this.protectedAreaId
-			}
-			return process.env.apiUrl + '/taspr/' + urlFragment + "?format=csv"
+			return (
+				process.env.apiUrl +
+				'/taspr/' +
+				this.$store.getters['place/urlFragment'] +
+				'?format=csv'
+			)
 		},
-		...mapGetters({
-			latLng: 'latLng',
-			hucId: 'hucId',
-			protectedAreaId: 'protectedAreaId',
-		}),
 	},
 }
 </script>

--- a/components/reports/MiniMap.vue
+++ b/components/reports/MiniMap.vue
@@ -22,7 +22,7 @@ export default {
 	name: 'MiniMap',
 	computed: {
 		...mapGetters({
-			latLng: 'latLng',
+			latLng: 'place/latLng',
 			geoJSON: 'place/geoJSON',
 		}),
 	},
@@ -35,6 +35,7 @@ export default {
 	mounted() {
 		this.map = L.map('report--minimmap--map', this.getBaseMapAndLayers())
 
+		// It's a lat/Lng location (community or point)
 		if (this.latLng) {
 			this.marker = L.marker(this.latLng).addTo(this.map)
 			this.map.panTo(this.latLng)

--- a/components/reports/QualitativeText.vue
+++ b/components/reports/QualitativeText.vue
@@ -54,14 +54,15 @@ export default {
   },
   computed: {
     ...mapGetters({
-      hucName: 'rawHucName',
-      place: 'placeName',
+      placeType: 'place/type',
+      hucName: 'place/rawHucName',
+      place: 'place/name',
       units: 'units',
       reportData: 'climate/climateData',
       altThawData: 'permafrost/altThaw',
       showPermafrost: 'permafrost/valid',
       permafrostPresent: 'permafrost/present',
-      permafrostDisappears: 'permafrost/disappears'
+      permafrostDisappears: 'permafrost/disappears',
     }),
     unitsText() {
       if (this.units) {
@@ -214,18 +215,17 @@ export default {
       // Average value against the 4 seasons included.
       annualTemperatureAverage = Math.round(annualTemperatureAverage / 4)
 
-      var returnedString = ''
-
-      // TODO.  If we do these kinds of comparisons a lot, we probably want
-      // to move this logic to the store or another component in some way.
-      // This code does need some special grammar, though, which wouldn't
-      // generalize!
-      if (this.$route.path.includes('community')) {
-        returnedString += '<p>In <strong>' + this.place + '</strong>'
-      } else if (this.$route.path.includes('huc')) {
-        returnedString += '<p>In the <strong>' + this.hucName + '</strong>'
-      } else {
-        returnedString += '<p>At <strong>' + this.place + '</strong>'
+      let returnedString = ''
+      switch (this.placeType) {
+        case 'community':
+          returnedString += '<p>In <strong>' + this.place + '</strong>'
+          break
+        case 'huc':
+          returnedString += '<p>In the <strong>' + this.hucName + '</strong>'
+          break
+        default:
+          returnedString += '<p>At <strong>' + this.place + '</strong>'
+          break
       }
 
       // Create the returned string using the values from the loop above.

--- a/store/climate.js
+++ b/store/climate.js
@@ -76,26 +76,8 @@ export const mutations = {
 export const actions = {
   async fetch(context) {
     // TODO: add error handling here for 404 (no data) etc.
-    let queryUrl = process.env.apiUrl + '/taspr'
-
-    // Determine the query type to perform.
-    if (context.rootGetters.hucId) {
-      // Fetch areal data by HUC.
-      queryUrl += '/huc/' + context.rootGetters.hucId
-    } else if (context.rootGetters.protectedAreaId) {
-      queryUrl += '/protectedarea/' + context.rootGetters.protectedAreaId
-    } else if (context.rootGetters.latLng) {
-      queryUrl +=
-        '/point/' +
-        context.rootGetters.latLng[0] +
-        '/' +
-        context.rootGetters.latLng[1]
-    } else {
-      // Don't know what to query, this is an error situation.
-      console.error("Unknown place type, can't fetch data")
-      return
-    }
-
+    let queryUrl =
+      process.env.apiUrl + '/taspr/' + context.rootGetters['place/urlFragment']
     let climateData = await this.$http.$get(queryUrl)
     context.commit('setClimateData', climateData)
   },

--- a/store/index.js
+++ b/store/index.js
@@ -1,7 +1,4 @@
 import _ from 'lodash'
-import communities from '~/assets/communities'
-import hucs from '~/assets/hucs'
-import protectedAreas from '~/assets/protected_areas'
 
 export const state = () => ({
   units: 'imperial',
@@ -26,114 +23,7 @@ export const getters = {
   // Boolean if any combo of place identifiers are active,
   // so the report section can be shown when a place has
   // been selected.
-  reportIsVisible: (state) => {
-    return (
-      (state.route.params.lat && state.route.params.lng) ||
-      state.route.params.communityId ||
-      state.route.params.protectedAreaId ||
-      state.route.params.hucId
-    )
-  },
-
-  // Gets the currently-selected lat/lon [directly or by placeID]
-  latLng: (state) => {
-    if (state.route.params.lat && state.route.params.lng) {
-      return [state.route.params.lat, state.route.params.lng]
-    }
-
-    if (state.route.params.communityId) {
-      let place = _.find(communities, {
-        id: Number(state.route.params.communityId),
-      })
-      if (place) {
-        return [place.latitude, place.longitude]
-      }
-      throw 'Could not find the community by ID.'
-    }
-
-    // It's not a point-based location with a defined lat/lon.
-    return false
-  },
-
-  // If present, returns the HucID in the URL.
-  hucId: (state) => {
-    if (state.route.params.hucId) {
-      return state.route.params.hucId
-    }
-    return false
-  },
-
-  // Fetch the protected area ID
-  protectedAreaId: (state) => {
-    if (state.route.params.protectedAreaId) {
-      return state.route.params.protectedAreaId
-    }
-    return false
-  },
-
-  // Returns a string for the correct current selected place,
-  // whether lat/lon, community name, or other regional name.
-  placeName: (state) => {
-    // Lat/lon!
-    if (state.route.params.lat && state.route.params.lng) {
-      return (
-        state.route.params.lat +
-        '&deg;N, ' +
-        Math.abs(state.route.params.lng) +
-        '&deg;W'
-      )
-    }
-
-    // Community name!
-    if (state.route.params.communityId) {
-      let place = _.find(communities, {
-        id: Number(state.route.params.communityId),
-      })
-      if (place) {
-        let name = place.name
-        if (place.alt_name) {
-          name += ' <span class="alt_name">(' + place.alt_name + ')</span>'
-        }
-        return name
-      }
-      throw 'Could not find the community by ID.'
-    }
-
-    // HUC!
-    if (state.route.params.hucId) {
-      let huc = _.find(hucs, {
-        id: Number(state.route.params.hucId),
-      })
-      // It's a little meh for the HTML to be here...
-      if (huc) {
-        return (
-          huc.name +
-          ' Watershed <span class="watershed">HUC ' +
-          huc.id +
-          '</span>'
-        )
-      }
-    }
-
-    // Protected area!
-    if (state.route.params.protectedAreaId) {
-      let pa = _.find(protectedAreas, {
-        id: state.route.params.protectedAreaId,
-      })
-      if (pa) {
-        return pa.name
-      }
-    }
-  },
-
-  rawHucName(state) {
-    if (state.route.params.hucId) {
-      let huc = _.find(hucs, {
-        id: Number(state.route.params.hucId),
-      })
-      if (huc) {
-        return huc.name
-      }
-    }
-  },
+  reportIsVisible: (state, getters) => {
+    return getters['place/type']
+  }
 }

--- a/store/permafrost.js
+++ b/store/permafrost.js
@@ -223,10 +223,8 @@ export const actions = {
     if (context.rootGetters.latLng) {
       let permafrostQueryUrl =
         process.env.apiUrl +
-        '/permafrost/point/' +
-        context.rootGetters.latLng[0] +
-        '/' +
-        context.rootGetters.latLng[1]
+        '/permafrost' +
+        context.rootGetters['place/urlFragment']
 
       try {
         let permafrostData = await this.$http.$get(permafrostQueryUrl)

--- a/store/permafrost.js
+++ b/store/permafrost.js
@@ -219,11 +219,10 @@ export const mutations = {
 export const actions = {
   async fetch(context) {
     // TODO: add error handling here for 404 (no data) etc.
-
-    if (context.rootGetters.latLng) {
+    if (context.rootGetters['place/latLng']) {
       let permafrostQueryUrl =
         process.env.apiUrl +
-        '/permafrost' +
+        '/permafrost/' +
         context.rootGetters['place/urlFragment']
 
       try {

--- a/store/place.js
+++ b/store/place.js
@@ -1,4 +1,7 @@
 // This store manages place-based information.
+import communities from '~/assets/communities'
+import hucs from '~/assets/hucs'
+import protectedAreas from '~/assets/protected_areas'
 
 // Store, namespaced as `place/`
 export const state = () => ({
@@ -6,8 +9,146 @@ export const state = () => ({
 })
 
 export const getters = {
+  // Returns GeoJSON boundary poly.
   geoJSON(state) {
     return state.geoJSON
+  },
+
+  // Gets the currently-selected lat/lon [directly or by placeID]
+  latLng: (state, getters, rootState) => {
+    if (rootState.route.params.lat && rootState.route.params.lng) {
+      return [rootState.route.params.lat, rootState.route.params.lng]
+    }
+
+    if (rootState.route.params.communityId) {
+      let place = _.find(communities, {
+        id: Number(rootState.route.params.communityId),
+      })
+      if (place) {
+        return [place.latitude, place.longitude]
+      }
+      throw 'Could not find the community by ID.'
+    }
+
+    // It's not a point-based location with a defined lat/lon.
+    return false
+  },
+
+  // If present, returns the HucID in the URL.
+  hucId: (state, getters, rootState) => {
+    if (rootState.route && rootState.route.params.hucId) {
+      return rootState.route.params.hucId
+    }
+    return false
+  },
+
+  // Fetch the protected area ID
+  protectedAreaId: (state, getters, rootState) => {
+    if (rootState.route.params.protectedAreaId) {
+      return rootState.route.params.protectedAreaId
+    }
+    return false
+  },
+
+  // What kind of place is this?
+  type: (state, getters, rootState) => {
+    if (rootState.route.params.lat && rootState.route.params.lng) {
+      return 'latLng'
+    } else if (rootState.route.params.communityId) {
+      return 'community'
+    } else if (rootState.route.params.hucId) {
+      return 'huc'
+    } else if (rootState.route.params.protectedAreaId) {
+      return 'protected_area'
+    }
+  },
+
+  // Returns a string for the correct current selected place,
+  // whether lat/lon, community name, or other regional name.
+  name: (state, getters, rootState) => {
+    // Lat/lon!
+    if (getters.type == 'latLng') {
+      return (
+        rootState.route.params.lat +
+        '&deg;N, ' +
+        Math.abs(rootState.route.params.lng) +
+        '&deg;W'
+      )
+    }
+
+    // Community name!
+    if (getters.type == 'community') {
+      let place = _.find(communities, {
+        id: Number(rootState.route.params.communityId),
+      })
+      if (place) {
+        let name = place.name
+        if (place.alt_name) {
+          name += ' <span class="alt_name">(' + place.alt_name + ')</span>'
+        }
+        return name
+      }
+      throw 'Could not find the community by ID.'
+    }
+
+    // HUC!
+    if (getters.type == 'huc') {
+      let huc = _.find(hucs, {
+        id: Number(rootState.route.params.hucId),
+      })
+      // It's a little meh for the HTML to be here...
+      if (huc) {
+        return (
+          huc.name +
+          ' Watershed <span class="watershed">HUC ' +
+          huc.id +
+          '</span>'
+        )
+      }
+    }
+
+    // Protected area!
+    if (getters.type == 'protected_area') {
+      let pa = _.find(protectedAreas, {
+        id: rootState.route.params.protectedAreaId,
+      })
+      if (pa) {
+        return pa.name
+      }
+    }
+
+    // Unknown or unset or invalid.
+    return false
+  },
+
+  rawHucName(state, getters, rootState) {
+    if (rootState.route.params.hucId) {
+      let huc = _.find(hucs, {
+        id: Number(rootState.route.params.hucId),
+      })
+      if (huc) {
+        return huc.name
+      }
+    }
+  },
+
+  urlFragment(state, getters) {
+    switch (getters.type) {
+      // These are the same.
+      case 'community':
+      case 'latLng':
+        return 'point/' + getters.latLng[0] + '/' + getters.latLng[1]
+        break
+      case 'huc':
+        return 'huc/huc8/' + getters.hucId
+        break
+      case 'protected_area':
+        return 'protectedarea/' + getters.protectedAreaId
+        break
+      default:
+        // Unknown.
+        return undefined
+    }
   },
 }
 
@@ -20,19 +161,7 @@ export const mutations = {
 export const actions = {
   async fetch(context) {
     // TODO: add error handling here for 404 (no data) etc.
-    let queryUrl = process.env.apiUrl
-    if (context.rootGetters.hucId) {
-      // Fetch areal data by HUC.
-      queryUrl += '/boundary/huc/huc8/' + context.rootGetters.hucId
-    } else if (context.rootGetters.protectedAreaId) {
-      queryUrl +=
-        '/boundary/protectedarea/' + context.rootGetters.protectedAreaId
-    } else {
-      // Unclear what do do here, bail.
-      return
-    }
-
-    // TODO, add error handling here.
+    let queryUrl = process.env.apiUrl + '/boundary/' + context.getters.urlFragment
     let geoJSON = await this.$http.$get(queryUrl)
     context.commit('setGeoJSON', geoJSON)
   },


### PR DESCRIPTION
Closes #160 

In the app previously, there were a bunch of places that were basically doing, "What kind of place is this?"  This PR consolidates that code into the `place` store by adding a `type` getter what does the logical comparison against the state of the app.  Client code now can `switch(type)` if needed.  I also added a `urlFragment` getter, which reduces the  number of places where client code needs to do conditional logic around building URLs.

Testing this:
 * Pull one of each type of place (community, latLng, HUC and Protected Area).  Everything should load and display properly.