### PR TITLE
Prevent non-visible wildfire data from blocking negative y-axis chart fix

### DIFF
--- a/components/reports/wildfire/ReportFlammabilityChart.vue
+++ b/components/reports/wildfire/ReportFlammabilityChart.vue
@@ -65,7 +65,7 @@ export default {
 
       // Prevent all-zero charts from showing negative y-axis.
       // Subtract a small buffer from 0 value to avoid cropping scatter marker.
-      if (allZeros(flammabilityData)) {
+      if (allZeros(flammabilityData, 'rf')) {
         layout['yaxis']['range'] = [-0.1, 2]
       }
 

--- a/components/reports/wildfire/ReportVegChangeChart.vue
+++ b/components/reports/wildfire/ReportVegChangeChart.vue
@@ -62,7 +62,7 @@ export default {
 
       // Prevent all-zero charts from showing negative y-axis.
       // Subtract a small buffer from 0 value to avoid cropping scatter marker.
-      if (allZeros(vegChangeData)) {
+      if (allZeros(vegChangeData, 'rvc')) {
         layout['yaxis']['range'] = [-0.1, 2]
       }
 

--- a/utils/wildfire_charts.js
+++ b/utils/wildfire_charts.js
@@ -160,16 +160,20 @@ export const getProjectedTraces = function (data, variable, plotType = 'box') {
   return projectedTraces
 }
 
-export const allZeros = function (data) {
-  let allValues = []
-  _.eachDeep(
-    data,
-    (value, key) => {
-      allValues.push(parseFloat(value))
-    },
-    {
-      leavesOnly: true,
-    }
-  )
-  return allValues.every(value => value == 0)
+export const allZeros = function (data, variable) {
+  let displayedValues = []
+
+  historicalDecades.forEach(decade => {
+    displayedValues.push(data[decade]['CRU-TS40']['CRU_historical'][variable])
+  })
+
+  projectedEras.forEach(era => {
+    models.forEach(model => {
+      scenarios.forEach(scenario => {
+        displayedValues.push(data[era][model][scenario][variable])
+      })
+    })
+  })
+
+  return displayedValues.every(value => value == 0)
 }


### PR DESCRIPTION
Closes #214.

We had previous implemented a fix to prevent the wildfire charts from showing a negative y-axis range when all of the chart data was zero. This fix did not take into account that we are hiding some of the available wildfire data (the models we have decided not to show on the charts). If any one of the invisible data points was non-zero, it prevented our fix from taking effect.

This PR fixes this problem by scanning only the visible wildfire data for non-zero values.

Here is a report that exhibits this bug for before & after testing:
http://localhost:3000/report/69.71/-154.53