### PR TITLE
Adjust API endpoint for HUC data fetches

### DIFF
--- a/store/place.js
+++ b/store/place.js
@@ -135,7 +135,7 @@ export const getters = {
         return 'point/' + getters.latLng[0] + '/' + getters.latLng[1]
         break
       case 'huc':
-        return 'huc/huc8/' + getters.hucId
+        return 'huc/' + getters.hucId
         break
       case 'protected_area':
         return 'protectedarea/' + getters.protectedAreaId


### PR DESCRIPTION
Closes #188 

To test, open the app and choose Chena River Watershed.  Notice that the temp/precip data shows up as expected.  (Note also that the boundary won't show up, but that's pending an adjustment on the API side so that's OK; will re-test after the API is updated).