### PR TITLE
Corrects a few map search result behaviors

### DIFF
--- a/components/MapWrapper.vue
+++ b/components/MapWrapper.vue
@@ -103,6 +103,7 @@ export default {
 				} else if (e.statusCode == 404) {
 					throw 'No results were found for this place.'
 				} else {
+					console.error(e) // at least get the error in the console.
 					throw 'Something unexpected went wrong.'
 				}
 			})

--- a/components/PlaceSelector.vue
+++ b/components/PlaceSelector.vue
@@ -85,6 +85,7 @@
     display: inline-block;
     padding-left: 1ex;
     color: #888;
+    font-size: 90%;
   }
 }
 </style>

--- a/components/SearchResults.vue
+++ b/components/SearchResults.vue
@@ -3,91 +3,38 @@
     <h3 class="title is-4">
       Locations matching {{ lat }}&deg;N, {{ lng }}&deg;E
     </h3>
-    <p>These areas of interest are at, or near, this point:</p>
-    <ul v-if="searchResults.protected_areas_near || searchResults.hucs_near || searchResults.corporations_near || searchResults.climate_divisions_near || searchResults.ethnolinguistic_regions_near">
-      <li
-        v-for="place in searchResults.climate_divisions_near"
-        :key="place.id"
-        class="additional-info"
-      >
-        <nuxt-link
-          :to="{
-            path: formUrl(place),
-            hash: '#results',
-          }"
-          >{{ place.name }}</nuxt-link
+
+    <div v-if="searchResults.areas">
+      <p>
+        The map on the left shows hydrological units (HUC-8) and protected areas
+        near the point you selected. Additional areas of interest
+        (ethnolinguistic regions, fire management units, climate divisions and
+        Native corporations) are not shown on the map because they are large,
+        but are included in the list of matching areas below.
+      </p>
+
+      <ul>
+        <li
+          v-for="place in searchResults.areas"
+          :key="place.id"
+          class="additional-info"
         >
-        <span>Climate Division</span>
-      </li>
-      <li
-        v-for="place in searchResults.ethnolinguistic_region"
-        :key="place.id"
-        class="additional-info"
-      >
-        <nuxt-link
-          :to="{
-            path: formUrl(place),
-            hash: '#results',
-          }"
-          >{{ place.name }}</nuxt-link
-        >
-        <span>Ethnolinguistic Region</span>
-      </li>
-      <li
-        v-for="place in searchResults.protected_areas_near"
-        :key="place.id"
-        class="additional-info"
-      >
-        <nuxt-link
-          :to="{
-            path: formUrl(place),
-            hash: '#results',
-          }"
-          >{{ place.name }}</nuxt-link
-        >
-        <span>{{ place.area_type }}</span>
-      </li>
-      <li v-for="huc in searchResults.hucs_near" :key="huc.id" class="additional-info">
-        <nuxt-link
-          :to="{
-            path: formUrl(huc),
-            hash: '#results',
-          }"
-          >{{ huc.name }}</nuxt-link
-        >
-        <span>HUC ID {{ huc.id }}</span>
-      </li>
-      <li
-        v-for="place in searchResults.corporations_near"
-        :key="place.id"
-        class="additional-info"
-      >
-        <nuxt-link
-          :to="{
-            path: formUrl(place),
-            hash: '#results',
-          }"
-          >{{ place.name }}</nuxt-link
-        >
-        <span>Native Corporation</span>
-      </li>
-      <li
-        v-for="place in searchResults.fire_management_units_near"
-        :key="place.id"
-        class="additional-info"
-      >
-        <nuxt-link
-          :to="{
-            path: formUrl(place),
-            hash: '#results',
-          }"
-          >{{ place.name }}</nuxt-link
-        >
-        <span>Fire Management Unit</span>
-      </li>
-    </ul>
-    <div v-if="searchResults.communities" class="mb-4">
-      <p>Nearby places and communities listed in this tool:</p>
+          <nuxt-link
+            :to="{
+              path: formUrl(place),
+              hash: '#results',
+            }"
+            >{{ place.name }}</nuxt-link
+          >
+          <span
+            v-if="formPlaceTypeFragment(place)"
+            v-html="formPlaceTypeFragment(place)"
+          ></span>
+        </li>
+      </ul>
+    </div>
+    <div v-if="searchResults.communities" class="mt-4 mb-4">
+      <p>Nearby places and communities included in this tool:</p>
       <ul>
         <li
           v-for="community in searchResults.communities"
@@ -107,7 +54,7 @@
         </li>
       </ul>
     </div>
-    <p>
+    <p class="mt-4">
       Or
       <nuxt-link
         :to="{
@@ -134,9 +81,11 @@ li.additional-info span {
   color: #888;
   text-transform: uppercase;
   font-weight: 600;
+  font-size: 85%;
 }
 </style>
 <script>
+import _ from 'lodash'
 import { mapGetters } from 'vuex'
 import { getAppPathFragment } from '~/utils/path.js'
 
@@ -157,6 +106,25 @@ export default {
   methods: {
     formUrl(place) {
       return getAppPathFragment(place.type, place.id)
+    },
+    formPlaceTypeFragment(place) {
+      let placeType = false
+      switch (place.type) {
+        case 'corporation':
+          placeType = 'Native Corporation Lands'
+          break
+        case 'huc':
+          placeType = 'HUC ID' + place.id
+          break
+        case 'climate_division':
+          placeType = 'Climate Division'
+          break
+        case 'fire_zone':
+          placeType = 'Fire Management Unit'
+          break
+        default: // Do nothing, don't decorate protected areas
+      }
+      return placeType
     },
   },
 }

--- a/store/place.js
+++ b/store/place.js
@@ -210,8 +210,50 @@ export const actions = {
         context.getters.latLng[1]
 
       await this.$http.$get(queryUrl).then(res => {
+        // Change the object structure to flatten & sort the areas
+        let ssr = []
+        _.each(res.climate_divisions_near, place => {
+          ssr.push(place)
+        })
+        _.each(res.corporations_near, place => {
+          ssr.push(place)
+        })
+        _.each(res.fire_management_units_near, place => {
+          ssr.push(place)
+        })
+        _.each(res.hucs_near, place => {
+          ssr.push(place)
+        })
+        _.each(res.protected_areas_near, place => {
+          ssr.push(place)
+        })
+
+        ssr.sort((a, b) => {
+          return a.name > b.name
+        })
+
+        // Sort the community names, if present
+        let communities = []
+        if (res.communities) {
+          // Restructure communities into an array to sort
+          _.each(res.communities, community => {
+            communities.push(community)
+          })
+          communities.sort((a, b) => {
+            return a.name > b.name
+          })
+        }
+        // Specifically make the communities key false if no matching communities
+        // were found.
+        if (_.isEmpty(communities)) {
+          communities = false
+        }
         Object.freeze(res) // remove reactivity of Vue, this is static
-        context.commit('setSearchResults', res)
+        context.commit('setSearchResults', {
+          areas: ssr,
+          communities: communities,
+          total_bounds: res.total_bounds,
+        })
       })
     }
   },


### PR DESCRIPTION
Closes #269
Closes #247

This PR improves the map search results by alphabetizing the search results (by area and by place) and properly hides/shows the blocks if no matching communities (or areas, though I think that'd never happen) are found.

The main changes are in the `place.js` store which does some additional pre-processing to alphabetize the results and mark `communities` key as false if there's no nearby communities.

Test by starting on the main branch and going to this URL: http://localhost:3000/search/67.75/-154.67#map-search
You should see that the "Nearby places and communities included in this tool:" fragment is shown even though there's no matching communities, and the list of matching areas aren't in alphabetical order.

Switch to this branch and try the same point.  Now the returned places should be in alphabetical order, with no erroneous text fragment behind.

Now go to this URL: http://localhost:3000/search/61.45/-149.60#map-search
Observe that the matching community names are in alphabetical order.
