### PR TITLE
Fixed bug where annual average temperature was not being divided by 4 for the number of seasons.

### DIFF
--- a/components/reports/QualitativeText.vue
+++ b/components/reports/QualitativeText.vue
@@ -155,9 +155,7 @@ export default {
       return seasonMetrics
     },
     temperatureString() {
-      // Average value against the 4 seasons included.
-      annualTemperatureAverage = Math.round(annualTemperatureAverage / 4)
-
+      
       var annualTemperatureAverage = 0
       var annualHighestTempChange = 0
       var seasonWithHighestTempChange = 'None'
@@ -182,6 +180,9 @@ export default {
           aboveFreezingSeasons.push(seasonOutput['season'])
         }
       })
+
+      // Average value against the 4 seasons included.
+      annualTemperatureAverage = Math.round(annualTemperatureAverage / 4)
 
       // Create the returned string using the values from the loop above.
       let string =


### PR DESCRIPTION
This is a simple PR that re-orders an operation meant to divide the total value of the maximum temperatures by 4 until after that variable has been appended by every season.