### PR TITLE
Restores `await` keyword to get the desired Loading... indicator working

### DIFF
--- a/components/Report.vue
+++ b/components/Report.vue
@@ -222,10 +222,10 @@ export default {
   // error handling, etc, can all be done in one spot.
   async fetch() {
     // TODO: Error handling.
-    this.$store.dispatch('climate/fetch').catch(e => {
+    await this.$store.dispatch('climate/fetch').catch(e => {
       console.error(e)
     })
-    this.$store.dispatch('permafrost/fetch').catch(e => {
+    await this.$store.dispatch('permafrost/fetch').catch(e => {
       console.error(e)
     })
   },

--- a/components/reports/MiniMap.vue
+++ b/components/reports/MiniMap.vue
@@ -35,13 +35,16 @@ export default {
   mounted() {
     this.map = L.map('report--minimmap--map', this.getBaseMapAndLayers())
 
-    // It's a lat/Lng location (community or point)
+    // It's a lat/Lng location (community or point) add the point to the map.
     if (this.latLng) {
       this.marker = L.marker(this.latLng).addTo(this.map)
       this.map.panTo(this.latLng)
-    } else {
-      // Fetch the GeoJSON outline
-      this.$store.dispatch('place/fetch')
+    }
+  },
+  async fetch() {
+    // Only fetch the GeoJSON if this is not a point location.
+    if (!this.latLng) {
+      await this.$store.dispatch('place/fetch')
     }
   },
   watch: {


### PR DESCRIPTION
Closes #166 

To test: first, from the `main` branch, observe that when you pick a location (say, Denali National Park) the app immediately shows the Report block even before data are loaded.  Switch to this branch and observe that the Loading... block is shown instead of the report, until the data are loaded.