### PR TITLE
Dynamic sizing of charts + hides all charts and data at small width screen sizes

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -71,3 +71,14 @@ table.table.report-table {
     padding-bottom: 1rem;
   }
 }
+
+@media screen and (max-width: 860px) {
+  .large-screen {
+    display: none;
+  }
+}
+@media screen and (min-width: 861px) {
+  .small-screen {
+    display: none;
+  }
+}

--- a/components/LatLngSelector.vue
+++ b/components/LatLngSelector.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="latlon-picker--wrapper">
+  <div class="latlon-picker--wrapper large-screen">
     <div class="content">
       <h4 class="title is-5">Find a place by latitude & longitude</h4>
       <p>

--- a/components/MapWrapper.vue
+++ b/components/MapWrapper.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="map-wrapper--outer">
+	<div class="map-wrapper--outer large-screen">
 		<div class="container">
 			<div class="section pullup content fullbleed">
 				<h4>Find a place by clicking on the map</h4>
@@ -41,6 +41,11 @@
 	</div>
 </template>
 <style lang="scss" scoped>
+@media screen and (max-width: 860px) {
+  .large-screen {
+    display: none;
+  }
+}
 .pending {
 	width: 80%;
 }

--- a/components/MapWrapper.vue
+++ b/components/MapWrapper.vue
@@ -41,11 +41,6 @@
 	</div>
 </template>
 <style lang="scss" scoped>
-@media screen and (max-width: 860px) {
-  .large-screen {
-    display: none;
-  }
-}
 .pending {
 	width: 80%;
 }

--- a/components/PlaceSelector.vue
+++ b/components/PlaceSelector.vue
@@ -28,17 +28,41 @@
             <template slot-scope="props">
               <div class="search-item">
                 {{ props.option.name }}
-                <span class="watershed" v-if="props.option.type == 'huc'"
+                <span class="area-additional-info" v-if="props.option.type == 'huc'"
                   >Watershed, HUC ID {{ props.option.id }}</span
                 >
                 <span class="alt-name" v-if="props.option.alt_name"
                   >({{ props.option.alt_name }})</span
                 >
                 <span
-                  class="protected-area"
+                  class="area-additional-info"
                   v-if="props.option.type == 'protected_area'"
                 >
                   {{ props.option.area_type }}
+                </span>
+                <span
+                  class="area-additional-info"
+                  v-if="props.option.type == 'corporation'"
+                >
+                  Native Corporation
+                </span>
+                <span
+                  class="area-additional-info"
+                  v-if="props.option.type == 'climate_division'"
+                >
+                  Climate Division
+                </span>
+                <span
+                  class="area-additional-info"
+                  v-if="props.option.type == 'ethnolinguistic_region'"
+                >
+                  Ethnolinguistic Region
+                </span>
+                <span
+                  class="area-additional-info"
+                  v-if="props.option.type == 'fire_zone'"
+                >
+                  Fire Management Unit
                 </span>
               </div>
             </template>
@@ -56,8 +80,7 @@
 .search-item {
   font-weight: 600;
   white-space: normal;
-  .watershed,
-  .protected-area {
+  .area-additional-info {
     text-transform: uppercase;
     display: inline-block;
     padding-left: 1ex;

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -73,7 +73,7 @@
             The sections below show output from different scientific simulations
             of possible future conditions for {{ presentDataTypesString }}.
             These simulations use different
-            <strong>Global Circulation Models (GCMs)</strong>&mdash;climate
+            <strong>Global Climate Models (GCMs)</strong>&mdash;climate
             models&mdash;such as the National Center for Atmospheric Research
             Community Climate System Model 4.0 (NCAR CCSM4).
           </p>

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -40,7 +40,7 @@
         <MiniMap />
         <QualitativeText />
       </section>
-      <section class="section content pb-0" v-if="dataPresent">
+      <section class="section content pb-0 large-screen" v-if="dataPresent">
         <h3 class="title is-3">Introduction</h3>
         <div class="is-size-5">
           <p>
@@ -132,7 +132,7 @@
           </b-field>
         </div>
       </section>
-      <section class="section content" v-if="dataPresent">
+      <section class="section content large-screen" v-if="dataPresent">
         <h4 class="title is-4" id="toc">Contents</h4>
         <div class="is-size-5">
           <ul>
@@ -190,26 +190,29 @@
         </div>
         <div v-if="!dataPresent" class="pb-3" />
       </section>
-      <section class="section" v-if="climateData">
+      <section class="section large-screen" v-if="climateData">
         <div id="temperature">
           <TempReport />
         </div>
       </section>
-      <section class="section" v-if="climateData">
+      <section class="section large-screen" v-if="climateData">
         <div id="precipitation">
           <PrecipReport />
         </div>
       </section>
-      <section class="section">
+      <section class="section large-screen">
         <div id="permafrost" v-if="permafrostData || type != 'latLng'">
           <PermafrostReport />
         </div>
       </section>
-      <section class="section" v-if="flammabilityData || vegChangeData">
+      <section class="section large-screen" v-if="flammabilityData || vegChangeData">
         <div id="wildfire">
           <WildfireReport />
         </div>
         <BackToTopButton />
+      </section>
+      <section class="section !large-screen">
+          <span class="centered"><b-icon icon="phone-rotate-landscape" size="is-medium" />&nbsp;&nbsp;To see additional charts and data, please rotate your device into landscape mode.</span>
       </section>
       <DownloadCsvButton />
       <BackToTopButton />
@@ -229,6 +232,11 @@
   </div>
 </template>
 <style lang="scss" scoped>
+@media screen and (max-width: 480px) {
+  .large-screen {
+    display: none !important;
+  }
+}
 .centered {
   text-align: center;
 }

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -157,7 +157,7 @@
           </ul>
         </div>
       </section>
-      <section class="section content py-0" v-if="dataMissing">
+      <section class="section content py-0 large-screen" v-if="dataMissing">
         <div class="is-size-5">
           <p class="no-data mt-6" v-if="uniformHttpError">
             {{ httpErrors[uniformHttpError] }}

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -211,8 +211,8 @@
         </div>
         <BackToTopButton />
       </section>
-      <section class="section !large-screen">
-          <span class="centered"><b-icon icon="phone-rotate-landscape" size="is-medium" />&nbsp;&nbsp;To see additional charts and data, please rotate your device into landscape mode.</span>
+      <section class="section small-screen">
+          <div class="is-size-5"><span class="centered"><b-icon icon="monitor" size="is-medium" />&nbsp;&nbsp;To view additional charts, tables, and data, please view this URL on a desktop computer with a wider display.</span></div>
       </section>
       <DownloadCsvButton />
       <BackToTopButton />
@@ -232,9 +232,14 @@
   </div>
 </template>
 <style lang="scss" scoped>
-@media screen and (max-width: 480px) {
+@media screen and (max-width: 860px) {
   .large-screen {
-    display: none !important;
+    display: none;
+  }
+}
+@media screen and (min-width: 861px) {
+  .small-screen {
+    display: none;
   }
 }
 .centered {

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -232,16 +232,6 @@
   </div>
 </template>
 <style lang="scss" scoped>
-@media screen and (max-width: 860px) {
-  .large-screen {
-    display: none;
-  }
-}
-@media screen and (min-width: 861px) {
-  .small-screen {
-    display: none;
-  }
-}
 .centered {
   text-align: center;
 }

--- a/components/SearchResults.vue
+++ b/components/SearchResults.vue
@@ -4,11 +4,39 @@
       Locations matching {{ lat }}&deg;N, {{ lng }}&deg;E
     </h3>
     <p>These areas of interest are at, or near, this point:</p>
-    <ul v-if="searchResults.protected_areas_near || searchResults.hucs_near">
+    <ul v-if="searchResults.protected_areas_near || searchResults.hucs_near || searchResults.corporations_near || searchResults.climate_divisions_near || searchResults.ethnolinguistic_regions_near">
+      <li
+        v-for="place in searchResults.climate_divisions_near"
+        :key="place.id"
+        class="additional-info"
+      >
+        <nuxt-link
+          :to="{
+            path: formUrl(place),
+            hash: '#results',
+          }"
+          >{{ place.name }}</nuxt-link
+        >
+        <span>Climate Division</span>
+      </li>
+      <li
+        v-for="place in searchResults.ethnolinguistic_region"
+        :key="place.id"
+        class="additional-info"
+      >
+        <nuxt-link
+          :to="{
+            path: formUrl(place),
+            hash: '#results',
+          }"
+          >{{ place.name }}</nuxt-link
+        >
+        <span>Ethnolinguistic Region</span>
+      </li>
       <li
         v-for="place in searchResults.protected_areas_near"
         :key="place.id"
-        class="protected-area"
+        class="additional-info"
       >
         <nuxt-link
           :to="{
@@ -19,7 +47,7 @@
         >
         <span>{{ place.area_type }}</span>
       </li>
-      <li v-for="huc in searchResults.hucs_near" :key="huc.id" class="huc">
+      <li v-for="huc in searchResults.hucs_near" :key="huc.id" class="additional-info">
         <nuxt-link
           :to="{
             path: formUrl(huc),
@@ -28,6 +56,34 @@
           >{{ huc.name }}</nuxt-link
         >
         <span>HUC ID {{ huc.id }}</span>
+      </li>
+      <li
+        v-for="place in searchResults.corporations_near"
+        :key="place.id"
+        class="additional-info"
+      >
+        <nuxt-link
+          :to="{
+            path: formUrl(place),
+            hash: '#results',
+          }"
+          >{{ place.name }}</nuxt-link
+        >
+        <span>Native Corporation</span>
+      </li>
+      <li
+        v-for="place in searchResults.fire_management_units_near"
+        :key="place.id"
+        class="additional-info"
+      >
+        <nuxt-link
+          :to="{
+            path: formUrl(place),
+            hash: '#results',
+          }"
+          >{{ place.name }}</nuxt-link
+        >
+        <span>Fire Management Unit</span>
       </li>
     </ul>
     <div v-if="searchResults.communities" class="mb-4">
@@ -74,8 +130,7 @@
   </div>
 </template>
 <style lang="scss" scoped>
-li.protected-area span,
-li.huc span {
+li.additional-info span {
   color: #888;
   text-transform: uppercase;
   font-weight: 600;

--- a/components/reports/permafrost/ReportAltFreezeChart.vue
+++ b/components/reports/permafrost/ReportAltFreezeChart.vue
@@ -75,9 +75,9 @@ export default {
 
       let yAxisAnnotationX
       if (window.innerWidth < 1250) {
-        yAxisAnnotationX = -0.06
+        yAxisAnnotationX = -0.07
       } else {
-        yAxisAnnotationX = -0.04
+        yAxisAnnotationX = -0.06
       }
 
       layout.annotations.push({

--- a/components/reports/permafrost/ReportAltThawChart.vue
+++ b/components/reports/permafrost/ReportAltThawChart.vue
@@ -76,14 +76,14 @@ export default {
 
       let yAxisAnnotationX
       if (window.innerWidth < 1250) {
-        yAxisAnnotationX = -0.06
+        yAxisAnnotationX = -0.07
       } else {
-        yAxisAnnotationX = -0.04
+        yAxisAnnotationX = -0.06
       }
 
       layout.annotations.push({
         x: yAxisAnnotationX,
-        y: 0.14,
+        y: 0.07,
         xref: 'paper',
         yref: 'paper',
         showarrow: true,

--- a/components/reports/permafrost/ReportMagtMaps.vue
+++ b/components/reports/permafrost/ReportMagtMaps.vue
@@ -83,6 +83,29 @@
         />
       </div>
     </div>
+    <table class="magt-legend">
+      <tbody>
+        <tr>
+          <td class="legend-20-below px-2">
+            <span class="is-pulled-left">
+              <span v-html="legendRedMin"></span>
+            </span>
+            <span class="is-pulled-right">
+              <span v-html="legendRedMax"></span>
+            </span>
+          </td>
+          <td class="legend-0 has-text-centered">0</td>
+          <td class="legend-20-above px-2">
+            <span class="is-pulled-left">
+              <span v-html="legendBlueMin"></span>
+            </span>
+            <span class="is-pulled-right">
+              <span v-html="legendBlueMax"></span>
+            </span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </section>
 </template>
 
@@ -97,6 +120,27 @@
   width: 20%;
   margin: 5px;
 }
+.magt-legend {
+  width: 700px;
+  border: 1px solid #999;
+  margin: 40px auto 0 auto;
+  font-weight: 700;
+  color: #fff;
+  text-shadow: 0 0 3px #000;
+  .legend-20-below {
+    width: 47.5%;
+    background: linear-gradient(90deg, #0000ffff 0%, #a0a0ffff 100%);
+  }
+  .legend-0 {
+    color: #000;
+    text-shadow: none;
+    width: 5%;
+  }
+  .legend-20-above {
+    width: 47.5%;
+    background: linear-gradient(90deg, #ffa0a0ff 0%, #ff0000ff 100%);
+  }
+}
 </style>
 
 <script>
@@ -109,8 +153,21 @@ export default {
   },
   computed: {
     ...mapGetters({
+      units: 'units',
       place: 'place/name',
     }),
+    legendRedMin() {
+      return this.units == 'imperial' ? '-4&deg;F' : '-20&deg;C'
+    },
+    legendRedMax() {
+      return this.units == 'imperial' ? '30.2&deg;F' : '-1&deg;C'
+    },
+    legendBlueMin() {
+      return this.units == 'imperial' ? '33.8&deg;F' : '1&deg;C'
+    },
+    legendBlueMax() {
+      return this.units == 'imperial' ? '68&deg;F' : '20&deg;C'
+    },
   },
   data() {
     return {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -101,11 +101,7 @@ export default {
         component: resolve(__dirname, 'pages/index'),
       })
       routes.push({
-        path: '/report/huc/:hucId',
-        component: resolve(__dirname, 'pages/index'),
-      })
-      routes.push({
-        path: '/report/protected_area/:protectedAreaId',
+        path: '/report/area/:areaId',
         component: resolve(__dirname, 'pages/index'),
       })
       routes.push({

--- a/store/place.js
+++ b/store/place.js
@@ -49,18 +49,10 @@ export const getters = {
     return false
   },
 
-  // If present, returns the HucID in the URL.
-  hucId: (state, getters, rootState) => {
-    if (rootState.route && rootState.route.params.hucId) {
-      return rootState.route.params.hucId
-    }
-    return false
-  },
-
-  // Fetch the protected area ID
-  protectedAreaId: (state, getters, rootState) => {
-    if (rootState.route.params.protectedAreaId) {
-      return rootState.route.params.protectedAreaId
+  // If present, returns the area ID from the URL.
+  areaId: (state, getters, rootState) => {
+    if (rootState.route && rootState.route.params.areaId) {
+      return rootState.route.params.areaId
     }
     return false
   },
@@ -71,17 +63,23 @@ export const getters = {
       return 'latLng'
     } else if (rootState.route.params.communityId) {
       return 'community'
-    } else if (rootState.route.params.hucId) {
-      return 'huc'
-    } else if (rootState.route.params.protectedAreaId) {
-      return 'protected_area'
+    } else if (rootState.route.params.areaId) {
+      let place = _.find(state.places, {
+        id: rootState.route.params.areaId,
+      })
+      if (place) {
+        return place.type
+      }
     }
+    throw 'Unknown place type!'
   },
 
   // Returns a string for the correct current selected place,
   // whether lat/lon, community name, or other regional name.
   // The code here is pretty similar between the different cases,
-  // but each has a few slight differences.
+  // but each has a few slight differences -- the point of this
+  // code is to return a "decorated" version of each place for use
+  // in titles, etc.
   name: (state, getters, rootState) => {
     // Lat/lon!
     if (getters.type == 'latLng') {
@@ -107,37 +105,36 @@ export const getters = {
       }
     }
 
-    // HUC!
-    if (getters.type == 'huc') {
-      let huc = _.find(state.places, {
-        id: rootState.route.params.hucId,
-      })
-      if (huc) {
-        return huc.name + ' Watershed HUC ' + huc.id
+    // Area types
+    let area = _.find(state.places, {
+      id: getters.areaId,
+    })
+    if (area) {
+      switch (getters.type) {
+        case 'huc':
+          return huc.name + ' Watershed HUC ' + huc.id
+        case 'corporation':
+          return area.name + ' (Native Corporation)'
+        case 'climate_division':
+          return area.name + ' (Climate Division)'
+        case 'ethnolinguistic_region':
+          return area.name + ' (Ethnolinguistic Region)'
+        case 'fire_zone':
+          return area.name + ' (Fire Management Unit)'
+        default:
+          return area.name
       }
     }
-
-    // Protected area!
-    if (getters.type == 'protected_area') {
-      let pa = _.find(state.places, {
-        id: rootState.route.params.protectedAreaId,
-      })
-      if (pa) {
-        return pa.name
-      }
-    }
-
-    // Unknown or unset or invalid.
-    return false
+    throw 'Could not determine name of place from ID.'
   },
 
   // This returns the name of the HUC without any extra stuff.
   rawHucName(state, getters, rootState) {
-    if (rootState.route.params.hucId) {
+    if (rootState.route.params.areaId) {
       let huc = _.find(state.places, {
-        id: rootState.route.params.hucId,
+        id: rootState.route.params.areaId,
       })
-      if (huc) {
+      if (huc && huc.type == 'huc') {
         return huc.name
       }
     }
@@ -146,21 +143,10 @@ export const getters = {
   // Returns a fragment URL for accessing
   // different resources on the API.
   urlFragment(state, getters) {
-    switch (getters.type) {
-      // These are the same.
-      case 'community':
-      case 'latLng':
-        return 'point/' + getters.latLng[0] + '/' + getters.latLng[1]
-        break
-      case 'huc':
-        return 'huc/' + getters.hucId
-        break
-      case 'protected_area':
-        return 'protectedarea/' + getters.protectedAreaId
-        break
-      default:
-        // Unknown.
-        return undefined
+    if (getters.type == 'community' || getters.type == 'latLng') {
+      return 'point/' + getters.latLng[0] + '/' + getters.latLng[1]
+    } else {
+      return 'area/' + getters.areaId
     }
   },
 }

--- a/utils/charts.js
+++ b/utils/charts.js
@@ -1,5 +1,6 @@
 export const getPlotSettings = function () {
   return {
+    responsive: true, // changes the height / width dynamically for charts
     displayModeBar: true, // always show the camera icon
     displaylogo: false,
     modeBarButtonsToRemove: [

--- a/utils/path.js
+++ b/utils/path.js
@@ -1,17 +1,18 @@
 export const getAppPathFragment = function (type, id) {
   let path
-  switch (type) {
-    case 'huc':
-      path = '/report/huc/' + id
-      break
-    case 'protected_area':
-      path = '/report/protected_area/' + id
-      break
-    case 'community':
-      path = '/report/community/' + id
-      break;
-    default:
-      throw "Unknown path fragment type in utils/path.js"
+  if (type == 'community') {
+    path = '/report/community/' + id
+  } else if (
+    type == 'huc' ||
+    type == 'protected_area' ||
+    type == 'corporation' ||
+    type == 'climate_division' ||
+    type == 'ethnolinguistic_region' ||
+    type == 'fire_zone'
+  ) {
+    path = '/report/area/' + id
+  } else {
+    throw 'Unknown path fragment type in utils/path.js'
   }
   return path
 }


### PR DESCRIPTION
This PR makes the Plotly graphs resize dynamically as someone changes the width of their browser window. Additionally, it hides all of the chart, tables, and associated text when the screen is less than 480px which is when a mobile phone is in portrait mode. It politely asks the user to rotate their phone into landscape mode if they want to see all of the data.

Fixes #130 