### PR TITLE
Changed the minimum zoom level to 1 on the base map.

### DIFF
--- a/components/Map.vue
+++ b/components/Map.vue
@@ -94,7 +94,7 @@ export default {
       // Map base configuration
       var config = {
         zoom: 1,
-        minZoom: 0,
+        minZoom: 1,
         maxZoom: 6,
         center: [64.7, -155],
         scrollWheelZoom: false,


### PR DESCRIPTION
Changes a single line to lock our map to zoom level 1 or higher to prevent the fragmented portions of the map from being accessible near the top of zoom level 0.