### PR TITLE
Relative flammability and vegetation change chart improvements

### DIFF
--- a/components/reports/wildfire/ReportVegChangeChart.vue
+++ b/components/reports/wildfire/ReportVegChangeChart.vue
@@ -1,5 +1,18 @@
 <template>
   <div class="wildfire-chart-wrapper">
+    <div class="is-size-6">
+      <b-field label="Projected Data">
+        <b-radio v-model="plotType" name="vegChangePlotType" native-value="box"
+          >Box Plot</b-radio
+        >
+        <b-radio
+          v-model="plotType"
+          name="vegChangePlotType"
+          native-value="scatter"
+          >Scatter Plot</b-radio
+        >
+      </b-field>
+    </div>
     <div id="wildfire-veg-change-chart" />
   </div>
 </template>
@@ -10,19 +23,29 @@ import { getPlotSettings, getLayout, getFooter } from '../../../utils/charts'
 import {
   getHistoricalTrace,
   getProjectedTraces,
+  allZeros,
 } from '../../../utils/wildfire_charts'
 export default {
   name: 'ReportVegChangeChart',
   mounted() {
     this.renderPlot()
   },
+  data() {
+    return {
+      plotType: 'box',
+    }
+  },
   computed: {
     ...mapGetters({
       vegChangeData: 'wildfire/veg_change',
+      place: 'place/name',
     }),
   },
   watch: {
     vegChangeData: function () {
+      this.renderPlot()
+    },
+    plotType: function () {
       this.renderPlot()
     },
   },
@@ -33,18 +56,32 @@ export default {
         return
       }
 
-      let title = 'Vegetation change'
-      let yAxisLabel = 'Average pixels that switched vegetation type'
-      let layout = getLayout(title, yAxisLabel, 600)
+      let title = 'Vegetation change, ' + this.place
+      let yAxisLabel = 'Annual chance of vegetation change (%)'
+      let layout = getLayout(title, yAxisLabel)
+
+      // Prevent all-zero charts from showing negative y-axis.
+      // Subtract a small buffer from 0 value to avoid cropping scatter marker.
+      if (allZeros(vegChangeData)) {
+        layout['yaxis']['range'] = [-0.1, 2]
+      }
 
       let dataTraces = []
 
-      let historicalTrace = getHistoricalTrace(vegChangeData, 'rvc')
+      let historicalTrace = getHistoricalTrace(
+        vegChangeData,
+        'rvc',
+        this.plotType
+      )
       if (historicalTrace != null) {
         dataTraces.push(historicalTrace)
       }
 
-      let projectedTraces = getProjectedTraces(vegChangeData, 'rvc')
+      let projectedTraces = getProjectedTraces(
+        vegChangeData,
+        'rvc',
+        this.plotType
+      )
       dataTraces = dataTraces.concat(projectedTraces)
 
       let footerLines = [

--- a/components/reports/wildfire/WildfireReport.vue
+++ b/components/reports/wildfire/WildfireReport.vue
@@ -6,8 +6,8 @@
         <p>
           The following charts show the historical and projected relative
           flammability and vegetation change for this location. Values represent
-          the average number of times the pixel at this location has burned or
-          changed dominant vegetation type for varios models and scenarios.
+          the percentage of times the pixel at this location has burned, or
+          changed dominant vegetation type, for varios models and scenarios.
           <nuxt-link :to="{ name: 'data', hash: '#datasets' }"
             >See information about the dataset shown here.</nuxt-link
           >

--- a/store/wildfire.js
+++ b/store/wildfire.js
@@ -43,10 +43,6 @@ export const mutations = {
   setVegChangeHttpError(state, error) {
     state.vegChangeHttpError = error
   },
-  clear(state) {
-    state.flammability = undefined
-    state.veg_change = undefined
-  },
 }
 
 export const actions = {

--- a/utils/charts.js
+++ b/utils/charts.js
@@ -17,7 +17,6 @@ export const getPlotSettings = function () {
 
 export const getLayout = function (title, yAxisLabel, height = 500) {
   return {
-    boxmode: 'group',
     yaxis: {
       title: {
         text: yAxisLabel,
@@ -44,9 +43,6 @@ export const getLayout = function (title, yAxisLabel, height = 500) {
     showlegend: true,
     legend: {
       x: 1.03,
-    },
-    margin: {
-      b: 40,
     },
     margin: {
       b: 120,

--- a/utils/convert.js
+++ b/utils/convert.js
@@ -73,3 +73,15 @@ export const convertToFahrenheit = function (
   )
   return t
 }
+
+export const convertToPercent = function (wildfireData) {
+  return _.mapValuesDeep(
+    wildfireData,
+    value => {
+      return value * 100
+    },
+    {
+      leavesOnly: true,
+    }
+  )
+}

--- a/utils/wildfire_charts.js
+++ b/utils/wildfire_charts.js
@@ -1,11 +1,4 @@
-let models = [
-  '5modelAvg',
-  'GFDL-CM3',
-  'GISS-E2-R',
-  'IPSL-CM5A-LR',
-  'MRI-CGCM3',
-  'NCAR-CCSM4',
-]
+let models = ['5modelAvg', 'GFDL-CM3', 'GISS-E2-R']
 let scenarios = ['rcp45', 'rcp60', 'rcp85']
 
 let historicalDecades = [
@@ -17,17 +10,7 @@ let historicalDecades = [
   '2000-2008',
 ]
 
-let projectedDecades = [
-  '2010-2019',
-  '2020-2029',
-  '2030-2039',
-  '2040-2049',
-  '2050-2059',
-  '2060-2069',
-  '2070-2079',
-  '2080-2089',
-  '2090-2099',
-]
+let projectedEras = ['2040-2069', '2070-2099']
 
 let traceLabels = {
   '5modelAvg': {
@@ -45,30 +28,12 @@ let traceLabels = {
     rcp60: 'RCP 6.0 (GISS E2-R)',
     rcp85: 'RCP 8.5 (GISS E2-R)',
   },
-  'IPSL-CM5A-LR': {
-    rcp45: 'RCP 4.5 (IPSL CM5A-LR)',
-    rcp60: 'RCP 6.0 (IPSL CM5A-LR)',
-    rcp85: 'RCP 8.5 (IPSL CM5A-LR)',
-  },
-  'MRI-CGCM3': {
-    rcp45: 'RCP 4.5 (MRI CGCM3)',
-    rcp60: 'RCP 6.0 (MRI CGCM3)',
-    rcp85: 'RCP 8.5 (MRI CGCM3)',
-  },
-  'NCAR-CCSM4': {
-    rcp45: 'RCP 4.5 (NCAR CCSM4)',
-    rcp60: 'RCP 6.0 (NCAR CCSM4)',
-    rcp85: 'RCP 8.5 (NCAR CCSM4)',
-  },
 }
 
 let symbols = {
   '5modelAvg': 'circle',
   'GFDL-CM3': 'square',
   'GISS-E2-R': 'cross',
-  'IPSL-CM5A-LR': 'x',
-  'MRI-CGCM3': 'pentagon',
-  'NCAR-CCSM4': 'hexagon',
 }
 
 let colors = {
@@ -87,21 +52,6 @@ let colors = {
     rcp60: 'rgb(180, 180, 90)',
     rcp85: 'rgb(140, 140, 30)',
   },
-  'IPSL-CM5A-LR': {
-    rcp45: 'rgb(250, 150, 30)',
-    rcp60: 'rgb(230, 145, 30)',
-    rcp85: 'rgb(210, 120, 30)',
-  },
-  'MRI-CGCM3': {
-    rcp45: 'rgb(210, 150, 210)',
-    rcp60: 'rgb(180, 90, 180)',
-    rcp85: 'rgb(140, 30, 140)',
-  },
-  'NCAR-CCSM4': {
-    rcp45: 'rgb(150, 210, 150)',
-    rcp60: 'rgb(90, 180, 90)',
-    rcp85: 'rgb(30, 140, 30)',
-  },
 }
 
 export const getHistoricalTrace = function (data, variable) {
@@ -113,7 +63,7 @@ export const getHistoricalTrace = function (data, variable) {
     mode: 'markers',
     name: 'Historical',
     hoverinfo: 'x+y+z+text',
-    hovertemplate: '%{y:.4f}',
+    hovertemplate: '%{y:.2f}',
     marker: {
       symbol: 'diamond',
       size: 8,
@@ -124,7 +74,30 @@ export const getHistoricalTrace = function (data, variable) {
   }
 }
 
-const getProjectedTrace = function (
+const getProjectedBoxTrace = function (data, variable) {
+  let projectedTrace = {
+    type: 'box',
+    mode: 'markers',
+    name: 'Projected',
+    x: [],
+    y: [],
+    boxpoints: false,
+    hoverinfo: 'skip',
+  }
+
+  projectedEras.forEach(era => {
+    models.forEach(model => {
+      scenarios.forEach(scenario => {
+        projectedTrace['x'].push(era)
+        projectedTrace['y'].push(data[era][model][scenario][variable])
+      })
+    })
+  })
+
+  return projectedTrace
+}
+
+const getProjectedScatterTrace = function (
   data,
   model,
   scenario,
@@ -137,47 +110,66 @@ const getProjectedTrace = function (
     name: traceLabels[model][scenario],
     hoverinfo: 'x+y+z+text',
     marker: {
-      symbol: Array(projectedDecades.length).fill(symbols[model]),
+      symbol: Array(projectedEras.length).fill(symbols[model]),
       size: 8,
       color: colors[model][scenario],
     },
-    x: projectedDecades,
+    x: projectedEras,
     y: [],
     customdata: [],
   }
 
-  projectedDecades.forEach(decade => {
-    let value = data[decade][model][scenario][variable]
+  projectedEras.forEach(era => {
+    let value = data[era][model][scenario][variable]
     projectedTrace['y'].push(value)
     let diff = value - historicalValue
     if (diff > 0) {
-      diff = '+' + diff.toFixed(4)
+      diff = '+' + diff.toFixed(2)
     } else {
-      diff = diff.toFixed(4)
+      diff = diff.toFixed(2)
     }
     projectedTrace['customdata'].push(diff)
   })
 
-  projectedTrace['hovertemplate'] = '%{y:.4f} <b>(%{customdata})</b>'
+  projectedTrace['hovertemplate'] = '%{y:.2f} <b>(%{customdata})</b>'
 
   return projectedTrace
 }
 
-export const getProjectedTraces = function (data, variable) {
+export const getProjectedTraces = function (data, variable, plotType = 'box') {
   let projectedTraces = []
   let historicalAverage =
     data['1950-2008']['CRU-TS40']['CRU_historical'][variable]
-  models.forEach(model => {
-    scenarios.forEach(scenario => {
-      let projectedTrace = getProjectedTrace(
-        data,
-        model,
-        scenario,
-        variable,
-        historicalAverage
-      )
-      projectedTraces.push(projectedTrace)
+  if (plotType == 'box') {
+    let projectedTrace = getProjectedBoxTrace(data, variable)
+    projectedTraces.push(projectedTrace)
+  } else {
+    models.forEach(model => {
+      scenarios.forEach(scenario => {
+        let projectedTrace = getProjectedScatterTrace(
+          data,
+          model,
+          scenario,
+          variable,
+          historicalAverage
+        )
+        projectedTraces.push(projectedTrace)
+      })
     })
-  })
+  }
   return projectedTraces
+}
+
+export const allZeros = function (data) {
+  let allValues = []
+  _.eachDeep(
+    data,
+    (value, key) => {
+      allValues.push(parseFloat(value))
+    },
+    {
+      leavesOnly: true,
+    }
+  )
+  return allValues.every(value => value == 0)
 }


### PR DESCRIPTION
- Users can now choose whether to view the projected data as a box plot or scatter plot.
- The charts are now showing just 2 models + 5-model-average. I took a guess at what to use for the bracketing models, but we'll want to put more thought into this (ticket created: #235). I don't think we have decided definitively whether to go with the 2 models + 5-model-average approach, but it saves us a lot of work on the UI side dealing with larger-than-normal charts to accommodate the longer-than-normal legend.
- Projected data is now plotted in mid-century and late-century 30-year eras instead of decades.
- Values have been converted to percentages by multiplying the API data by 100.