### PR TITLE
Fixes two errors induced when different complex branches landed in main

### DIFF
--- a/components/Map.vue
+++ b/components/Map.vue
@@ -60,7 +60,6 @@ export default {
     // The map is either being drawn for a broad search interface,
     // or to show the results of a search.
     if (this.mapSearchIsVisible && this.searchResults) {
-      this.marker = L.marker(this.latLng).addTo(this.map)
       this.drawSearchResults()
     } else {
       new this.$L.Control.Zoom({ position: 'topright' }).addTo(this.map)
@@ -166,6 +165,8 @@ export default {
               this.searchResults.total_bounds['xmax'],
             ],
           ])
+          // Add marker where the user clicked.
+          this.marker = L.marker(this.latLng).addTo(this.map)
 
           // LayerGroup for the GeoJSON and stuff so it's easy to remove.
           // This property is non-reactive.

--- a/store/place.js
+++ b/store/place.js
@@ -175,6 +175,11 @@ export const mutations = {
   setSearchResults(state, searchResults) {
     state.searchResults = searchResults
   },
+  clear(state) {
+    // Flush the geoJSON.
+    state.geoJSON = undefined
+    // Don't clear the list of places, that's always the same for the UX.
+  },
   clearSearchResults(state, searchResults) {
     state.searchResults = undefined
   },


### PR DESCRIPTION
To test this:

 * Run the API locally, set the app to look for the local API
 * Open the console in the web app.  There should be no warnings that the `place/clear` mutation is missing when you open the app.
 * Search for a place.  You should see a map marker where the user clicked, in the search results.