### PR TITLE
Add deltas to hover text on permafrost charts

### DIFF
--- a/components/reports/permafrost/ReportAltFreezeChart.vue
+++ b/components/reports/permafrost/ReportAltFreezeChart.vue
@@ -104,6 +104,7 @@ export default {
         },
       }
 
+      let precision = this.units == 'metric' ? 2 : 1
       let allYears = Object.keys(altFreezeData)
       let historicalYear = allYears.slice(0, 1)
       let projectedYears = allYears.slice(1)
@@ -117,7 +118,7 @@ export default {
           mode: 'markers',
           name: 'Historical',
           hoverinfo: 'x+y+z+text',
-          hovertemplate: '%{y}' + units,
+          hovertemplate: '%{y:.' + precision + 'f}' + units,
           marker: {
             symbol: 'diamond',
             size: 8,
@@ -137,7 +138,7 @@ export default {
             mode: 'markers',
             name: traceLabels_lu[model][scenario],
             hoverinfo: 'x+y+z+text',
-            hovertemplate: '%{y}' + units,
+            hovertemplate: '%{y:.' + precision + 'f}' + units,
             marker: {
               symbol: Array(eras.length).fill(symbols[model]),
               size: 8,
@@ -145,16 +146,30 @@ export default {
             },
             x: eras,
             y: [null],
+            customdata: [null],
           }
 
           let dataFound = false
           projectedYears.forEach(year => {
             let value = altFreezeData[year][model][scenario]
-            if (value != null) dataFound = true
-            scatterTraces[model][scenario]['y'].push(
-              altFreezeData[year][model][scenario]
-            )
+            if (value != null) {
+              dataFound = true
+            }
+            scatterTraces[model][scenario]['y'].push(value)
+            if (historicValue != null) {
+              let diff = value - historicValue
+              if (diff > 0) {
+                diff = '+' + diff.toFixed(precision)
+              } else {
+                diff = diff.toFixed(precision)
+              }
+              scatterTraces[model][scenario]['customdata'].push(diff)
+            }
           })
+          if (historicValue != null) {
+            scatterTraces[model][scenario]['hovertemplate'] +=
+              ' <b>(%{customdata}' + units + ')</b>'
+          }
           if (dataFound) {
             data_traces.push(scatterTraces[model][scenario])
           }

--- a/components/reports/permafrost/ReportAltThawChart.vue
+++ b/components/reports/permafrost/ReportAltThawChart.vue
@@ -104,6 +104,7 @@ export default {
         },
       }
 
+      let precision = this.units == 'metric' ? 2 : 1
       let allYears = Object.keys(altThawData)
       let historicalYear = allYears.slice(0, 1)
       let projectedYears = allYears.slice(1)
@@ -117,7 +118,7 @@ export default {
           mode: 'markers',
           name: 'Historical',
           hoverinfo: 'x+y+z+text',
-          hovertemplate: '%{y}' + units,
+          hovertemplate: '%{y:.' + precision + 'f}' + units,
           marker: {
             symbol: 'diamond',
             size: 8,
@@ -137,7 +138,7 @@ export default {
             mode: 'markers',
             name: traceLabels_lu[model][scenario],
             hoverinfo: 'x+y+z+text',
-            hovertemplate: '%{y}' + units,
+            hovertemplate: '%{y:.' + precision + 'f}' + units,
             marker: {
               symbol: Array(eras.length).fill(symbols[model]),
               size: 8,
@@ -145,6 +146,7 @@ export default {
             },
             x: eras,
             y: [null],
+            customdata: [null],
           }
 
           let dataFound = false
@@ -153,10 +155,21 @@ export default {
             if (value != null) {
               dataFound = true
             }
-            scatterTraces[model][scenario]['y'].push(
-              altThawData[year][model][scenario]
-            )
+            scatterTraces[model][scenario]['y'].push(value)
+            if (historicValue != null) {
+              let diff = value - historicValue
+              if (diff > 0) {
+                diff = '+' + diff.toFixed(precision)
+              } else {
+                diff = diff.toFixed(precision)
+              }
+              scatterTraces[model][scenario]['customdata'].push(diff)
+            }
           })
+          if (historicValue != null) {
+            scatterTraces[model][scenario]['hovertemplate'] +=
+              ' <b>(%{customdata}' + units + ')</b>'
+          }
           if (dataFound) {
             data_traces.push(scatterTraces[model][scenario])
           }

--- a/components/reports/permafrost/ReportMagtChart.vue
+++ b/components/reports/permafrost/ReportMagtChart.vue
@@ -111,7 +111,8 @@ export default {
       let projectedYears = allYears.slice(1)
 
       let historicY = Array(years.length).fill(null)
-      historicY[0] = magtData[historicalYear]
+      let historicValue = magtData[historicalYear]
+      historicY[0] = historicValue
       let historicalTrace = {
         type: 'scatter',
         mode: 'markers',
@@ -137,7 +138,8 @@ export default {
             mode: 'markers',
             name: traceLabels_lu[model][scenario],
             hoverinfo: 'x+y+z+text',
-            hovertemplate: '%{y}' + units,
+            hovertemplate:
+              '%{y}' + units + ' <b>(%{customdata}' + units + ')</b>',
             marker: {
               symbol: Array(eras.length).fill(symbols[model]),
               size: 8,
@@ -145,6 +147,7 @@ export default {
             },
             x: eras,
             y: [null],
+            customdata: [null],
           }
         })
       })
@@ -152,9 +155,15 @@ export default {
       models.forEach(model => {
         scenarios.forEach(scenario => {
           projectedYears.forEach(year => {
-            scatterTraces[model][scenario]['y'].push(
-              magtData[year][model][scenario]
-            )
+            let value = magtData[year][model][scenario]
+            scatterTraces[model][scenario]['y'].push(value)
+            let diff = value - historicValue
+            if (diff > 0) {
+              diff = '+' + diff.toFixed(1)
+            } else {
+              diff = diff.toFixed(1)
+            }
+            scatterTraces[model][scenario]['customdata'].push(diff)
           })
         })
       })

--- a/store/permafrost.js
+++ b/store/permafrost.js
@@ -14,7 +14,7 @@ var getProcessedData = function (permafrostData) {
 
   let models = ['gfdlcm3', 'gisse2r', 'ipslcm5alr', 'mricgcm3', 'ncarccsm4']
   let scenarios = ['rcp45', 'rcp85']
-  let projectedYears = Object.keys(permafrostData['gipl']).slice(1)
+  let projectedYears = ['2025', '2050', '2075', '2095']
 
   let historicalAlt =
     permafrostData['gipl']['1995']['cruts31']['historical']['alt']


### PR DESCRIPTION
Closes #168.

This adds deltas to the hover text of each of these permafrost charts:

- Active layer thickness
- Ground freeze depth
- Mean annual ground temperature

For locations like Fairbanks that have both the Active Layer Thickness and Ground Freeze Depth charts, the deltas are only shown on the Active Layer Thickness chart since only that chart has a historical baseline from which to compute a delta.

Since the metric versions of the Active Layer Thickness and Ground Freeze Depth charts are shown in meters, I'm showing two decimal places of precision. The delta values were rounding inconsistently otherwise, sometimes showing different delta values for the same subtraction because two decimal places were being used for calculations behind the scenes.

To test, make sure the hover text makes sense for both the imperial & metric versions of these report pages:

http://localhost:3000/report/69.58/-146.45
http://localhost:3000/report/community/124
http://localhost:3000/report/community/15
http://localhost:3000/report/61.95/-148.28