### PR TITLE
Clears state upon going back to /, prevents spurious data load

### DIFF
--- a/components/App.vue
+++ b/components/App.vue
@@ -52,6 +52,14 @@ export default {
       this.$router.push({ path: path })
     }
 
+    // Since this component is invoked whenever the `/` route fires,
+    // we need to clear the stores.
+    this.$store.commit('place/clear')
+    this.$store.commit('climate/clear')
+    this.$store.commit('elevation/clear')
+    this.$store.commit('permafrost/clear')
+    this.$store.commit('wildfire/clear')
+
     // Populate the store with places.
     this.$fetch()
   },

--- a/store/climate.js
+++ b/store/climate.js
@@ -52,6 +52,9 @@ export const mutations = {
   setClimateData(state, climateData) {
     state.climateData = climateData
   },
+  clear(state) {
+    state.climateData = undefined
+  },
 }
 
 export const actions = {

--- a/store/elevation.js
+++ b/store/elevation.js
@@ -30,6 +30,9 @@ export const mutations = {
   setElevation(state, elevation) {
     state.elevation = elevation
   },
+  clear(state) {
+    state.elevation = undefined
+  },
 }
 
 export const actions = {

--- a/store/permafrost.js
+++ b/store/permafrost.js
@@ -208,6 +208,15 @@ export const mutations = {
   setUncertain(state, uncertain) {
     state.uncertain = uncertain
   },
+  clear(state) {
+    state.permafrostData = undefined
+    state.altThaw = undefined
+    state.altFreeze = undefined
+    state.magt = undefined
+    state.disappears = undefined
+    state.present = undefined
+    state.uncertain = undefined
+  },
 }
 
 export const actions = {

--- a/store/place.js
+++ b/store/place.js
@@ -162,6 +162,11 @@ export const mutations = {
   setPlaces(state, places) {
     state.places = places
   },
+  clear(state) {
+    // Flush the geoJSON.
+    state.geoJSON = undefined
+    // Don't clear the list of places, that's always the same for the UX.
+  },
 }
 
 export const actions = {
@@ -174,6 +179,11 @@ export const actions = {
   },
 
   async fetchPlaces(context) {
+    // If we've already fetched this, don't do that again.
+    if (context.state.places) {
+      return
+    }
+
     // TODO: add error handling here for 404 (no data) etc.
     let queryUrl = process.env.apiUrl + '/places/all'
     let places = await this.$http.$get(queryUrl)

--- a/store/wildfire.js
+++ b/store/wildfire.js
@@ -23,6 +23,10 @@ export const mutations = {
   setVegChange(state, veg_change) {
     state.veg_change = veg_change
   },
+  clear(state) {
+    state.flammability = undefined
+    state.veg_change = undefined
+  }
 }
 
 export const actions = {


### PR DESCRIPTION
Fixes #179 
Fixes #229 

I couldn't find a solution to watch for route changes (!) -- it would see some route changes but not all, not really clear why except that there may be some combination between the `nuxt-link` component and `vue-router-sync` that is making things wonky.  I did note that the App component is created each time so we can clear the stores there; _but_ it does feel like we may want to improve this implementation in the future.  I suggest that we create another ticket to figure our the "watch state change on router".