### PR TITLE
Sketch of code to change for adapting client to use /area/ 

### DIFF
--- a/components/PlaceSelector.vue
+++ b/components/PlaceSelector.vue
@@ -52,6 +52,12 @@
                 >
                   Ethnolinguistic Region
                 </span>
+                <span
+                  class="area-additional-info"
+                  v-if="props.option.type == 'fire_zone'"
+                >
+                  Fire Management Unit
+                </span>
               </div>
             </template>
           </b-autocomplete>

--- a/components/PlaceSelector.vue
+++ b/components/PlaceSelector.vue
@@ -42,6 +42,12 @@
                 </span>
                 <span
                   class="area-additional-info"
+                  v-if="props.option.type == 'corporation'"
+                >
+                  Native Corporation
+                </span>
+                <span
+                  class="area-additional-info"
                   v-if="props.option.type == 'climate_division'"
                 >
                   Climate Division

--- a/components/PlaceSelector.vue
+++ b/components/PlaceSelector.vue
@@ -28,17 +28,29 @@
             <template slot-scope="props">
               <div class="search-item">
                 {{ props.option.name }}
-                <span class="watershed" v-if="props.option.type == 'huc'"
+                <span class="area-additional-info" v-if="props.option.type == 'huc'"
                   >Watershed, HUC ID {{ props.option.id }}</span
                 >
                 <span class="alt-name" v-if="props.option.alt_name"
                   >({{ props.option.alt_name }})</span
                 >
                 <span
-                  class="protected-area"
+                  class="area-additional-info"
                   v-if="props.option.type == 'protected_area'"
                 >
                   {{ props.option.area_type }}
+                </span>
+                <span
+                  class="area-additional-info"
+                  v-if="props.option.type == 'climate_division'"
+                >
+                  Climate Division
+                </span>
+                <span
+                  class="area-additional-info"
+                  v-if="props.option.type == 'ethnolinguistic_region'"
+                >
+                  Ethnolinguistic Region
                 </span>
               </div>
             </template>
@@ -56,8 +68,7 @@
 .search-item {
   font-weight: 600;
   white-space: normal;
-  .watershed,
-  .protected-area {
+  .area-additional-info {
     text-transform: uppercase;
     display: inline-block;
     padding-left: 1ex;

--- a/components/SearchResults.vue
+++ b/components/SearchResults.vue
@@ -4,11 +4,39 @@
       Locations matching {{ lat }}&deg;N, {{ lng }}&deg;E
     </h3>
     <p>These areas of interest are at, or near, this point:</p>
-    <ul v-if="searchResults.protected_areas_near || searchResults.hucs_near">
+    <ul v-if="searchResults.protected_areas_near || searchResults.hucs_near || searchResults.corporations_near || searchResults.climate_divisions_near || searchResults.ethnolinguistic_regions_near">
+      <li
+        v-for="place in searchResults.climate_divisions_near"
+        :key="place.id"
+        class="additional-info"
+      >
+        <nuxt-link
+          :to="{
+            path: formUrl(place),
+            hash: '#results',
+          }"
+          >{{ place.name }}</nuxt-link
+        >
+        <span>Climate Division</span>
+      </li>
+      <li
+        v-for="place in searchResults.ethnolinguistic_region"
+        :key="place.id"
+        class="additional-info"
+      >
+        <nuxt-link
+          :to="{
+            path: formUrl(place),
+            hash: '#results',
+          }"
+          >{{ place.name }}</nuxt-link
+        >
+        <span>Ethnolinguistic Region</span>
+      </li>
       <li
         v-for="place in searchResults.protected_areas_near"
         :key="place.id"
-        class="protected-area"
+        class="additional-info"
       >
         <nuxt-link
           :to="{
@@ -19,7 +47,7 @@
         >
         <span>{{ place.area_type }}</span>
       </li>
-      <li v-for="huc in searchResults.hucs_near" :key="huc.id" class="huc">
+      <li v-for="huc in searchResults.hucs_near" :key="huc.id" class="additional-info">
         <nuxt-link
           :to="{
             path: formUrl(huc),
@@ -28,6 +56,20 @@
           >{{ huc.name }}</nuxt-link
         >
         <span>HUC ID {{ huc.id }}</span>
+      </li>
+      <li
+        v-for="place in searchResults.corporations_near"
+        :key="place.id"
+        class="additional-info"
+      >
+        <nuxt-link
+          :to="{
+            path: formUrl(place),
+            hash: '#results',
+          }"
+          >{{ place.name }}</nuxt-link
+        >
+        <span>Native Corporation</span>
       </li>
     </ul>
     <div v-if="searchResults.communities" class="mb-4">
@@ -74,8 +116,7 @@
   </div>
 </template>
 <style lang="scss" scoped>
-li.protected-area span,
-li.huc span {
+li.additional-info span {
   color: #888;
   text-transform: uppercase;
   font-weight: 600;

--- a/components/SearchResults.vue
+++ b/components/SearchResults.vue
@@ -71,6 +71,20 @@
         >
         <span>Native Corporation</span>
       </li>
+      <li
+        v-for="place in searchResults.fire_management_units_near"
+        :key="place.id"
+        class="additional-info"
+      >
+        <nuxt-link
+          :to="{
+            path: formUrl(place),
+            hash: '#results',
+          }"
+          >{{ place.name }}</nuxt-link
+        >
+        <span>Fire Management Unit</span>
+      </li>
     </ul>
     <div v-if="searchResults.communities" class="mb-4">
       <p>Nearby places and communities listed in this tool:</p>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -101,11 +101,7 @@ export default {
         component: resolve(__dirname, 'pages/index'),
       })
       routes.push({
-        path: '/report/huc/:hucId',
-        component: resolve(__dirname, 'pages/index'),
-      })
-      routes.push({
-        path: '/report/protected_area/:protectedAreaId',
+        path: '/report/area/:areaId',
         component: resolve(__dirname, 'pages/index'),
       })
       routes.push({

--- a/store/place.js
+++ b/store/place.js
@@ -116,7 +116,7 @@ export const getters = {
     }
 
     // Everything else!
-    if (getters.type == 'protected_area' || getters.type == 'corporation' || getters.type == 'climate_division' || getters.type == 'ethnolinguistic_region') {
+    if (getters.type == 'protected_area' || getters.type == 'corporation' || getters.type == 'climate_division' || getters.type == 'ethnolinguistic_region' || getters.type == 'fire_zone') {
       let area = _.find(state.places, {
         id: getters.areaId,
       })
@@ -124,8 +124,6 @@ export const getters = {
         return area.name
       }
     }
-
-    // Native corps, ethnolinguistic regions, etc...
 
     // Unknown or unset or invalid.
     return false

--- a/store/place.js
+++ b/store/place.js
@@ -69,9 +69,9 @@ export const getters = {
       })
       if (place) {
         return place.type
-      } 
+      }
     }
-    throw "Unknown place type!"
+    throw 'Unknown place type!'
   },
 
   // Returns a string for the correct current selected place,
@@ -105,36 +105,27 @@ export const getters = {
       }
     }
 
-    // HUC
-    if (getters.type == 'huc') {
-      let huc = _.find(state.places, {
-        id: getters.areaId,
-      })
-      if (huc) {
-        return huc.name + ' Watershed HUC ' + huc.id
+    // Area types
+    let area = _.find(state.places, {
+      id: getters.areaId,
+    })
+    if (area) {
+      switch (getters.type) {
+        case 'huc':
+          return huc.name + ' Watershed HUC ' + huc.id
+        case 'corporation':
+          return area.name + ' (Native Corporation)'
+        case 'climate_division':
+          return area.name + ' (Climate Division)'
+        case 'ethnolinguistic_region':
+          return area.name + ' (Ethnolinguistic Region)'
+        case 'fire_zone':
+          return area.name + ' (Fire Management Unit)'
+        default:
+          return area.name
       }
     }
-
-    // Protected Area
-    if (getters.type == 'protected_area' || getters.type == 'corporation' || getters.type == 'climate_division' || getters.type == 'ethnolinguistic_region' || getters.type == 'fire_zone') {
-      let area = _.find(state.places, {
-        id: getters.areaId,
-      })
-      if (area) {
-        switch(getters.type) {
-          case 'corporation':
-            return area.name + ' (Native Corporation)'
-          case 'climate_division':
-            return area.name + ' (Climate Division)'
-          case 'ethnolinguistic_region':
-            return area.name + ' (Ethnolinguistic Region)'
-          case 'fire_zone':
-            return area.name + ' (Fire Management Unit)'
-          default:
-            return area.name
-        }
-      }
-    }
+    throw 'Could not determine name of place from ID.'
   },
 
   // This returns the name of the HUC without any extra stuff.

--- a/store/place.js
+++ b/store/place.js
@@ -105,7 +105,7 @@ export const getters = {
       }
     }
 
-    // HUC!
+    // HUC
     if (getters.type == 'huc') {
       let huc = _.find(state.places, {
         id: getters.areaId,
@@ -115,18 +115,24 @@ export const getters = {
       }
     }
 
-    // Everything else!
+    // Protected Area
     if (getters.type == 'protected_area' || getters.type == 'corporation' || getters.type == 'climate_division' || getters.type == 'ethnolinguistic_region' || getters.type == 'fire_zone') {
       let area = _.find(state.places, {
         id: getters.areaId,
       })
       if (area) {
-        return area.name
+        switch(getters.type) {
+          case 'corporation':
+            return area.name + ' (Native Corporation)'
+          case 'climate_division':
+            return area.name + ' (Climate Division)'
+          case 'ethnolinguistic_region':
+            return area.name + ' (Ethnolinguistic Region)'
+          default:
+            return area.name
+        }
       }
     }
-
-    // Unknown or unset or invalid.
-    return false
   },
 
   // This returns the name of the HUC without any extra stuff.

--- a/store/place.js
+++ b/store/place.js
@@ -49,18 +49,10 @@ export const getters = {
     return false
   },
 
-  // If present, returns the HucID in the URL.
-  hucId: (state, getters, rootState) => {
-    if (rootState.route && rootState.route.params.hucId) {
-      return rootState.route.params.hucId
-    }
-    return false
-  },
-
-  // Fetch the protected area ID
-  protectedAreaId: (state, getters, rootState) => {
-    if (rootState.route.params.protectedAreaId) {
-      return rootState.route.params.protectedAreaId
+  // If present, returns the area ID from the URL.
+  areaId: (state, getters, rootState) => {
+    if (rootState.route && rootState.route.params.areaId) {
+      return rootState.route.params.areaId
     }
     return false
   },
@@ -71,17 +63,23 @@ export const getters = {
       return 'latLng'
     } else if (rootState.route.params.communityId) {
       return 'community'
-    } else if (rootState.route.params.hucId) {
-      return 'huc'
-    } else if (rootState.route.params.protectedAreaId) {
-      return 'protected_area'
+    } else if (rootState.route.params.areaId) {
+      let place = _.find(state.places, {
+        id: rootState.route.params.areaId,
+      })
+      if (place) {
+        return place.type
+      } 
     }
+    throw "Unknown place type!"
   },
 
   // Returns a string for the correct current selected place,
   // whether lat/lon, community name, or other regional name.
   // The code here is pretty similar between the different cases,
-  // but each has a few slight differences.
+  // but each has a few slight differences -- the point of this
+  // code is to return a "decorated" version of each place for use
+  // in titles, etc.
   name: (state, getters, rootState) => {
     // Lat/lon!
     if (getters.type == 'latLng') {
@@ -110,7 +108,7 @@ export const getters = {
     // HUC!
     if (getters.type == 'huc') {
       let huc = _.find(state.places, {
-        id: rootState.route.params.hucId,
+        id: getters.areaId,
       })
       if (huc) {
         return huc.name + ' Watershed HUC ' + huc.id
@@ -120,12 +118,14 @@ export const getters = {
     // Protected area!
     if (getters.type == 'protected_area') {
       let pa = _.find(state.places, {
-        id: rootState.route.params.protectedAreaId,
+        id: getters.areaId,
       })
       if (pa) {
         return pa.name
       }
     }
+
+    // Native corps, ethnolinguistic regions, etc...
 
     // Unknown or unset or invalid.
     return false
@@ -133,11 +133,11 @@ export const getters = {
 
   // This returns the name of the HUC without any extra stuff.
   rawHucName(state, getters, rootState) {
-    if (rootState.route.params.hucId) {
+    if (rootState.route.params.areaId) {
       let huc = _.find(state.places, {
-        id: rootState.route.params.hucId,
+        id: rootState.route.params.areaId,
       })
-      if (huc) {
+      if (huc && huc.type == 'huc') {
         return huc.name
       }
     }
@@ -152,11 +152,8 @@ export const getters = {
       case 'latLng':
         return 'point/' + getters.latLng[0] + '/' + getters.latLng[1]
         break
-      case 'huc':
-        return 'huc/' + getters.hucId
-        break
-      case 'protected_area':
-        return 'protectedarea/' + getters.protectedAreaId
+      case 'area':
+        return 'area/' + getters.areaId
         break
       default:
         // Unknown.

--- a/store/place.js
+++ b/store/place.js
@@ -115,13 +115,13 @@ export const getters = {
       }
     }
 
-    // Protected area!
-    if (getters.type == 'protected_area') {
-      let pa = _.find(state.places, {
+    // Everything else!
+    if (getters.type == 'protected_area' || getters.type == 'corporation' || getters.type == 'climate_division' || getters.type == 'ethnolinguistic_region') {
+      let area = _.find(state.places, {
         id: getters.areaId,
       })
-      if (pa) {
-        return pa.name
+      if (area) {
+        return area.name
       }
     }
 
@@ -146,18 +146,10 @@ export const getters = {
   // Returns a fragment URL for accessing
   // different resources on the API.
   urlFragment(state, getters) {
-    switch (getters.type) {
-      // These are the same.
-      case 'community':
-      case 'latLng':
-        return 'point/' + getters.latLng[0] + '/' + getters.latLng[1]
-        break
-      case 'area':
-        return 'area/' + getters.areaId
-        break
-      default:
-        // Unknown.
-        return undefined
+    if (getters.type == 'community' || getters.type == 'latLng') {
+      return 'point/' + getters.latLng[0] + '/' + getters.latLng[1]
+    } else {
+      return 'area/' + getters.areaId
     }
   },
 }

--- a/store/place.js
+++ b/store/place.js
@@ -128,6 +128,8 @@ export const getters = {
             return area.name + ' (Climate Division)'
           case 'ethnolinguistic_region':
             return area.name + ' (Ethnolinguistic Region)'
+          case 'fire_zone':
+            return area.name + ' (Fire Management Unit)'
           default:
             return area.name
         }

--- a/utils/path.js
+++ b/utils/path.js
@@ -2,10 +2,17 @@ export const getAppPathFragment = function (type, id) {
   let path
   if (type == 'community') {
     path = '/report/community/' + id
-  } else if (type =='huc' || type == 'protected_area' || type == 'corporation' || type == 'climate_division' || type == 'ethnolinguistic_region' || type == 'fire_zone') {
+  } else if (
+    type == 'huc' ||
+    type == 'protected_area' ||
+    type == 'corporation' ||
+    type == 'climate_division' ||
+    type == 'ethnolinguistic_region' ||
+    type == 'fire_zone'
+  ) {
     path = '/report/area/' + id
   } else {
-    throw "Unknown path fragment type in utils/path.js"
+    throw 'Unknown path fragment type in utils/path.js'
   }
   return path
 }

--- a/utils/path.js
+++ b/utils/path.js
@@ -1,27 +1,11 @@
 export const getAppPathFragment = function (type, id) {
   let path
-  console.log(path)
-  switch (type) {
-    case 'huc':
-      path = '/report/area/' + id
-      break
-    case 'protected_area':
-      path = '/report/area/' + id
-      break
-    case 'corporation':
-      path = '/report/area/' + id
-      break
-    case 'climate_division':
-      path = '/report/area/' + id
-      break
-    case 'ethnolinguistic_region':
-      path = '/report/area/' + id
-      break
-    case 'community':
-      path = '/report/community/' + id
-      break;
-    default:
-      throw "Unknown path fragment type in utils/path.js"
+  if (type == 'community') {
+    path = '/report/community/' + id
+  } else if (type =='huc' || type == 'protected_area' || type == 'corporation' || type == 'climate_division' || type == 'ethnolinguistic_region') {
+    path = '/report/area/' + id
+  } else {
+    throw "Unknown path fragment type in utils/path.js"
   }
   return path
 }

--- a/utils/path.js
+++ b/utils/path.js
@@ -1,11 +1,21 @@
 export const getAppPathFragment = function (type, id) {
   let path
+  console.log(path)
   switch (type) {
     case 'huc':
-      path = '/report/huc/' + id
+      path = '/report/area/' + id
       break
     case 'protected_area':
-      path = '/report/protected_area/' + id
+      path = '/report/area/' + id
+      break
+    case 'corporation':
+      path = '/report/area/' + id
+      break
+    case 'climate_division':
+      path = '/report/area/' + id
+      break
+    case 'ethnolinguistic_region':
+      path = '/report/area/' + id
       break
     case 'community':
       path = '/report/community/' + id

--- a/utils/path.js
+++ b/utils/path.js
@@ -2,7 +2,7 @@ export const getAppPathFragment = function (type, id) {
   let path
   if (type == 'community') {
     path = '/report/community/' + id
-  } else if (type =='huc' || type == 'protected_area' || type == 'corporation' || type == 'climate_division' || type == 'ethnolinguistic_region') {
+  } else if (type =='huc' || type == 'protected_area' || type == 'corporation' || type == 'climate_division' || type == 'ethnolinguistic_region' || type == 'fire_zone') {
     path = '/report/area/' + id
   } else {
     throw "Unknown path fragment type in utils/path.js"


### PR DESCRIPTION
This PR modifies the underlying code that communicates with the backend API to combine all different polygon requests into the new /area endpoint on the API. In addition, it adds all native corporations, climate divisions, and ethnolinguistic regions to the search results for both the search bar + search by clicking on the map.

Resolves #152 