### PR TITLE
Make API HTTP error messages more user friendly and descriptive

### DIFF
--- a/utils/http_errors.js
+++ b/utils/http_errors.js
@@ -1,9 +1,10 @@
 export let httpErrors = {
-  bad_request: 'Bad request',
+  bad_request: 'Data request was not understood',
   no_data: 'No data at this location',
-  invalid_coordinates: 'Invalid coordinates',
-  timeout: 'Server timeout',
-  server_error: 'Server error',
+  invalid_coordinates:
+    'Provided coordinates or area are not included in coverage',
+  timeout: 'Data request timed out',
+  server_error: 'A problem occurred while requesting data',
 }
 
 export const getHttpError = function (error) {


### PR DESCRIPTION
Closes #142.

This PR improves the error messages shown to the user when API HTTP requests fail. The goal is to make the error messages sound less technical and convey more information that is relevant to the user, but the error messages can only be as descriptive as the HTTP error codes received from the API.