### PR TITLE
Add model selection and title to permafrost mini-maps, clean up code, fix Rasdaman HTTPS issue

### DIFF
--- a/components/reports/permafrost/ReportMagtMap.vue
+++ b/components/reports/permafrost/ReportMagtMap.vue
@@ -49,11 +49,8 @@ export default {
   mounted() {
     this.map = L.map(this.mapID, this.getBaseMapAndLayers())
     if (this.latLng) {
-      this.map.panTo(this.latLng)
       this.marker = L.marker(this.latLng).addTo(this.map)
-    } else if (this.hucId) {
-      // Fetch the GeoJSON outline
-      this.loadHucGeoJSON()
+      this.map.panTo(this.latLng)
     }
   },
   watch: {
@@ -89,12 +86,6 @@ export default {
         }).addTo(this.map)
         this.map.fitBounds(this.geoJSONLayer.getBounds())
       }
-    },
-    async loadHucGeoJSON() {
-      let queryUrl = process.env.apiUrl + '/huc/huc8/' + this.hucId
-      // TODO, add error handling here.
-      let geoJson = await this.$http.$get(queryUrl)
-      this.map.fitBounds(this.geoJsonLayer.getBounds())
     },
     getBaseMapAndLayers() {
       // Projection definition.

--- a/components/reports/permafrost/ReportMagtMap.vue
+++ b/components/reports/permafrost/ReportMagtMap.vue
@@ -34,6 +34,7 @@ export default {
       title: this.getTitle(),
       marker: undefined,
       geoJsonLayer: undefined,
+      baseLayer: undefined,
     }
   },
   mounted() {
@@ -47,12 +48,32 @@ export default {
     }
   },
   watch: {
+    model: function () {
+      this.map.removeLayer(this.baseLayer)
+      this.baseLayer = this.getBaseLayer()
+      this.map.addLayer(this.baseLayer)
+    },
     // After geoJSON is loaded, display on map.
     geoJSON: function () {
       this.addGeoJSONtoMap()
     },
   },
   methods: {
+    getBaseLayer() {
+      return new L.tileLayer.wms(
+        'http://apollo.snap.uaf.edu:8080/rasdaman/ows',
+        {
+          transparent: true,
+          format: 'image/png',
+          version: '1.3.0',
+          layers: 'test_iem_gipl_magt_alt_4km',
+          dim_era: this.era,
+          dim_model: this.model,
+          dim_scenario: this.scenario,
+          styles: 'climate_impact_reports',
+        }
+      )
+    },
     addGeoJSONtoMap() {
       if (this.geoJSON) {
         this.geoJSONLayer = L.geoJSON(this.geoJSON, {
@@ -89,19 +110,7 @@ export default {
           resolutions: [4096, 2048, 1024, 512, 256, 128, 64],
         }
       )
-      var baseLayer = new L.tileLayer.wms(
-        'http://apollo.snap.uaf.edu:8080/rasdaman/ows',
-        {
-          transparent: true,
-          format: 'image/png',
-          version: '1.3.0',
-          layers: 'test_iem_gipl_magt_alt_4km',
-          dim_era: this.era,
-          dim_model: this.model,
-          dim_scenario: this.scenario,
-          styles: 'climate_impact_reports',
-        }
-      )
+      this.baseLayer = this.getBaseLayer()
       // Map base configuration
       var config = {
         zoom: 1,
@@ -113,7 +122,7 @@ export default {
         zoomControl: false,
         doubleClickZoom: false,
         attributionControl: false,
-        layers: [baseLayer],
+        layers: [this.baseLayer],
         crs: proj,
       }
       return config

--- a/components/reports/permafrost/ReportMagtMap.vue
+++ b/components/reports/permafrost/ReportMagtMap.vue
@@ -27,11 +27,20 @@ export default {
       latLng: 'place/latLng',
       geoJSON: 'place/geoJSON',
     }),
+    title() {
+      var title = ''
+      if (this.scenario > 0) {
+        title += scenarios[this.scenario] + ', '
+      }
+      title += eras[this.era]
+      return title
+    },
+    mapID() {
+      return this.scenario + '_' + this.model + '_' + this.era
+    },
   },
   data() {
     return {
-      mapID: this.getMapID(),
-      title: this.getTitle(),
       marker: undefined,
       geoJsonLayer: undefined,
       baseLayer: undefined,
@@ -86,17 +95,6 @@ export default {
       // TODO, add error handling here.
       let geoJson = await this.$http.$get(queryUrl)
       this.map.fitBounds(this.geoJsonLayer.getBounds())
-    },
-    getTitle() {
-      var title = ''
-      if (this.scenario > 0) {
-        title += scenarios[this.scenario] + ', '
-      }
-      title += eras[this.era]
-      return title
-    },
-    getMapID() {
-      return this.scenario + '_' + this.model + '_' + this.era
     },
     getBaseMapAndLayers() {
       // Projection definition.

--- a/components/reports/permafrost/ReportMagtMap.vue
+++ b/components/reports/permafrost/ReportMagtMap.vue
@@ -60,19 +60,16 @@ export default {
   },
   methods: {
     getBaseLayer() {
-      return new L.tileLayer.wms(
-        'http://apollo.snap.uaf.edu:8080/rasdaman/ows',
-        {
-          transparent: true,
-          format: 'image/png',
-          version: '1.3.0',
-          layers: 'test_iem_gipl_magt_alt_4km',
-          dim_era: this.era,
-          dim_model: this.model,
-          dim_scenario: this.scenario,
-          styles: 'climate_impact_reports',
-        }
-      )
+      return new L.tileLayer.wms(process.env.rasdamanUrl, {
+        transparent: true,
+        format: 'image/png',
+        version: '1.3.0',
+        layers: 'test_iem_gipl_magt_alt_4km',
+        dim_era: this.era,
+        dim_model: this.model,
+        dim_scenario: this.scenario,
+        styles: 'climate_impact_reports',
+      })
     },
     addGeoJSONtoMap() {
       if (this.geoJSON) {

--- a/components/reports/permafrost/ReportMagtMap.vue
+++ b/components/reports/permafrost/ReportMagtMap.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="report--minimap--wrapper has-text-centered has-text-weight-bold">
+  <div class="has-text-centered has-text-weight-bold">
     {{ title }}
-    <div :id="mapID" class="report--deltamap--map"></div>
+    <div :id="mapID" class="permafrost-minimap"></div>
   </div>
 </template>
 
 <style lang="scss" scoped>
-.report--deltamap--map {
+.permafrost-minimap {
   height: 15vw;
   width: 100%;
 }

--- a/components/reports/permafrost/ReportMagtMaps.vue
+++ b/components/reports/permafrost/ReportMagtMaps.vue
@@ -83,10 +83,6 @@
 </template>
 
 <style lang="scss" scoped>
-h1 {
-  text-align: center;
-  font-size: 3rem;
-}
 .report--deltamap--map {
   height: 17vw;
   min-width: 10vw;

--- a/components/reports/permafrost/ReportMagtMaps.vue
+++ b/components/reports/permafrost/ReportMagtMaps.vue
@@ -1,5 +1,21 @@
 <template>
   <section class="section">
+    <div class="is-size-6 mb-4">
+      <b-field label="Model">
+        <b-radio
+          v-model="model_selection"
+          name="model_selection"
+          native-value="3"
+          >NCAR CCSM4</b-radio
+        >
+        <b-radio
+          v-model="model_selection"
+          name="model_selection"
+          native-value="4"
+          >MRI CGCM3</b-radio
+        >
+      </b-field>
+    </div>
     <div class="columns">
       <div class="column is-flex">
         <ReportMagtMap
@@ -10,25 +26,29 @@
         />
         <ReportMagtMap
           scenario="1"
-          model="1"
+          :model="model_selection"
+          :key="model_selection + '-rcp45-2025'"
           era="1"
           class="report--deltamap--map"
         />
         <ReportMagtMap
           scenario="1"
-          model="1"
+          :model="model_selection"
+          :key="model_selection + '-rcp45-2050'"
           era="2"
           class="report--deltamap--map"
         />
         <ReportMagtMap
           scenario="1"
-          model="1"
+          :model="model_selection"
+          :key="model_selection + '-rcp45-2075'"
           era="3"
           class="report--deltamap--map"
         />
         <ReportMagtMap
           scenario="1"
-          model="1"
+          :model="model_selection"
+          :key="model_selection + '-rcp45-2095'"
           era="4"
           class="report--deltamap--map"
         />
@@ -39,25 +59,29 @@
         <div class="report--deltamap--map" />
         <ReportMagtMap
           scenario="2"
-          model="1"
+          :model="model_selection"
+          :key="model_selection + '-rcp85-2025'"
           era="1"
           class="report--deltamap--map"
         />
         <ReportMagtMap
           scenario="2"
-          model="1"
+          :model="model_selection"
+          :key="model_selection + '-rcp85-2050'"
           era="2"
           class="report--deltamap--map"
         />
         <ReportMagtMap
           scenario="2"
-          model="1"
+          :model="model_selection"
+          :key="model_selection + '-rcp85-2075'"
           era="3"
           class="report--deltamap--map"
         />
         <ReportMagtMap
           scenario="2"
-          model="1"
+          :model="model_selection"
+          :key="model_selection + '-rcp85-2095'"
           era="4"
           class="report--deltamap--map"
         />
@@ -85,6 +109,11 @@ export default {
   name: 'ReportMagtMaps',
   components: {
     ReportMagtMap,
+  },
+  data() {
+    return {
+      model_selection: 3,
+    }
   },
 }
 </script>

--- a/components/reports/permafrost/ReportMagtMaps.vue
+++ b/components/reports/permafrost/ReportMagtMaps.vue
@@ -1,5 +1,9 @@
 <template>
   <section class="section">
+    <h5 class="permafrost-minimaps-title has-text-centered">
+      Mean annual ground temperature,
+      <span v-html="place"></span>
+    </h5>
     <div class="is-size-6 mb-4">
       <b-field label="Model">
         <b-radio
@@ -22,60 +26,60 @@
           scenario="0"
           model="0"
           era="0"
-          class="report--deltamap--map"
+          class="permafrost-minimaps-map"
         />
         <ReportMagtMap
           scenario="1"
           :model="model_selection"
           era="1"
-          class="report--deltamap--map"
+          class="permafrost-minimaps-map"
         />
         <ReportMagtMap
           scenario="1"
           :model="model_selection"
           era="2"
-          class="report--deltamap--map"
+          class="permafrost-minimaps-map"
         />
         <ReportMagtMap
           scenario="1"
           :model="model_selection"
           era="3"
-          class="report--deltamap--map"
+          class="permafrost-minimaps-map"
         />
         <ReportMagtMap
           scenario="1"
           :model="model_selection"
           era="4"
-          class="report--deltamap--map"
+          class="permafrost-minimaps-map"
         />
       </div>
     </div>
     <div class="columns">
       <div class="column is-flex">
-        <div class="report--deltamap--map" />
+        <div class="permafrost-minimaps-map" />
         <ReportMagtMap
           scenario="2"
           :model="model_selection"
           era="1"
-          class="report--deltamap--map"
+          class="permafrost-minimaps-map"
         />
         <ReportMagtMap
           scenario="2"
           :model="model_selection"
           era="2"
-          class="report--deltamap--map"
+          class="permafrost-minimaps-map"
         />
         <ReportMagtMap
           scenario="2"
           :model="model_selection"
           era="3"
-          class="report--deltamap--map"
+          class="permafrost-minimaps-map"
         />
         <ReportMagtMap
           scenario="2"
           :model="model_selection"
           era="4"
-          class="report--deltamap--map"
+          class="permafrost-minimaps-map"
         />
       </div>
     </div>
@@ -83,7 +87,11 @@
 </template>
 
 <style lang="scss" scoped>
-.report--deltamap--map {
+.permafrost-minimaps-title {
+  font-size: 150%;
+  padding-bottom: 1rem;
+}
+.permafrost-minimaps-map {
   height: 17vw;
   min-width: 10vw;
   width: 20%;
@@ -93,10 +101,16 @@
 
 <script>
 import ReportMagtMap from './ReportMagtMap'
+import { mapGetters } from 'vuex'
 export default {
   name: 'ReportMagtMaps',
   components: {
     ReportMagtMap,
+  },
+  computed: {
+    ...mapGetters({
+      place: 'place/name',
+    }),
   },
   data() {
     return {

--- a/components/reports/permafrost/ReportMagtMaps.vue
+++ b/components/reports/permafrost/ReportMagtMaps.vue
@@ -27,28 +27,24 @@
         <ReportMagtMap
           scenario="1"
           :model="model_selection"
-          :key="model_selection + '-rcp45-2025'"
           era="1"
           class="report--deltamap--map"
         />
         <ReportMagtMap
           scenario="1"
           :model="model_selection"
-          :key="model_selection + '-rcp45-2050'"
           era="2"
           class="report--deltamap--map"
         />
         <ReportMagtMap
           scenario="1"
           :model="model_selection"
-          :key="model_selection + '-rcp45-2075'"
           era="3"
           class="report--deltamap--map"
         />
         <ReportMagtMap
           scenario="1"
           :model="model_selection"
-          :key="model_selection + '-rcp45-2095'"
           era="4"
           class="report--deltamap--map"
         />
@@ -60,28 +56,24 @@
         <ReportMagtMap
           scenario="2"
           :model="model_selection"
-          :key="model_selection + '-rcp85-2025'"
           era="1"
           class="report--deltamap--map"
         />
         <ReportMagtMap
           scenario="2"
           :model="model_selection"
-          :key="model_selection + '-rcp85-2050'"
           era="2"
           class="report--deltamap--map"
         />
         <ReportMagtMap
           scenario="2"
           :model="model_selection"
-          :key="model_selection + '-rcp85-2075'"
           era="3"
           class="report--deltamap--map"
         />
         <ReportMagtMap
           scenario="2"
           :model="model_selection"
-          :key="model_selection + '-rcp85-2095'"
           era="4"
           class="report--deltamap--map"
         />

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -87,7 +87,7 @@ export default {
     geoserverUrl:
       process.env.GEOSERVER_URL || 'https://gs.mapventure.org/geoserver/wms',
     rasdamanUrl:
-      process.env.RASDAMAN_URL || 'https://apollo.snap.uaf.edu/rasdaman/ows',
+      process.env.RASDAMAN_URL || 'https://zeus.snap.uaf.edu/rasdaman/ows',
     apiUrl: process.env.SNAP_API_URL || 'https://earthmaps.io',
   },
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -87,8 +87,7 @@ export default {
     geoserverUrl:
       process.env.GEOSERVER_URL || 'https://gs.mapventure.org/geoserver/wms',
     rasdamanUrl:
-      process.env.RASDAMAN_URL ||
-      'http://apollo.snap.uaf.edu:8080/rasdaman/ows',
+      process.env.RASDAMAN_URL || 'https://apollo.snap.uaf.edu/rasdaman/ows',
     apiUrl: process.env.SNAP_API_URL || 'https://earthmaps.io',
   },
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -86,6 +86,9 @@ export default {
   env: {
     geoserverUrl:
       process.env.GEOSERVER_URL || 'https://gs.mapventure.org/geoserver/wms',
+    rasdamanUrl:
+      process.env.RASDAMAN_URL ||
+      'http://apollo.snap.uaf.edu:8080/rasdaman/ows',
     apiUrl: process.env.SNAP_API_URL || 'https://earthmaps.io',
   },
 


### PR DESCRIPTION
Fixes most of the issues in #201, but let's leave #201 open until the rest can be tackled.

This PR:

- Adds radio buttons above the permafrost MAGT mini-maps to allow users to switch between models.
- Adds a title above the permafrost MAGT mini-maps section.
- Cleans up some code to do things the proper Vue way.
- Loads Rasdaman over HTTPS so the permafrost mini-maps load properly from an HTTPS site (fixes current issue on https://northernclimatereports.org/).