### PR TITLE
Add CSV download buttons to each section of report page

### DIFF
--- a/components/Report.vue
+++ b/components/Report.vue
@@ -225,8 +225,6 @@
           >
         </div>
       </section>
-      <DownloadCsvButton />
-      <BackToTopButton />
       <hr />
       <div class="back">
         <b-button

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -14,7 +14,9 @@
     <hr />
     <section v-if="$fetchState.pending" class="section content">
       <!-- Drama dots -->
-      <h4 class="title is-5">Loading data for <span v-html=place />&hellip;</h4>
+      <h4 class="title is-5">
+        Loading data for <span v-html="place" />&hellip;
+      </h4>
       <b-progress type="is-info"></b-progress>
     </section>
     <section v-else-if="$fetchState.error" class="section content error">
@@ -211,7 +213,6 @@
         </div>
         <BackToTopButton />
       </section>
-      <DownloadCsvButton />
       <BackToTopButton />
       <hr />
       <div class="back">
@@ -261,7 +262,6 @@ import PermafrostReport from '~/components/reports/permafrost/PermafrostReport'
 import WildfireReport from '~/components/reports/wildfire/WildfireReport'
 import MiniMap from '~/components/reports/MiniMap'
 import QualitativeText from '~/components/reports/QualitativeText'
-import DownloadCsvButton from '~/components/reports/DownloadCsvButton'
 import BackToTopButton from '~/components/reports/BackToTopButton'
 import { mapGetters } from 'vuex'
 import { httpErrors } from '../utils/http_errors'
@@ -279,7 +279,6 @@ export default {
     WildfireReport,
     MiniMap,
     QualitativeText,
-    DownloadCsvButton,
     BackToTopButton,
   },
   data() {

--- a/components/reports/DownloadCsvButton.vue
+++ b/components/reports/DownloadCsvButton.vue
@@ -1,18 +1,34 @@
 <template>
-  <a :href="downloadTarget" class="button is-primary">Download data as CSV</a>
+  <a :href="downloadTarget" class="button is-primary">{{ text }}</a>
 </template>
 <style lang="scss" scoped></style>
 <script>
 export default {
   name: 'DownloadCsvButton',
+  props: ['text', 'endpoint'],
   computed: {
     downloadTarget() {
-      return (
+      let endpointPath = this.endpoint
+      if (this.endpoint == 'flammability' || this.endpoint == 'veg_change') {
+        endpointPath = 'alfresco/' + endpointPath
+      }
+
+      let url =
         process.env.apiUrl +
-        '/taspr/' +
+        '/' +
+        endpointPath +
+        '/' +
         this.$store.getters['place/urlFragment'] +
         '?format=csv'
-      )
+
+      if (this.$store.getters['place/type'] == 'community') {
+        let communityId = this.$store.getters['place/communityId']
+        if (communityId != false) {
+          url += '&community=' + communityId
+        }
+      }
+
+      return url
     },
   },
 }

--- a/components/reports/DownloadCsvButton.vue
+++ b/components/reports/DownloadCsvButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <a :href="downloadTarget" class="button is-primary">{{ text }}</a>
+  <a :href="downloadTarget" class="button is-info">{{ text }}</a>
 </template>
 <style lang="scss" scoped></style>
 <script>

--- a/components/reports/permafrost/PermafrostReport.vue
+++ b/components/reports/permafrost/PermafrostReport.vue
@@ -105,6 +105,11 @@
       <div class="chart" v-show="this.permafrostUncertain">
         <ReportMagtChart />
       </div>
+      <DownloadCsvButton
+        text="Download permafrost data as CSV"
+        endpoint="permafrost"
+        class="mt-3 mb-5"
+      />
     </div>
     <div v-else>
       <div class="content">
@@ -129,6 +134,7 @@ import ReportAltThawChart from './ReportAltThawChart'
 import ReportAltFreezeChart from './ReportAltFreezeChart'
 import ReportMagtChart from './ReportMagtChart'
 import BackToTopButton from '~/components/reports/BackToTopButton'
+import DownloadCsvButton from '~/components/reports/DownloadCsvButton'
 import { mapGetters } from 'vuex'
 
 export default {
@@ -139,6 +145,7 @@ export default {
     ReportAltFreezeChart,
     ReportMagtChart,
     BackToTopButton,
+    DownloadCsvButton,
   },
   computed: {
     // The range of uncertainty, within 1ºC of freezing.

--- a/components/reports/precipitation/ReportPrecipTable.vue
+++ b/components/reports/precipitation/ReportPrecipTable.vue
@@ -481,6 +481,11 @@
         </tr>
       </tfoot>
     </table>
+    <DownloadCsvButton
+      text="Download precipitation data as CSV"
+      endpoint="precipitation"
+      class="mt-3 mb-5"
+    />
   </div>
 </template>
 <style lang="scss" scoped>
@@ -489,10 +494,11 @@
 <script>
 import UnitWidget from '~/components/UnitWidget'
 import PrecipDiffWidget from './PrecipDiffWidget'
+import DownloadCsvButton from '~/components/reports/DownloadCsvButton'
 import { mapGetters } from 'vuex'
 export default {
   name: 'PrecipReportTable',
-  components: { PrecipDiffWidget, UnitWidget },
+  components: { PrecipDiffWidget, UnitWidget, DownloadCsvButton },
   computed: {
     ...mapGetters({
       reportData: 'climate/climateData',

--- a/components/reports/temperature/TempReport.vue
+++ b/components/reports/temperature/TempReport.vue
@@ -33,6 +33,11 @@
     </div>
     <ReportTempChart :season="temp_season" />
     <ReportTempTable />
+    <DownloadCsvButton
+      text="Download temperature data as CSV"
+      endpoint="temperature"
+      class="mt-3 mb-5"
+    />
     <BackToTopButton />
   </div>
 </template>
@@ -41,10 +46,16 @@
 import ReportTempChart from './ReportTempChart'
 import ReportTempTable from './ReportTempTable'
 import BackToTopButton from '~/components/reports/BackToTopButton'
+import DownloadCsvButton from '~/components/reports/DownloadCsvButton'
 import { mapGetters } from 'vuex'
 export default {
   name: 'ReportTable',
-  components: { ReportTempChart, ReportTempTable, BackToTopButton },
+  components: {
+    ReportTempChart,
+    ReportTempTable,
+    BackToTopButton,
+    DownloadCsvButton,
+  },
   data() {
     return {
       temp_season: 'DJF',

--- a/components/reports/wildfire/WildfireReport.vue
+++ b/components/reports/wildfire/WildfireReport.vue
@@ -18,10 +18,20 @@
     <div class="chart-wrapper">
       <ReportFlammabilityChart />
     </div>
+    <DownloadCsvButton
+      text="Download flammability data as CSV"
+      endpoint="flammability"
+      class="mt-3 mb-5"
+    />
     <ReportVegChangeMaps />
     <div class="chart-wrapper">
       <ReportVegChangeChart />
     </div>
+    <DownloadCsvButton
+      text="Download vegetation change data as CSV"
+      endpoint="veg_change"
+      class="mt-3 mb-5"
+    />
   </div>
 </template>
 <style></style>
@@ -30,6 +40,7 @@ import ReportFlammabilityMaps from './ReportFlammabilityMaps'
 import ReportFlammabilityChart from './ReportFlammabilityChart'
 import ReportVegChangeMaps from './ReportVegChangeMaps'
 import ReportVegChangeChart from './ReportVegChangeChart'
+import DownloadCsvButton from '~/components/reports/DownloadCsvButton'
 import { mapGetters } from 'vuex'
 
 export default {
@@ -39,6 +50,7 @@ export default {
     ReportFlammabilityChart,
     ReportVegChangeMaps,
     ReportVegChangeChart,
+    DownloadCsvButton,
   },
 }
 </script>

--- a/store/place.js
+++ b/store/place.js
@@ -49,6 +49,14 @@ export const getters = {
     return false
   },
 
+  // If present, returns the community ID in the URL.
+  communityId: (state, getters, rootState) => {
+    if (rootState.route && rootState.route.params.communityId) {
+      return rootState.route.params.communityId
+    }
+    return false
+  },
+
   // If present, returns the HucID in the URL.
   hucId: (state, getters, rootState) => {
     if (rootState.route && rootState.route.params.hucId) {


### PR DESCRIPTION
Closes #62.
Closes #69.
Closes #118.
Closes #169.
Closes #244.

This PR depends on the `csvs_for_iem_webapp` branch of the data-api.

To test, run the data-api like this:

```
git checkout csvs_for_iem_webapp
export WEB_APP_URL=http://localhost:3000/
pipenv run flask run
```

And run the iem-webapp like this:

```
git checkout csv_improvements
export SNAP_API_URL=http://localhost:5000
npm run dev
```

Visit the iem-web app at http://localhost:3000 and load a report for each of the following:
- A lat/lon point (not a pre-defined community)
- A community
- A HUC
- A protected area
- A fire management unit
- A corporation
- A climate division
- An ethnolinguistic region

For each of the types of report above, verify that there is a CSV download button for each of the following types of data (if such data is displayed on the report page):

- Temperature
- Precipitation
- Permafrost
- Flammability
- Vegetation change

Load each of the CSV downloads into a spreadsheet application and verify that the metadata, columns, and values make sense. Also verify that the filename of each CSV file is named after the corresponding place name.

I did some research and there appears to be no standard way to add metadata/comments to a CSV file. Currently, metadata is added as lines starting with "#" at the beginning of the CSV.