### PR TITLE
Add a legend below permafrost MAGT mini-maps

### DIFF
--- a/components/reports/permafrost/ReportAltFreezeChart.vue
+++ b/components/reports/permafrost/ReportAltFreezeChart.vue
@@ -75,9 +75,9 @@ export default {
 
       let yAxisAnnotationX
       if (window.innerWidth < 1250) {
-        yAxisAnnotationX = -0.06
+        yAxisAnnotationX = -0.07
       } else {
-        yAxisAnnotationX = -0.04
+        yAxisAnnotationX = -0.06
       }
 
       layout.annotations.push({

--- a/components/reports/permafrost/ReportAltThawChart.vue
+++ b/components/reports/permafrost/ReportAltThawChart.vue
@@ -76,14 +76,14 @@ export default {
 
       let yAxisAnnotationX
       if (window.innerWidth < 1250) {
-        yAxisAnnotationX = -0.06
+        yAxisAnnotationX = -0.07
       } else {
-        yAxisAnnotationX = -0.04
+        yAxisAnnotationX = -0.06
       }
 
       layout.annotations.push({
         x: yAxisAnnotationX,
-        y: 0.14,
+        y: 0.07,
         xref: 'paper',
         yref: 'paper',
         showarrow: true,

--- a/components/reports/permafrost/ReportMagtMaps.vue
+++ b/components/reports/permafrost/ReportMagtMaps.vue
@@ -83,6 +83,29 @@
         />
       </div>
     </div>
+    <table class="magt-legend">
+      <tbody>
+        <tr>
+          <td class="legend-20-below px-2">
+            <span class="is-pulled-left">
+              <span v-html="legendRedMin"></span>
+            </span>
+            <span class="is-pulled-right">
+              <span v-html="legendRedMax"></span>
+            </span>
+          </td>
+          <td class="legend-0 has-text-centered">0</td>
+          <td class="legend-20-above px-2">
+            <span class="is-pulled-left">
+              <span v-html="legendBlueMin"></span>
+            </span>
+            <span class="is-pulled-right">
+              <span v-html="legendBlueMax"></span>
+            </span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </section>
 </template>
 
@@ -97,6 +120,27 @@
   width: 20%;
   margin: 5px;
 }
+.magt-legend {
+  width: 700px;
+  border: 1px solid #999;
+  margin: 40px auto 0 auto;
+  font-weight: 700;
+  color: #fff;
+  text-shadow: 0 0 3px #000;
+  .legend-20-below {
+    width: 47.5%;
+    background: linear-gradient(90deg, #0000ffff 0%, #a0a0ffff 100%);
+  }
+  .legend-0 {
+    color: #000;
+    text-shadow: none;
+    width: 5%;
+  }
+  .legend-20-above {
+    width: 47.5%;
+    background: linear-gradient(90deg, #ffa0a0ff 0%, #ff0000ff 100%);
+  }
+}
 </style>
 
 <script>
@@ -109,8 +153,21 @@ export default {
   },
   computed: {
     ...mapGetters({
+      units: 'units',
       place: 'place/name',
     }),
+    legendRedMin() {
+      return this.units == 'imperial' ? '-4&deg;F' : '-20&deg;C'
+    },
+    legendRedMax() {
+      return this.units == 'imperial' ? '30.2&deg;F' : '-1&deg;C'
+    },
+    legendBlueMin() {
+      return this.units == 'imperial' ? '33.8&deg;F' : '1&deg;C'
+    },
+    legendBlueMax() {
+      return this.units == 'imperial' ? '68&deg;F' : '20&deg;C'
+    },
   },
   data() {
     return {


### PR DESCRIPTION
Closes #193.

This PR adds a legend below the permafrost MAGT mini-maps. This legend was implemented using HTML and CSS, similar to a legend on the Historical Sea Ice Atlas. The legend is proportional to the MAGT mini-map color maps, including the pure white +/- 1 degree Celsius "uncertainty threshold" between the blue and red gradients. The legend also adapts to the user's selection of imperial or metric units.

I've given the legend a fixed pixel width of 700px, but this shouldn't be a problem if we do end up showing only the report's qualitative text at narrow browser resolutions like we had discussed.

To test, load a report with visible permafrost MAGT mini-maps. You should see the legend below the maps. Try switching between imperial and metric units near the top of the report page to verify that the legend converts properly.