### PR TITLE
Add permafrost MAGT mini-maps for two scenarios and all eras

### DIFF
--- a/components/reports/permafrost/PermafrostReport.vue
+++ b/components/reports/permafrost/PermafrostReport.vue
@@ -2,17 +2,68 @@
   <div>
     <h4 class="title is-3">Permafrost</h4>
     <div class="content is-size-5">
+      <p>
+        <span
+          v-show="
+            permafrostPresent && permafrostDisappears && !permafrostUncertain
+          "
+        >
+          Historical data and model projections indicate that
+          <strong
+            >this place has permafrost which disappears within
+            <span v-html="depthFragment"></span> of the ground surface over
+            time.</strong
+          >
+        </span>
+        <span
+          v-show="
+            permafrostPresent && !permafrostDisappears && !permafrostUncertain
+          "
+          >Historical data and model projections indicate that
+          <strong>this place has permafrost.</strong>
+        </span>
+        <span
+          v-show="
+            !permafrostPresent && permafrostDisappears && !permafrostUncertain
+          "
+        >
+          <strong>
+            There is no permafrost within
+            <span v-html="depthFragment"></span> of the ground surface at this
+            location</strong
+          >.</span
+        >
+        <span v-show="permafrostUncertain">
+          <strong
+            >The presence or absence of permafrost could not be determined for
+            this location</strong
+          ></span
+        >
+        Results were produced by the GIPL 2.0 permafrost model using five
+        separate climate models and two different greenhouse gas scenarios or
+        Representative Concentration Pathways (RCPs). RCP4.5 is an optimistic
+        future, and RCP8.5 is more pessimistic but also more likely.
+        <nuxt-link :to="{ name: 'about' }"
+          >Read more about models and RCPs.</nuxt-link
+        >
+      </p>
+      <p>
+        The following maps show the historical and projected mean annual ground
+        temperature over time. This is the temperature of the soil directly
+        above the permafrost layer. Red represents temperatures above freezing,
+        blue represents temperatures below freezing, and white represents
+        temperatures near the freezing point. Darker reds represent warmer
+        temperatures. Darker blues represent colder temperatures.
+      </p>
+    </div>
+    <ReportMagtMaps />
+
+    <div class="content is-size-5">
       <span
         v-show="
           permafrostPresent && permafrostDisappears && !permafrostUncertain
         "
       >
-        Historical data and model projections indicate that
-        <strong
-          >this place has permafrost which disappears within
-          <span v-html="depthFragment"></span> of the ground surface over
-          time.</strong
-        >
         Projected permafrost active layer thickness and ground freeze depth
         through the end of the century is shown below. The active layer is the
         layer of soil above permafrost that thaws seasonally.
@@ -21,8 +72,7 @@
         v-show="
           permafrostPresent && !permafrostDisappears && !permafrostUncertain
         "
-        >Historical data and model projections indicate that
-        <strong>this place has permafrost.</strong>
+      >
         Projected permafrost active layer thickness through the end of the
         century is shown below. The active layer is the layer of soil above
         permafrost that thaws seasonally.
@@ -32,31 +82,16 @@
           !permafrostPresent && permafrostDisappears && !permafrostUncertain
         "
       >
-        <strong>
-          There is no permafrost within <span v-html="depthFragment"></span> of
-          the ground surface at this location</strong
-        >. Projected ground freeze depth through the end of the century is shown
+        Projected ground freeze depth through the end of the century is shown
         below.
       </span>
       <span v-show="permafrostUncertain">
-        <strong
-          >The presence or absence of permafrost could not be determined for
-          this location</strong
-        >
         because the historical mean annual ground temperature falls within the
         threshold of uncertainty (<span v-html="uncertaintyFragment"></span>). A
         chart of the historical and projected mean annual ground temperature is
         provided below.
       </span>
-      Results were produced by the GIPL 2.0 permafrost model using five separate
-      climate models and two different greenhouse gas scenarios or
-      Representative Concentration Pathways (RCPs). RCP4.5 is an optimistic
-      future, and RCP8.5 is more pessimistic but also more likely.
-      <nuxt-link :to="{ name: 'about' }"
-        >Read more about models and RCPs.</nuxt-link
-      >
     </div>
-    <ReportMagtMaps />
     <div class="chart-wrapper permafrost" v-show="this.permafrostPresent">
       <ReportAltThawChart />
     </div>

--- a/components/reports/permafrost/PermafrostReport.vue
+++ b/components/reports/permafrost/PermafrostReport.vue
@@ -56,6 +56,7 @@
         >Read more about models and RCPs.</nuxt-link
       >
     </div>
+    <ReportMagtMaps />
     <div class="chart-wrapper permafrost" v-show="this.permafrostPresent">
       <ReportAltThawChart />
     </div>
@@ -69,6 +70,7 @@
 </template>
 <style></style>
 <script>
+import ReportMagtMaps from './ReportMagtMaps'
 import ReportAltThawChart from './ReportAltThawChart'
 import ReportAltFreezeChart from './ReportAltFreezeChart'
 import ReportMagtChart from './ReportMagtChart'
@@ -76,7 +78,12 @@ import { mapGetters } from 'vuex'
 
 export default {
   name: 'PermafrostReport',
-  components: { ReportAltThawChart, ReportAltFreezeChart, ReportMagtChart },
+  components: {
+    ReportMagtMaps,
+    ReportAltThawChart,
+    ReportAltFreezeChart,
+    ReportMagtChart,
+  },
   computed: {
     // The range of uncertainty, within 1ºC of freezing.
     uncertaintyFragment() {

--- a/components/reports/permafrost/ReportMagtMap.vue
+++ b/components/reports/permafrost/ReportMagtMap.vue
@@ -1,0 +1,123 @@
+<template>
+  <div class="report--minimap--wrapper has-text-centered has-text-weight-bold">
+    {{ title }}
+    <div :id="mapID" class="report--deltamap--map"></div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.report--deltamap--map {
+  height: 15vw;
+  width: 100%;
+}
+</style>
+
+<script>
+import _ from 'lodash'
+import { mapGetters } from 'vuex'
+
+let scenarios = ['', 'RCP 4.5', 'RCP 8.5']
+let eras = ['1995', '2011-2040', '2036-2065', '2061–2090', '2086–2100']
+
+export default {
+  name: 'ReportMagtMap',
+  props: ['scenario', 'model', 'era'],
+  computed: {
+    ...mapGetters({
+      latLng: 'place/latLng',
+      geoJSON: 'place/geoJSON',
+    }),
+  },
+  data() {
+    return {
+      mapID: this.getMapID(),
+      title: this.getTitle(),
+      marker: undefined,
+      geoJsonLayer: undefined,
+    }
+  },
+  mounted() {
+    this.map = L.map(this.mapID, this.getBaseMapAndLayers())
+    if (this.latLng) {
+      this.map.panTo(this.latLng)
+      this.marker = L.marker(this.latLng).addTo(this.map)
+    } else if (this.hucId) {
+      // Fetch the GeoJSON outline
+      this.loadHucGeoJSON()
+    }
+  },
+  watch: {
+    // After geoJSON is loaded, display on map.
+    geoJSON: function () {
+      this.addGeoJSONtoMap()
+    },
+  },
+  methods: {
+    addGeoJSONtoMap() {
+      if (this.geoJSON) {
+        this.geoJSONLayer = L.geoJSON(this.geoJSON, {
+          style: {
+            color: '#444444',
+          },
+        }).addTo(this.map)
+        this.map.fitBounds(this.geoJSONLayer.getBounds())
+      }
+    },
+    async loadHucGeoJSON() {
+      let queryUrl = process.env.apiUrl + '/huc/huc8/' + this.hucId
+      // TODO, add error handling here.
+      let geoJson = await this.$http.$get(queryUrl)
+      this.map.fitBounds(this.geoJsonLayer.getBounds())
+    },
+    getTitle() {
+      var title = ''
+      if (this.scenario > 0) {
+        title += scenarios[this.scenario] + ', '
+      }
+      title += eras[this.era]
+      return title
+    },
+    getMapID() {
+      return this.scenario + '_' + this.model + '_' + this.era
+    },
+    getBaseMapAndLayers() {
+      // Projection definition.
+      var proj = new this.$L.Proj.CRS(
+        'EPSG:3338',
+        '+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +ellps=GRS80 +datum=NAD83 +units=m +no_defs',
+        {
+          resolutions: [4096, 2048, 1024, 512, 256, 128, 64],
+        }
+      )
+      var baseLayer = new L.tileLayer.wms(
+        'http://apollo.snap.uaf.edu:8080/rasdaman/ows',
+        {
+          transparent: true,
+          format: 'image/png',
+          version: '1.3.0',
+          layers: 'test_iem_gipl_magt_alt_4km',
+          dim_era: this.era,
+          dim_model: this.model,
+          dim_scenario: this.scenario,
+          styles: 'climate_impact_reports',
+        }
+      )
+      // Map base configuration
+      var config = {
+        zoom: 1,
+        minZoom: 0,
+        maxZoom: 2,
+        center: [64.7, -155],
+        scrollWheelZoom: false,
+        dragging: false,
+        zoomControl: false,
+        doubleClickZoom: false,
+        attributionControl: false,
+        layers: [baseLayer],
+        crs: proj,
+      }
+      return config
+    },
+  },
+}
+</script>

--- a/components/reports/permafrost/ReportMagtMaps.vue
+++ b/components/reports/permafrost/ReportMagtMaps.vue
@@ -1,0 +1,90 @@
+<template>
+  <section class="section">
+    <div class="columns">
+      <div class="column is-flex">
+        <ReportMagtMap
+          scenario="0"
+          model="0"
+          era="0"
+          class="report--deltamap--map"
+        />
+        <ReportMagtMap
+          scenario="1"
+          model="1"
+          era="1"
+          class="report--deltamap--map"
+        />
+        <ReportMagtMap
+          scenario="1"
+          model="1"
+          era="2"
+          class="report--deltamap--map"
+        />
+        <ReportMagtMap
+          scenario="1"
+          model="1"
+          era="3"
+          class="report--deltamap--map"
+        />
+        <ReportMagtMap
+          scenario="1"
+          model="1"
+          era="4"
+          class="report--deltamap--map"
+        />
+      </div>
+    </div>
+    <div class="columns">
+      <div class="column is-flex">
+        <div class="report--deltamap--map" />
+        <ReportMagtMap
+          scenario="2"
+          model="1"
+          era="1"
+          class="report--deltamap--map"
+        />
+        <ReportMagtMap
+          scenario="2"
+          model="1"
+          era="2"
+          class="report--deltamap--map"
+        />
+        <ReportMagtMap
+          scenario="2"
+          model="1"
+          era="3"
+          class="report--deltamap--map"
+        />
+        <ReportMagtMap
+          scenario="2"
+          model="1"
+          era="4"
+          class="report--deltamap--map"
+        />
+      </div>
+    </div>
+  </section>
+</template>
+
+<style lang="scss" scoped>
+h1 {
+  text-align: center;
+  font-size: 3rem;
+}
+.report--deltamap--map {
+  height: 17vw;
+  min-width: 10vw;
+  width: 20%;
+  margin: 5px;
+}
+</style>
+
+<script>
+import ReportMagtMap from './ReportMagtMap'
+export default {
+  name: 'ReportMagtMaps',
+  components: {
+    ReportMagtMap,
+  },
+}
+</script>


### PR DESCRIPTION
Related to #155, but does not close it until we get feedback from IEM team.

This PR adds historical and projected MAGT mini-maps for all locations (points & polygons) using data from one of the five available models provided by the GIPL dataset.

Let's merge this PR into `main` so it's easier to demo to the IEM team. If the IEM team agrees that this is a valuable addition to reports, we will need to tackle #190, #191, and #193 also.