### PR TITLE
Hide permafrost section for locations that have no permafrost data & bad MAGT mini-maps

### DIFF
--- a/components/Report.vue
+++ b/components/Report.vue
@@ -426,11 +426,8 @@ export default {
     },
     validPermafrost() {
       // Hide permafrost section for locations known to have bad MAGT maps.
-      let badMagtMapIds = ['19030103', 'AK26']
-      if (
-        badMagtMapIds.indexOf(this.hucId) != -1 ||
-        badMagtMapIds.indexOf(this.communityId) != -1
-      ) {
+      let badMagtMapAreas = ['19030103']
+      if (badMagtMapAreas.indexOf(this.hucId) != -1) {
         return false
       }
 

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -184,7 +184,7 @@
                 <span v-if="permafrostHttpError && type == 'latLng'">{{
                   httpErrors[permafrostHttpError]
                 }}</span>
-                <span v-if="!showPermafrost">
+                <span v-else-if="!showPermafrost">
                   {{ httpErrors['no_data'] }}
                 </span>
               </li>
@@ -435,7 +435,10 @@ export default {
       }
 
       // Always show the permafrost section for area reports.
-      if (this.permafrostData || this.type != 'latLng') {
+      if (
+        this.permafrostData ||
+        (this.type != 'latLng' && this.type != 'community')
+      ) {
         return true
       }
 

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -350,6 +350,7 @@ export default {
     ...mapGetters({
       place: 'place/name',
       type: 'place/type',
+      communityId: 'place/communityId',
       hucId: 'place/hucId',
       elevation: 'elevation/elevation',
       climateData: 'climate/climateData',
@@ -424,14 +425,20 @@ export default {
       return string
     },
     validPermafrost() {
-      let badMagtMapAreas = ['19030103']
+      // Hide permafrost section for locations known to have bad MAGT maps.
+      let badMagtMapIds = ['19030103', 'AK26']
+      if (
+        badMagtMapIds.indexOf(this.hucId) != -1 ||
+        badMagtMapIds.indexOf(this.communityId) != -1
+      ) {
+        return false
+      }
+
       // Always show the permafrost section for area reports.
       if (this.permafrostData || this.type != 'latLng') {
-        // Except for area IDs known to have bad MAGT mini-maps.
-        if (badMagtMapAreas.indexOf(this.hucId) == -1) {
-          return true
-        }
+        return true
       }
+
       return false
     },
   },

--- a/store/place.js
+++ b/store/place.js
@@ -49,6 +49,14 @@ export const getters = {
     return false
   },
 
+  // If present, returns the community ID in the URL.
+  communityId: (state, getters, rootState) => {
+    if (rootState.route && rootState.route.params.communityId) {
+      return rootState.route.params.communityId
+    }
+    return false
+  },
+
   // If present, returns the HucID in the URL.
   hucId: (state, getters, rootState) => {
     if (rootState.route && rootState.route.params.hucId) {


### PR DESCRIPTION
Resolves #252.

In a previous PR, we started showing MAGT mini-maps for all polygonal area reports since we do not query the permafrost data API for areas, and we can assume nearly all pre-defined areas have permafrost data to show on mini-maps. However, the following locations were showing MAGT mini-maps despite having no data to show:

- HUC 19030103
- Attu (AK26) - This was due to a bug that was treating communities as areas.

This PR allows us to hide MAGT mini-maps (and thus the entire Permafrost section) for HUC IDs known to have no permafrost data. Currently there is only one HUC ID in this list (19030103), but we can add more later if needed. I spent a few minutes loading HUC reports around random islands and none of the others were as bad as HUC 19030103.

The bug that was treating communities as areas has also been fixed, which fixes Attu (AK26).