### PR TITLE
Allows searching HUCs with prefixed "huc-" or similar.

### DIFF
--- a/components/PlaceSelector.vue
+++ b/components/PlaceSelector.vue
@@ -82,6 +82,11 @@ export default {
     filteredDataObj() {
       // Guard in case the async loading of places isn't done yet.
       if (this.places) {
+        // Strip non-digit characters at the start to allow for
+        // searching by "huc 1901..." etc -- the numeric HucID will
+        // be searched.
+        let strippedHucSearch = this.selectedPlace.replace(/^[\D]*/g, '')
+
         return this.places.filter(option => {
           return (
             option.name
@@ -101,13 +106,9 @@ export default {
             // HUCID, check only if it's 4 digits or more
             (this.selectedPlace.length > 3 &&
               (option.id.toString().indexOf(this.selectedPlace) >= 0 ||
-                option.id.toString().indexOf('huc ' + this.selectedPlace) >=
-                  0 ||
-                option.id.toString().indexOf('HUC ' + this.selectedPlace) >=
-                  0 ||
-                option.id.toString().indexOf('huc-' + this.selectedPlace) >=
-                  0 ||
-                option.id.toString().indexOf('HUC-' + this.selectedPlace) >= 0))
+                // Check for nonzero length of strippedHucSearch!
+                (strippedHucSearch &&
+                  option.id.toString().indexOf(strippedHucSearch) >= 0)))
           )
         })
       }
@@ -119,7 +120,6 @@ export default {
   watch: {
     selected: function (selected) {
       if (selected && selected.type) {
-        
         // Triggers the navigation to the route path,
         // which loads the report + queries API, etc.
         this.$router.push({


### PR DESCRIPTION
Closes #186 

To test this, start on the `main` branch and try searching for "huc 1901" -- there aren't any matches.  Try the same with just "1901" and you'll see some candidate matches.

Then, switch to this branch and try the same tests.  "Huc 1901", "Huc-1901" should both show some candidate matches now.

There should be no other changes to how the search operates.