### PR TITLE
Prevent API queries before location is chosen and fix permafrost API queries

### DIFF
--- a/components/App.vue
+++ b/components/App.vue
@@ -18,7 +18,7 @@
         <!-- Map can't be wrapped in container/section, if we want it full-screen. -->
         <Map></Map>
       </div>
-      <div v-show="this.reportIsVisible" class="report-wrapper">
+      <div v-if="this.reportIsVisible" class="report-wrapper">
         <Report></Report>
       </div>
     </client-only>

--- a/components/App.vue
+++ b/components/App.vue
@@ -44,5 +44,13 @@ export default {
   computed: {
     ...mapGetters(['reportIsVisible']),
   },
+  created() {
+    // Switch back to clean URL after S3 redirect. Adapted from here:
+    // https://via.studio/journal/hosting-a-reactjs-app-with-routing-on-aws-s3
+    const path = (/#!(\/.*)$/.exec(this.$route.fullPath) || [])[1]
+    if (path) {
+      this.$router.push({ path: path })
+    }
+  },
 }
 </script>

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -229,15 +229,6 @@ export default {
       console.error(e)
     })
   },
-  created() {
-    // Switch back to clean URL after S3 redirect. Adapted from here:
-    // https://via.studio/journal/hosting-a-reactjs-app-with-routing-on-aws-s3
-    const path = (/#!(\/.*)$/.exec(this.$route.fullPath) || [])[1]
-    if (path) {
-      this.$router.push({ path: path })
-    }
-    this.$fetch()
-  },
   watch: {
     units: function () {
       if (this.units == 'metric') {

--- a/store/permafrost.js
+++ b/store/permafrost.js
@@ -14,7 +14,7 @@ var getProcessedData = function (permafrostData) {
 
   let models = ['gfdlcm3', 'gisse2r', 'ipslcm5alr', 'mricgcm3', 'ncarccsm4']
   let scenarios = ['rcp45', 'rcp85']
-  let projectedYears = Object.keys(permafrostData['gipl']).slice(1)
+  let projectedYears = ['2025', '2050', '2075', '2095']
 
   let historicalAlt =
     permafrostData['gipl']['1995']['cruts31']['historical']['alt']


### PR DESCRIPTION
This PR fixes two issues related to API queries:

1. The app attempts to query the API when the front page loads, before a location is chosen. This is because we are using `v-show` to control if the Report component is shown when we should be using `v-if`. Using `v-show` simply hides the Report component but still calls its `fetch()` method regardless, whereas `v-if` does not call the Report component's `fetch()` method until the Report component is visible. [More info here.](https://vueschool.io/articles/vuejs-tutorials/lazy-loading-individual-vue-components-and-prefetching/)
2. On the API side, we moved the "title" field of the permafrost's GIPL output higher up the JSON hierarchy. This made the field a sibling of the year keys, and the "title" key is being included in the list of projected years. I've fixed this by hard-coding the projected years. This seems appropriate since we are already hard-coding the model and scenario arrays.

Testing:
- Load the front page of the web app with your browser's console open. Without this PR, you will see some HTTP 404 errors when the app attempts to load data from, for example, https://earthmaps.io/taspr/undefined These errors should go away with this PR.
- Load the report for any location and verify that permafrost charts show up.