### PR TITLE
Fix y-axis annotation positioning of permafrost thaw/freeze charts

### DIFF
--- a/components/reports/permafrost/ReportAltFreezeChart.vue
+++ b/components/reports/permafrost/ReportAltFreezeChart.vue
@@ -75,9 +75,9 @@ export default {
 
       let yAxisAnnotationX
       if (window.innerWidth < 1250) {
-        yAxisAnnotationX = -0.06
+        yAxisAnnotationX = -0.07
       } else {
-        yAxisAnnotationX = -0.04
+        yAxisAnnotationX = -0.06
       }
 
       layout.annotations.push({

--- a/components/reports/permafrost/ReportAltThawChart.vue
+++ b/components/reports/permafrost/ReportAltThawChart.vue
@@ -76,14 +76,14 @@ export default {
 
       let yAxisAnnotationX
       if (window.innerWidth < 1250) {
-        yAxisAnnotationX = -0.06
+        yAxisAnnotationX = -0.07
       } else {
-        yAxisAnnotationX = -0.04
+        yAxisAnnotationX = -0.06
       }
 
       layout.annotations.push({
         x: yAxisAnnotationX,
-        y: 0.14,
+        y: 0.07,
         xref: 'paper',
         yref: 'paper',
         showarrow: true,


### PR DESCRIPTION
Closes #164.

To test, the following URL's ground freeze chart has a y-axis annotation that overlaps the y-axis tick labels slightly at wide browser resolutions on the `main` branch:

http://localhost:3000/report/62.83/-151.18#results

This PR prevents the overlap by adjusting the y-axis annotation positioning slightly.