### PR TITLE
Add Natural Earth layers to permafrost, flammability, and vegetation change mini-maps

### DIFF
--- a/components/reports/permafrost/ReportMagtMap.vue
+++ b/components/reports/permafrost/ReportMagtMap.vue
@@ -15,7 +15,7 @@
 <script>
 import _ from 'lodash'
 import { mapGetters } from 'vuex'
-import { getBaseMapAndLayers, addGeoJSONtoMap } from '../../../utils/maps'
+import { getBaseMapAndLayers, addGeoJSONtoMap } from '~/utils/maps'
 
 let scenarios = ['', 'RCP 4.5', 'RCP 8.5']
 let eras = ['1995', '2011-2040', '2036-2065', '2061–2090', '2086–2100']
@@ -61,6 +61,7 @@ export default {
       this.map.removeLayer(this.baseLayer)
       this.baseLayer = this.getBaseLayer()
       this.map.addLayer(this.baseLayer)
+      this.baseLayer.bringToBack()
     },
     // After geoJSON is loaded, display on map.
     geoJSON: function () {

--- a/utils/maps.js
+++ b/utils/maps.js
@@ -8,6 +8,41 @@ export const getBaseMapAndLayers = function () {
     }
   )
   this.baseLayer = this.getBaseLayer()
+  let coastline = new L.tileLayer.wms(process.env.geoserverUrl, {
+    transparent: true,
+    format: 'image/png',
+    layers: 'natural_earth:ne_10m_coastline',
+    styles: 'natural_earth:iem_line',
+  })
+
+  let rivers = new L.tileLayer.wms(process.env.geoserverUrl, {
+    transparent: true,
+    format: 'image/png',
+    layers: 'natural_earth:ne_10m_rivers_lake_centerlines',
+    styles: 'natural_earth:iem_line',
+  })
+
+  let lakes = new L.tileLayer.wms(process.env.geoserverUrl, {
+    transparent: true,
+    format: 'image/png',
+    layers: 'natural_earth:ne_10m_lakes',
+    styles: 'natural_earth:iem_polygon',
+  })
+
+  let roads = new L.tileLayer.wms(process.env.geoserverUrl, {
+    transparent: true,
+    format: 'image/png',
+    layers: 'natural_earth:ne_10m_roads',
+    styles: 'natural_earth:iem_line',
+  })
+
+  let places = new L.tileLayer.wms(process.env.geoserverUrl, {
+    transparent: true,
+    format: 'image/png',
+    layers: 'natural_earth:ne_10m_populated_places',
+    styles: 'natural_earth:iem_place',
+  })
+
   // Map base configuration
   var config = {
     zoom: 1,
@@ -19,7 +54,7 @@ export const getBaseMapAndLayers = function () {
     zoomControl: false,
     doubleClickZoom: false,
     attributionControl: false,
-    layers: [this.baseLayer],
+    layers: [this.baseLayer, coastline, rivers, lakes, roads, places],
     crs: proj,
   }
   return config

--- a/utils/maps.js
+++ b/utils/maps.js
@@ -8,39 +8,10 @@ export const getBaseMapAndLayers = function () {
     }
   )
   this.baseLayer = this.getBaseLayer()
-  let coastline = new L.tileLayer.wms(process.env.geoserverUrl, {
+  let naturalEarth = new L.tileLayer.wms(process.env.geoserverUrl, {
     transparent: true,
     format: 'image/png',
-    layers: 'natural_earth:ne_10m_coastline',
-    styles: 'natural_earth:iem_line',
-  })
-
-  let rivers = new L.tileLayer.wms(process.env.geoserverUrl, {
-    transparent: true,
-    format: 'image/png',
-    layers: 'natural_earth:ne_10m_rivers_lake_centerlines',
-    styles: 'natural_earth:iem_line',
-  })
-
-  let lakes = new L.tileLayer.wms(process.env.geoserverUrl, {
-    transparent: true,
-    format: 'image/png',
-    layers: 'natural_earth:ne_10m_lakes',
-    styles: 'natural_earth:iem_polygon',
-  })
-
-  let roads = new L.tileLayer.wms(process.env.geoserverUrl, {
-    transparent: true,
-    format: 'image/png',
-    layers: 'natural_earth:ne_10m_roads',
-    styles: 'natural_earth:iem_line',
-  })
-
-  let places = new L.tileLayer.wms(process.env.geoserverUrl, {
-    transparent: true,
-    format: 'image/png',
-    layers: 'natural_earth:ne_10m_populated_places',
-    styles: 'natural_earth:iem_place',
+    layers: 'natural_earth:iem-natural-earth',
   })
 
   // Map base configuration
@@ -54,7 +25,7 @@ export const getBaseMapAndLayers = function () {
     zoomControl: false,
     doubleClickZoom: false,
     attributionControl: false,
-    layers: [this.baseLayer, coastline, rivers, lakes, roads, places],
+    layers: [this.baseLayer, naturalEarth],
     crs: proj,
   }
   return config


### PR DESCRIPTION
Closes #249 
Xref: #201.

This PR adds a layer group overtop the permafrost MAGT, flammability, and vegetation change mini-maps with the following Natural Earth sublayers:

- Coastline
- Rivers & lake centerlines
- Lakes & reservoirs
- Roads
- Populated places (currently styled to show only places with a max population of 10,000+)

Sublayers are styled like this currenty:

- Coastline: Line with 0.5px width and color #555555.
- Rivers & lake centerlines: Line with 1.0px width and color #555555.
- Roads: Line with 1.0px width and color #555555.
- Lakes & reservoirs: Polygons with no stroke line, just a #555555 fill color.
- Populated places: Only places with a population of 10,000+, width a circle marker offset from the label by 8 pixels horizontally. Color #000000.