### PR TITLE
Add new vegetation type maps and charts, 30-year era flammability maps, and merged pre-demo PRs

### DIFF
--- a/assets/scss/minimaps.scss
+++ b/assets/scss/minimaps.scss
@@ -1,0 +1,14 @@
+.minimaps-section-title {
+  font-size: 150%;
+  padding-bottom: 1rem;
+}
+
+.minimap-container {
+  width: 20%;
+}
+
+/* CSS trick to make height same as dynamic width */
+.minimap {
+  height: 0;
+  padding-bottom: 100%;
+}

--- a/components/MapWrapper.vue
+++ b/components/MapWrapper.vue
@@ -103,6 +103,7 @@ export default {
 				} else if (e.statusCode == 404) {
 					throw 'No results were found for this place.'
 				} else {
+					console.error(e) // at least get the error in the console.
 					throw 'Something unexpected went wrong.'
 				}
 			})

--- a/components/PlaceSelector.vue
+++ b/components/PlaceSelector.vue
@@ -85,6 +85,7 @@
     display: inline-block;
     padding-left: 1ex;
     color: #888;
+    font-size: 90%;
   }
 }
 </style>

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -153,8 +153,8 @@
               depending on the presence or absence of permafrost
             </li>
             <li v-if="flammabilityData || vegChangeData">
-              <a href="#wildfire">Wildfire</a> charts of relative flammability
-              and vegetation change with with multiple models and scenarios
+              <a href="#wildfire">Wildfire</a> charts of flammability and
+              vegetation change with with multiple models and scenarios
             </li>
           </ul>
         </div>
@@ -180,7 +180,7 @@
                 {{ httpErrors[permafrostHttpError] }}
               </li>
               <li v-if="flammabilityHttpError">
-                <strong>Relative flammability:</strong>
+                <strong>Flammability:</strong>
                 {{ httpErrors[flammabilityHttpError] }}
               </li>
               <li v-if="vegChangeHttpError">
@@ -395,7 +395,7 @@ export default {
       }
 
       if (this.flammabilityData) {
-        types.push('relative flammability')
+        types.push('flammability')
       }
       if (this.vegChangeData) {
         types.push('vegetation change')

--- a/components/SearchResults.vue
+++ b/components/SearchResults.vue
@@ -3,91 +3,38 @@
     <h3 class="title is-4">
       Locations matching {{ lat }}&deg;N, {{ lng }}&deg;E
     </h3>
-    <p>These areas of interest are at, or near, this point:</p>
-    <ul v-if="searchResults.protected_areas_near || searchResults.hucs_near || searchResults.corporations_near || searchResults.climate_divisions_near || searchResults.ethnolinguistic_regions_near">
-      <li
-        v-for="place in searchResults.climate_divisions_near"
-        :key="place.id"
-        class="additional-info"
-      >
-        <nuxt-link
-          :to="{
-            path: formUrl(place),
-            hash: '#results',
-          }"
-          >{{ place.name }}</nuxt-link
+
+    <div v-if="searchResults.areas">
+      <p>
+        The map on the left shows hydrological units (HUC-8) and protected areas
+        near the point you selected. Additional areas of interest
+        (ethnolinguistic regions, fire management units, climate divisions and
+        Native corporations) are not shown on the map because they are large,
+        but are included in the list of matching areas below.
+      </p>
+
+      <ul>
+        <li
+          v-for="place in searchResults.areas"
+          :key="place.id"
+          class="additional-info"
         >
-        <span>Climate Division</span>
-      </li>
-      <li
-        v-for="place in searchResults.ethnolinguistic_region"
-        :key="place.id"
-        class="additional-info"
-      >
-        <nuxt-link
-          :to="{
-            path: formUrl(place),
-            hash: '#results',
-          }"
-          >{{ place.name }}</nuxt-link
-        >
-        <span>Ethnolinguistic Region</span>
-      </li>
-      <li
-        v-for="place in searchResults.protected_areas_near"
-        :key="place.id"
-        class="additional-info"
-      >
-        <nuxt-link
-          :to="{
-            path: formUrl(place),
-            hash: '#results',
-          }"
-          >{{ place.name }}</nuxt-link
-        >
-        <span>{{ place.area_type }}</span>
-      </li>
-      <li v-for="huc in searchResults.hucs_near" :key="huc.id" class="additional-info">
-        <nuxt-link
-          :to="{
-            path: formUrl(huc),
-            hash: '#results',
-          }"
-          >{{ huc.name }}</nuxt-link
-        >
-        <span>HUC ID {{ huc.id }}</span>
-      </li>
-      <li
-        v-for="place in searchResults.corporations_near"
-        :key="place.id"
-        class="additional-info"
-      >
-        <nuxt-link
-          :to="{
-            path: formUrl(place),
-            hash: '#results',
-          }"
-          >{{ place.name }}</nuxt-link
-        >
-        <span>Native Corporation</span>
-      </li>
-      <li
-        v-for="place in searchResults.fire_management_units_near"
-        :key="place.id"
-        class="additional-info"
-      >
-        <nuxt-link
-          :to="{
-            path: formUrl(place),
-            hash: '#results',
-          }"
-          >{{ place.name }}</nuxt-link
-        >
-        <span>Fire Management Unit</span>
-      </li>
-    </ul>
-    <div v-if="searchResults.communities" class="mb-4">
-      <p>Nearby places and communities listed in this tool:</p>
+          <nuxt-link
+            :to="{
+              path: formUrl(place),
+              hash: '#results',
+            }"
+            >{{ place.name }}</nuxt-link
+          >
+          <span
+            v-if="formPlaceTypeFragment(place)"
+            v-html="formPlaceTypeFragment(place)"
+          ></span>
+        </li>
+      </ul>
+    </div>
+    <div v-if="searchResults.communities" class="mt-4 mb-4">
+      <p>Nearby places and communities included in this tool:</p>
       <ul>
         <li
           v-for="community in searchResults.communities"
@@ -107,7 +54,7 @@
         </li>
       </ul>
     </div>
-    <p>
+    <p class="mt-4">
       Or
       <nuxt-link
         :to="{
@@ -134,9 +81,11 @@ li.additional-info span {
   color: #888;
   text-transform: uppercase;
   font-weight: 600;
+  font-size: 85%;
 }
 </style>
 <script>
+import _ from 'lodash'
 import { mapGetters } from 'vuex'
 import { getAppPathFragment } from '~/utils/path.js'
 
@@ -157,6 +106,25 @@ export default {
   methods: {
     formUrl(place) {
       return getAppPathFragment(place.type, place.id)
+    },
+    formPlaceTypeFragment(place) {
+      let placeType = false
+      switch (place.type) {
+        case 'corporation':
+          placeType = 'Native Corporation Lands'
+          break
+        case 'huc':
+          placeType = 'HUC ID' + place.id
+          break
+        case 'climate_division':
+          placeType = 'Climate Division'
+          break
+        case 'fire_zone':
+          placeType = 'Fire Management Unit'
+          break
+        default: // Do nothing, don't decorate protected areas
+      }
+      return placeType
     },
   },
 }

--- a/components/reports/DownloadCsvButton.vue
+++ b/components/reports/DownloadCsvButton.vue
@@ -9,7 +9,7 @@ export default {
   computed: {
     downloadTarget() {
       let endpointPath = this.endpoint
-      if (this.endpoint == 'flammability' || this.endpoint == 'veg_change') {
+      if (_.includes(['flammability', 'veg_type'], this.endpoint)) {
         endpointPath = 'alfresco/' + endpointPath
       }
 

--- a/components/reports/permafrost/ReportMagtChart.vue
+++ b/components/reports/permafrost/ReportMagtChart.vue
@@ -73,7 +73,6 @@ export default {
         opacity: 0.2,
       })
 
-
       let footerLines = [
         'Projected values are taken from GIPL 2.0 model output.',
       ]
@@ -98,7 +97,6 @@ export default {
         layout,
         plotSettings
       )
-
     },
   },
 }

--- a/components/reports/permafrost/ReportMagtMap.vue
+++ b/components/reports/permafrost/ReportMagtMap.vue
@@ -1,14 +1,29 @@
 <template>
-  <div class="has-text-centered has-text-weight-bold">
-    {{ title }}
-    <div :id="mapID" class="permafrost-minimap"></div>
+  <div>
+    <div class="map-title has-text-centered">
+      <div>
+        <span class="has-text-weight-bold">{{ mapEra }}<br /></span>
+        <span v-if="mapModel">{{ mapModel }}<br class="narrow-br" /></span>
+        <span>{{ mapScenario }}</span>
+      </div>
+    </div>
+    <div :id="mapID" class="minimap"></div>
   </div>
 </template>
 
 <style lang="scss" scoped>
-.permafrost-minimap {
-  height: 15vw;
-  width: 100%;
+@media (max-width: 929px) {
+  .map-title {
+    min-height: 84px;
+  }
+}
+@media (min-width: 930px) {
+  .map-title {
+    min-height: 60px;
+  }
+  .narrow-br {
+    display: none;
+  }
 }
 </style>
 
@@ -17,9 +32,6 @@ import _ from 'lodash'
 import { mapGetters } from 'vuex'
 import { getBaseMapAndLayers, addGeoJSONtoMap } from '~/utils/maps'
 
-let scenarios = ['', 'RCP 4.5', 'RCP 8.5']
-let eras = ['1995', '2011-2040', '2036-2065', '2061–2090', '2086–2100']
-
 export default {
   name: 'ReportMagtMap',
   props: ['scenario', 'model', 'era'],
@@ -27,17 +39,25 @@ export default {
     ...mapGetters({
       latLng: 'place/latLng',
       geoJSON: 'place/geoJSON',
+      eras: 'permafrost/eras',
+      models: 'permafrost/models',
+      scenarios: 'permafrost/scenarios',
     }),
-    title() {
-      var title = ''
-      if (this.scenario > 0) {
-        title += scenarios[this.scenario] + ', '
-      }
-      title += eras[this.era]
-      return title
-    },
     mapID() {
       return this.scenario + '_' + this.model + '_' + this.era
+    },
+    mapEra() {
+      return this.eras[this.era]
+    },
+    mapModel() {
+      // The "era" at index 0 is the historical year (1995).
+      if (this.era > 0) {
+        return this.models[this.model] + ', '
+      }
+    },
+    mapScenario() {
+      // The "scenario" at index 0 is the historical data set (CRU TS 3.1).
+      return this.scenarios[this.scenario]
     },
   },
   data() {

--- a/components/reports/permafrost/ReportMagtMaps.vue
+++ b/components/reports/permafrost/ReportMagtMaps.vue
@@ -1,86 +1,55 @@
 <template>
   <section class="section">
-    <h5 class="permafrost-minimaps-title has-text-centered">
+    <h5 class="minimaps-section-title has-text-centered">
       Mean annual ground temperature,
       <span v-html="place"></span>
     </h5>
     <div class="is-size-6 mb-4">
       <b-field label="Model">
         <b-radio
-          v-model="model_selection"
-          name="model_selection"
+          v-model="magt_model_selection"
+          name="magt_model_selection"
           native-value="3"
           >NCAR CCSM4</b-radio
         >
         <b-radio
-          v-model="model_selection"
-          name="model_selection"
+          v-model="magt_model_selection"
+          name="magt_model_selection"
           native-value="4"
           >MRI CGCM3</b-radio
         >
       </b-field>
     </div>
-    <div class="columns">
-      <div class="column is-flex">
-        <ReportMagtMap
-          scenario="0"
-          model="0"
-          era="0"
-          class="permafrost-minimaps-map"
-        />
-        <ReportMagtMap
-          scenario="1"
-          :model="model_selection"
-          era="1"
-          class="permafrost-minimaps-map"
-        />
-        <ReportMagtMap
-          scenario="1"
-          :model="model_selection"
-          era="2"
-          class="permafrost-minimaps-map"
-        />
-        <ReportMagtMap
-          scenario="1"
-          :model="model_selection"
-          era="3"
-          class="permafrost-minimaps-map"
-        />
-        <ReportMagtMap
-          scenario="1"
-          :model="model_selection"
-          era="4"
-          class="permafrost-minimaps-map"
-        />
+    <div class="columns is-flex-direction-row">
+      <div class="minimap-container my-4 p-1">
+        <ReportMagtMap scenario="0" model="0" era="0" />
+      </div>
+      <div class="minimap-container my-4 p-1">
+        <ReportMagtMap scenario="1" :model="magt_model_selection" era="1" />
+      </div>
+      <div class="minimap-container my-4 p-1">
+        <ReportMagtMap scenario="1" :model="magt_model_selection" era="2" />
+      </div>
+      <div class="minimap-container my-4 p-1">
+        <ReportMagtMap scenario="1" :model="magt_model_selection" era="3" />
+      </div>
+      <div class="minimap-container my-4 p-1">
+        <ReportMagtMap scenario="1" :model="magt_model_selection" era="4" />
       </div>
     </div>
-    <div class="columns">
-      <div class="column is-flex">
-        <div class="permafrost-minimaps-map" />
-        <ReportMagtMap
-          scenario="2"
-          :model="model_selection"
-          era="1"
-          class="permafrost-minimaps-map"
-        />
-        <ReportMagtMap
-          scenario="2"
-          :model="model_selection"
-          era="2"
-          class="permafrost-minimaps-map"
-        />
-        <ReportMagtMap
-          scenario="2"
-          :model="model_selection"
-          era="3"
-          class="permafrost-minimaps-map"
-        />
-        <ReportMagtMap
-          scenario="2"
-          :model="model_selection"
-          era="4"
-          class="permafrost-minimaps-map"
-        />
+    <div class="columns is-flex-direction-row">
+      <div class="minimap-container my-4 p-1"></div>
+      <div class="minimap-container my-4 p-1">
+        <ReportMagtMap scenario="2" :model="magt_model_selection" era="1" />
+      </div>
+      <div class="minimap-container my-4 p-1">
+        <ReportMagtMap scenario="2" :model="magt_model_selection" era="2" />
+      </div>
+      <div class="minimap-container my-4 p-1">
+        <ReportMagtMap scenario="2" :model="magt_model_selection" era="3" />
+      </div>
+      <div class="minimap-container my-4 p-1">
+        <ReportMagtMap scenario="2" :model="magt_model_selection" era="4" />
       </div>
     </div>
     <table class="magt-legend">
@@ -112,16 +81,6 @@
 </template>
 
 <style lang="scss" scoped>
-.permafrost-minimaps-title {
-  font-size: 150%;
-  padding-bottom: 1rem;
-}
-.permafrost-minimaps-map {
-  height: 17vw;
-  min-width: 10vw;
-  width: 20%;
-  margin: 5px;
-}
 .magt-legend {
   width: 800px;
   border: 1px solid #999;
@@ -176,7 +135,7 @@ export default {
   },
   data() {
     return {
-      model_selection: 3,
+      magt_model_selection: 3,
     }
   },
 }

--- a/components/reports/permafrost/ReportMagtMaps.vue
+++ b/components/reports/permafrost/ReportMagtMaps.vue
@@ -83,6 +83,7 @@
 <style lang="scss" scoped>
 .magt-legend {
   width: 800px;
+  height: 26px;
   border: 1px solid #999;
   margin: 40px auto 0 auto;
   font-weight: 700;

--- a/components/reports/wildfire/ReportFlammabilityChart.vue
+++ b/components/reports/wildfire/ReportFlammabilityChart.vue
@@ -59,7 +59,7 @@ export default {
         return
       }
 
-      let title = 'Relative flammability, ' + this.place
+      let title = 'Flammability, ' + this.place
       let yAxisLabel = 'Annual chance of burning (%)'
       let layout = getLayout(title, yAxisLabel)
 

--- a/components/reports/wildfire/ReportFlammabilityMap.vue
+++ b/components/reports/wildfire/ReportFlammabilityMap.vue
@@ -1,44 +1,36 @@
 <template>
-  <div class="has-text-centered has-text-weight-bold">
-    <span v-html="title"></span>
-    <div :id="mapID" class="flammability-minimap"></div>
+  <div>
+    <div class="map-title has-text-centered">
+      <div>
+        <span class="has-text-weight-bold">{{ mapEra }}<br /></span>
+        <span v-if="mapModel">{{ mapModel }}<br class="narrow-br" /></span>
+        <span>{{ mapScenario }}</span>
+      </div>
+    </div>
+    <div :id="mapID" class="minimap"></div>
   </div>
 </template>
 
 <style lang="scss" scoped>
-.flammability-minimap {
-  height: 15vw;
-  width: 100%;
+@media (max-width: 1215px) {
+  .map-title {
+    min-height: 84px;
+  }
+}
+@media (min-width: 1216px) {
+  .map-title {
+    min-height: 60px;
+  }
+  .narrow-br {
+    display: none;
+  }
 }
 </style>
 
 <script>
 import _ from 'lodash'
 import { mapGetters } from 'vuex'
-import { getBaseMapAndLayers, addGeoJSONtoMap } from '../../../utils/maps'
-
-let models = [
-  '5 Model Average',
-  'GFDL CM3',
-  'GISS E2-R',
-  'IPSL CM5A-LR',
-  'MRI CGCM3',
-  'NCAR CCSM4',
-]
-
-let scenarios = ['RCP 4.5', 'RCP 6.0', 'RCP 8.5']
-
-let eras = [
-  '2010-2019',
-  '2020-2029',
-  '2030-2039',
-  '2040-2049',
-  '2050-2059',
-  '2060-2069',
-  '2070-2079',
-  '2080-2089',
-  '2090-2099',
-]
+import { getBaseMapAndLayers, addGeoJSONtoMap } from '~/utils/maps'
 
 export default {
   name: 'ReportFlammabilityMap',
@@ -47,21 +39,31 @@ export default {
     ...mapGetters({
       latLng: 'place/latLng',
       geoJSON: 'place/geoJSON',
+      eras: 'wildfire/eras',
+      models: 'wildfire/models',
+      scenarios: 'wildfire/scenarios',
     }),
-    title() {
-      if (this.historical == 'true') {
-        return 'CRU TS 4.0,<br />1950-2008'
-      }
-      return (
-        models[this.model] +
-        ',<br />' +
-        scenarios[this.scenario] +
-        ', ' +
-        eras[this.era]
-      )
-    },
     mapID() {
       return 'flammability_' + this.scenario + '_' + this.model + '_' + this.era
+    },
+    mapEra() {
+      if (this.historical == 'true') {
+        return '1950-2008'
+      } else {
+        return this.eras[this.era]
+      }
+    },
+    mapModel() {
+      if (this.historical != 'true') {
+        return this.models[this.model] + ', '
+      }
+    },
+    mapScenario() {
+      if (this.historical == 'true') {
+        return 'CRU TS 4.0'
+      } else {
+        return this.scenarios[this.scenario]
+      }
     },
   },
   data() {

--- a/components/reports/wildfire/ReportFlammabilityMap.vue
+++ b/components/reports/wildfire/ReportFlammabilityMap.vue
@@ -32,38 +32,68 @@ import _ from 'lodash'
 import { mapGetters } from 'vuex'
 import { getBaseMapAndLayers, addGeoJSONtoMap } from '~/utils/maps'
 
+let eras = {
+  relative_flammability_historical: {
+    climate_impact_reports: '1950-2008',
+  },
+  relative_flammability_future: {
+    'rcp45_2010-2039': '2010-2039',
+    'rcp45_2040-2069': '2040-2069',
+    'rcp45_2070-2099': '2070-2099',
+    'rcp85_2010-2039': '2010-2039',
+    'rcp85_2040-2069': '2040-2069',
+    'rcp85_2070-2099': '2070-2099',
+  },
+}
+
+let models = {
+  relative_flammability_historical: {
+    climate_impact_reports: 'CRU TS 4.0',
+  },
+  relative_flammability_future: {
+    'rcp45_2010-2039': 'NCAR CCSM4',
+    'rcp45_2040-2069': 'NCAR CCSM4',
+    'rcp45_2070-2099': 'NCAR CCSM4',
+    'rcp85_2010-2039': 'NCAR CCSM4',
+    'rcp85_2040-2069': 'NCAR CCSM4',
+    'rcp85_2070-2099': 'NCAR CCSM4',
+  },
+}
+
+let scenarios = {
+  relative_flammability_historical: {
+    climate_impact_reports: 'Historical',
+  },
+  relative_flammability_future: {
+    'rcp45_2010-2039': 'RCP 4.5',
+    'rcp45_2040-2069': 'RCP 4.5',
+    'rcp45_2070-2099': 'RCP 4.5',
+    'rcp85_2010-2039': 'RCP 8.5',
+    'rcp85_2040-2069': 'RCP 8.5',
+    'rcp85_2070-2099': 'RCP 8.5',
+  },
+}
+
 export default {
   name: 'ReportFlammabilityMap',
-  props: ['historical', 'scenario', 'model', 'era'],
+  props: ['layer', 'map_style'],
   computed: {
     ...mapGetters({
       latLng: 'place/latLng',
       geoJSON: 'place/geoJSON',
-      eras: 'wildfire/eras',
-      models: 'wildfire/models',
       scenarios: 'wildfire/scenarios',
     }),
     mapID() {
-      return 'flammability_' + this.scenario + '_' + this.model + '_' + this.era
+      return 'flammability_' + this.layer + '_' + this.map_style
     },
     mapEra() {
-      if (this.historical == 'true') {
-        return '1950-2008'
-      } else {
-        return this.eras[this.era]
-      }
+      return eras[this.layer][this.map_style]
     },
     mapModel() {
-      if (this.historical != 'true') {
-        return this.models[this.model] + ', '
-      }
+      return models[this.layer][this.map_style] + ', '
     },
     mapScenario() {
-      if (this.historical == 'true') {
-        return 'CRU TS 4.0'
-      } else {
-        return this.scenarios[this.scenario]
-      }
+      return scenarios[this.layer][this.map_style]
     },
   },
   data() {
@@ -99,16 +129,8 @@ export default {
         transparent: true,
         format: 'image/png',
         version: '1.3.0',
-        styles: 'climate_impact_reports',
-      }
-      if (this.historical == 'true') {
-        layerOptions['layers'] = 'relative_flammability_historical'
-        layerOptions['dim_era'] = this.era
-      } else {
-        layerOptions['layers'] = 'relative_flammability_future'
-        layerOptions['dim_era'] = this.era
-        layerOptions['dim_model'] = this.model
-        layerOptions['dim_scenario'] = this.scenario
+        layers: this.layer,
+        styles: this.map_style,
       }
       return new L.tileLayer.wms(process.env.rasdamanUrl, layerOptions)
     },

--- a/components/reports/wildfire/ReportFlammabilityMap.vue
+++ b/components/reports/wildfire/ReportFlammabilityMap.vue
@@ -32,68 +32,32 @@ import _ from 'lodash'
 import { mapGetters } from 'vuex'
 import { getBaseMapAndLayers, addGeoJSONtoMap } from '~/utils/maps'
 
-let eras = {
-  relative_flammability_historical: {
-    climate_impact_reports: '1950-2008',
-  },
-  relative_flammability_future: {
-    'rcp45_2010-2039': '2010-2039',
-    'rcp45_2040-2069': '2040-2069',
-    'rcp45_2070-2099': '2070-2099',
-    'rcp85_2010-2039': '2010-2039',
-    'rcp85_2040-2069': '2040-2069',
-    'rcp85_2070-2099': '2070-2099',
-  },
-}
-
-let models = {
-  relative_flammability_historical: {
-    climate_impact_reports: 'CRU TS 4.0',
-  },
-  relative_flammability_future: {
-    'rcp45_2010-2039': 'NCAR CCSM4',
-    'rcp45_2040-2069': 'NCAR CCSM4',
-    'rcp45_2070-2099': 'NCAR CCSM4',
-    'rcp85_2010-2039': 'NCAR CCSM4',
-    'rcp85_2040-2069': 'NCAR CCSM4',
-    'rcp85_2070-2099': 'NCAR CCSM4',
-  },
-}
-
-let scenarios = {
-  relative_flammability_historical: {
-    climate_impact_reports: 'Historical',
-  },
-  relative_flammability_future: {
-    'rcp45_2010-2039': 'RCP 4.5',
-    'rcp45_2040-2069': 'RCP 4.5',
-    'rcp45_2070-2099': 'RCP 4.5',
-    'rcp85_2010-2039': 'RCP 8.5',
-    'rcp85_2040-2069': 'RCP 8.5',
-    'rcp85_2070-2099': 'RCP 8.5',
-  },
-}
-
 export default {
   name: 'ReportFlammabilityMap',
-  props: ['layer', 'map_style'],
+  props: ['historical', 'scenario', 'model', 'era'],
   computed: {
     ...mapGetters({
       latLng: 'place/latLng',
       geoJSON: 'place/geoJSON',
+      eras: 'wildfire/eras',
+      models: 'wildfire/flammabilityModels',
       scenarios: 'wildfire/scenarios',
     }),
     mapID() {
-      return 'flammability_' + this.layer + '_' + this.map_style
+      return 'flammability_' + this.scenario + '_' + this.model + '_' + this.era
     },
     mapEra() {
-      return eras[this.layer][this.map_style]
+      return this.eras[this.era]
     },
     mapModel() {
-      return models[this.layer][this.map_style] + ', '
+      if (this.models[this.model] != '') {
+        return this.models[this.model] + ', '
+      } else {
+        return ''
+      }
     },
     mapScenario() {
-      return scenarios[this.layer][this.map_style]
+      return this.scenarios[this.scenario]
     },
   },
   data() {
@@ -117,6 +81,7 @@ export default {
       this.map.removeLayer(this.baseLayer)
       this.baseLayer = this.getBaseLayer()
       this.map.addLayer(this.baseLayer)
+      this.baseLayer.bringToBack()
     },
     // After geoJSON is loaded, display on map.
     geoJSON: function () {
@@ -129,9 +94,12 @@ export default {
         transparent: true,
         format: 'image/png',
         version: '1.3.0',
-        layers: this.layer,
-        styles: this.map_style,
+        styles: 'climate_impact_reports',
       }
+      layerOptions['layers'] = 'alfresco_relative_flammability_30yr'
+      layerOptions['dim_era'] = this.era
+      layerOptions['dim_model'] = this.model
+      layerOptions['dim_scenario'] = this.scenario
       return new L.tileLayer.wms(process.env.rasdamanUrl, layerOptions)
     },
   },

--- a/components/reports/wildfire/ReportFlammabilityMaps.vue
+++ b/components/reports/wildfire/ReportFlammabilityMaps.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="section">
     <h5 class="minimaps-section-title has-text-centered">
-      Relative flammability,
+      Flammability,
       <span v-html="place"></span>
     </h5>
     <div class="columns is-flex-direction-row is-centered">

--- a/components/reports/wildfire/ReportFlammabilityMaps.vue
+++ b/components/reports/wildfire/ReportFlammabilityMaps.vue
@@ -4,29 +4,45 @@
       Flammability,
       <span v-html="place"></span>
     </h5>
+    <div class="is-size-6 mb-4">
+      <b-field label="Model">
+        <b-radio
+          v-model="flammability_maps_model_selection"
+          name="flammability_maps_model_selection"
+          native-value="6"
+          >NCAR CCSM4</b-radio
+        >
+        <b-radio
+          v-model="flammability_maps_model_selection"
+          name="flammability_maps_model_selection"
+          native-value="5"
+          >MRI CGCM3</b-radio
+        >
+      </b-field>
+    </div>
     <div class="columns is-flex-direction-row is-centered">
       <div class="minimap-container my-4 p-1">
+        <ReportFlammabilityMap model="0" scenario="0" era="0" />
+      </div>
+      <div class="minimap-container my-4 p-1">
         <ReportFlammabilityMap
-          layer="relative_flammability_historical"
-          map_style="climate_impact_reports"
+          :model="flammability_maps_model_selection"
+          scenario="1"
+          era="1"
         />
       </div>
       <div class="minimap-container my-4 p-1">
         <ReportFlammabilityMap
-          layer="relative_flammability_future"
-          map_style="rcp45_2010-2039"
+          :model="flammability_maps_model_selection"
+          scenario="1"
+          era="2"
         />
       </div>
       <div class="minimap-container my-4 p-1">
         <ReportFlammabilityMap
-          layer="relative_flammability_future"
-          map_style="rcp45_2040-2069"
-        />
-      </div>
-      <div class="minimap-container my-4 p-1">
-        <ReportFlammabilityMap
-          layer="relative_flammability_future"
-          map_style="rcp45_2070-2099"
+          :model="flammability_maps_model_selection"
+          scenario="1"
+          era="3"
         />
       </div>
     </div>
@@ -34,20 +50,23 @@
       <div class="minimap-container my-4 p-1"></div>
       <div class="minimap-container my-4 p-1">
         <ReportFlammabilityMap
-          layer="relative_flammability_future"
-          map_style="rcp85_2010-2039"
+          :model="flammability_maps_model_selection"
+          scenario="3"
+          era="1"
         />
       </div>
       <div class="minimap-container my-4 p-1">
         <ReportFlammabilityMap
-          layer="relative_flammability_future"
-          map_style="rcp85_2040-2069"
+          :model="flammability_maps_model_selection"
+          scenario="3"
+          era="2"
         />
       </div>
       <div class="minimap-container my-4 p-1">
         <ReportFlammabilityMap
-          layer="relative_flammability_future"
-          map_style="rcp85_2070-2099"
+          :model="flammability_maps_model_selection"
+          scenario="3"
+          era="3"
         />
       </div>
     </div>
@@ -86,6 +105,11 @@ export default {
     ...mapGetters({
       place: 'place/name',
     }),
+  },
+  data() {
+    return {
+      flammability_maps_model_selection: 6,
+    }
   },
 }
 </script>

--- a/components/reports/wildfire/ReportFlammabilityMaps.vue
+++ b/components/reports/wildfire/ReportFlammabilityMaps.vue
@@ -1,70 +1,45 @@
 <template>
   <section class="section">
-    <h5 class="flammability-minimaps-title has-text-centered">
+    <h5 class="minimaps-section-title has-text-centered">
       Relative flammability,
       <span v-html="place"></span>
     </h5>
-    <div class="columns">
-      <div class="column is-flex">
-        <div class="flammability-minimaps-map" />
-        <ReportFlammabilityMap
-          historical="true"
-          era="1"
-          class="flammability-minimaps-map"
-        />
-        <ReportFlammabilityMap
-          historical="false"
-          scenario="0"
-          model="0"
-          era="4"
-          class="flammability-minimaps-map"
-        />
-        <ReportFlammabilityMap
-          historical="false"
-          scenario="0"
-          model="0"
-          era="8"
-          class="flammability-minimaps-map"
-        />
-        <div class="flammability-minimaps-map" />
+    <div class="columns is-flex-direction-row">
+      <div class="minimap-container my-4 p-1"></div>
+      <div class="minimap-container my-4 p-1">
+        <ReportFlammabilityMap historical="true" era="1" />
       </div>
+      <div class="minimap-container my-4 p-1">
+        <ReportFlammabilityMap model="0" scenario="0" era="4" />
+      </div>
+      <div class="minimap-container my-4 p-1">
+        <ReportFlammabilityMap model="0" scenario="0" era="8" />
+      </div>
+      <div class="minimap-container my-4 p-1"></div>
     </div>
-    <div class="columns">
-      <div class="column is-flex">
-        <div class="flammability-minimaps-map" />
-        <div class="flammability-minimaps-map" />
+    <div class="columns is-flex-direction-row">
+      <div class="minimap-container my-4 p-1"></div>
+      <div class="minimap-container my-4 p-1"></div>
+      <div class="minimap-container my-4 p-1">
         <ReportFlammabilityMap
           historical="false"
           scenario="2"
           model="0"
           era="4"
-          class="flammability-minimaps-map"
         />
+      </div>
+      <div class="minimap-container my-4 p-1">
         <ReportFlammabilityMap
           historical="false"
           scenario="2"
           model="0"
           era="8"
-          class="flammability-minimaps-map"
         />
-        <div class="flammability-minimaps-map" />
       </div>
+      <div class="minimap-container my-4 p-1"></div>
     </div>
   </section>
 </template>
-
-<style lang="scss" scoped>
-.flammability-minimaps-title {
-  font-size: 150%;
-  padding-bottom: 1rem;
-}
-.flammability-minimaps-map {
-  height: 17vw;
-  min-width: 10vw;
-  width: 20%;
-  margin: 5px;
-}
-</style>
 
 <script>
 import ReportFlammabilityMap from './ReportFlammabilityMap'

--- a/components/reports/wildfire/ReportFlammabilityMaps.vue
+++ b/components/reports/wildfire/ReportFlammabilityMaps.vue
@@ -4,42 +4,75 @@
       Relative flammability,
       <span v-html="place"></span>
     </h5>
-    <div class="columns is-flex-direction-row">
-      <div class="minimap-container my-4 p-1"></div>
+    <div class="columns is-flex-direction-row is-centered">
       <div class="minimap-container my-4 p-1">
-        <ReportFlammabilityMap historical="true" era="1" />
+        <ReportFlammabilityMap
+          layer="relative_flammability_historical"
+          map_style="climate_impact_reports"
+        />
       </div>
       <div class="minimap-container my-4 p-1">
-        <ReportFlammabilityMap model="0" scenario="0" era="4" />
+        <ReportFlammabilityMap
+          layer="relative_flammability_future"
+          map_style="rcp45_2010-2039"
+        />
       </div>
       <div class="minimap-container my-4 p-1">
-        <ReportFlammabilityMap model="0" scenario="0" era="8" />
+        <ReportFlammabilityMap
+          layer="relative_flammability_future"
+          map_style="rcp45_2040-2069"
+        />
       </div>
-      <div class="minimap-container my-4 p-1"></div>
+      <div class="minimap-container my-4 p-1">
+        <ReportFlammabilityMap
+          layer="relative_flammability_future"
+          map_style="rcp45_2070-2099"
+        />
+      </div>
     </div>
-    <div class="columns is-flex-direction-row">
-      <div class="minimap-container my-4 p-1"></div>
+    <div class="columns is-flex-direction-row is-centered">
       <div class="minimap-container my-4 p-1"></div>
       <div class="minimap-container my-4 p-1">
         <ReportFlammabilityMap
-          historical="false"
-          scenario="2"
-          model="0"
-          era="4"
+          layer="relative_flammability_future"
+          map_style="rcp85_2010-2039"
         />
       </div>
       <div class="minimap-container my-4 p-1">
         <ReportFlammabilityMap
-          historical="false"
-          scenario="2"
-          model="0"
-          era="8"
+          layer="relative_flammability_future"
+          map_style="rcp85_2040-2069"
         />
       </div>
-      <div class="minimap-container my-4 p-1"></div>
+      <div class="minimap-container my-4 p-1">
+        <ReportFlammabilityMap
+          layer="relative_flammability_future"
+          map_style="rcp85_2070-2099"
+        />
+      </div>
+    </div>
+    <div class="flammability-legend">
+      <div class="tick is-pulled-left">0%</div>
+      <div class="tick is-pulled-right">3%</div>
     </div>
   </section>
 </template>
+
+<style lang="scss" scoped>
+.flammability-legend {
+  width: 800px;
+  height: 26px;
+  border: 1px solid #999;
+  margin: 40px auto 0 auto;
+  font-weight: 700;
+  color: #fff;
+  text-shadow: 0 0 3px #000;
+  background: linear-gradient(90deg, #ffffff 0%, #ff0000 100%);
+  .tick {
+    margin: 0 8px;
+  }
+}
+</style>
 
 <script>
 import ReportFlammabilityMap from './ReportFlammabilityMap'

--- a/components/reports/wildfire/ReportVegChangeChart.vue
+++ b/components/reports/wildfire/ReportVegChangeChart.vue
@@ -4,16 +4,16 @@
       <b-field label="Model" class="px-3">
         <div>
           <b-radio
-            v-model="veg_model_selection"
-            name="veg_model_selection"
+            v-model="veg_chart_model_selection"
+            name="veg_chart_model_selection"
             native-value="NCAR-CCSM4"
             >NCAR CCSM4</b-radio
           >
         </div>
         <div>
           <b-radio
-            v-model="veg_model_selection"
-            name="veg_model_selection"
+            v-model="veg_chart_model_selection"
+            name="veg_chart_model_selection"
             native-value="MRI-CGCM3"
             >MRI CGCM3</b-radio
           >
@@ -54,7 +54,7 @@ export default {
   data() {
     return {
       plotType: 'box',
-      veg_model_selection: 'NCAR-CCSM4',
+      veg_chart_model_selection: 'NCAR-CCSM4',
       veg_scenario_selection: 'rcp85',
     }
   },
@@ -68,7 +68,7 @@ export default {
     vegChangeData: function () {
       this.renderPlot()
     },
-    veg_model_selection: function () {
+    veg_chart_model_selection: function () {
       this.renderPlot()
     },
     veg_scenario_selection: function () {
@@ -132,7 +132,7 @@ export default {
             yValues.push(vegChangeData[era]['CRU-TS']['historical'][type]['vt'])
           } else {
             yValues.push(
-              vegChangeData[era][this.veg_model_selection][
+              vegChangeData[era][this.veg_chart_model_selection][
                 this.veg_scenario_selection
               ][type]['vt']
             )

--- a/components/reports/wildfire/ReportVegChangeChart.vue
+++ b/components/reports/wildfire/ReportVegChangeChart.vue
@@ -88,43 +88,43 @@ export default {
 
       let dataTraces = []
 
-      let types = [
-        'Not Modeled',
-        'Barren/Lichen/Moss',
-        'Black Spruce',
-        'Deciduous Forest',
-        'Graminoid Tundra',
-        'Shrub Tundra',
-        'Temperate Rainforest',
-        'Wetland Tundra',
-        'White Spruce',
-      ]
+      let typeLabels = {
+        not_modeled: 'Not Modeled',
+        barren_lichen_moss: 'Barren/Lichen/Moss',
+        black_spruce: 'Black Spruce',
+        deciduous_forest: 'Deciduous Forest',
+        graminoid_tundra: 'Graminoid Tundra',
+        shrub_tundra: 'Shrub Tundra',
+        temperate_rainforest: 'Temperate Rainforest',
+        wetland_tundra: 'Wetland Tundra',
+        white_spruce: 'White Spruce',
+      }
 
       let symbols = {
-        'Not Modeled': 'circle',
-        'Barren/Lichen/Moss': 'square',
-        'Black Spruce': 'diamond',
-        'Deciduous Forest': 'cross',
-        'Graminoid Tundra': 'x',
-        'Shrub Tundra': 'triangle-up',
-        'Temperate Rainforest': 'triangle-down',
-        'Wetland Tundra': 'pentagon',
-        'White Spruce': 'hexagon',
+        not_modeled: 'circle',
+        barren_lichen_moss: 'square',
+        black_spruce: 'diamond',
+        deciduous_forest: 'cross',
+        graminoid_tundra: 'x',
+        shrub_tundra: 'triangle-up',
+        temperate_rainforest: 'triangle-down',
+        wetland_tundra: 'pentagon',
+        white_spruce: 'hexagon',
       }
 
       let colors = {
-        'Not Modeled': '#a6cee3',
-        'Barren/Lichen/Moss': '#ff7f00',
-        'Black Spruce': '#1f78b4',
-        'Deciduous Forest': '#33a02c',
-        'Graminoid Tundra': '#e31a1c',
-        'Shrub Tundra': '#fb9a99',
-        'Temperate Rainforest': '#cab2d6',
-        'Wetland Tundra': '#fdbf6f',
-        'White Spruce': '#b2df8a',
+        not_modeled: '#a6cee3',
+        barren_lichen_moss: '#ff7f00',
+        black_spruce: '#1f78b4',
+        deciduous_forest: '#33a02c',
+        graminoid_tundra: '#e31a1c',
+        shrub_tundra: '#fb9a99',
+        temperate_rainforest: '#cab2d6',
+        wetland_tundra: '#fdbf6f',
+        white_spruce: '#b2df8a',
       }
 
-      types.forEach(type => {
+      Object.keys(typeLabels).forEach(type => {
         let yValues = []
         let eras = ['1950-2008', '2010-2039', '2040-2069', '2070-2099']
         eras.forEach(era => {
@@ -142,7 +142,7 @@ export default {
         let historicalTrace = {
           type: 'scatter',
           mode: 'markers',
-          name: type,
+          name: typeLabels[type],
           hoverinfo: 'x+y+z+text',
           hovertemplate: '%{y:.2f}%',
           showlegend: false,
@@ -158,7 +158,7 @@ export default {
         let projectedTrace = {
           type: 'scatter',
           mode: 'markers',
-          name: type,
+          name: typeLabels[type],
           hoverinfo: 'x+y+z+text',
           hovertemplate: '%{y:.2f}% <b>(%{customdata}%)</b>',
           marker: {

--- a/components/reports/wildfire/ReportVegChangeChart.vue
+++ b/components/reports/wildfire/ReportVegChangeChart.vue
@@ -89,39 +89,27 @@ export default {
       let dataTraces = []
 
       let types = [
-        'not_modeled',
-        'barren_lichen_moss',
-        'black_spruce',
-        'deciduous_forest',
-        'graminoid_tundra',
-        'shrub_tundra',
-        'temperate_rainforest',
-        'wetland_tundra',
-        'white_spruce',
+        'Not Modeled',
+        'Barren/Lichen/Moss',
+        'Black Spruce',
+        'Deciduous Forest',
+        'Graminoid Tundra',
+        'Shrub Tundra',
+        'Temperate Rainforest',
+        'Wetland Tundra',
+        'White Spruce',
       ]
 
-      let traceLabels = {
-        not_modeled: 'Not Modeled',
-        barren_lichen_moss: 'Barren/Lichen/Moss',
-        black_spruce: 'Black Spruce',
-        deciduous_forest: 'Deciduous Forest',
-        graminoid_tundra: 'Graminoid Tundra',
-        shrub_tundra: 'Shrub Tundra',
-        temperate_rainforest: 'Temperate Rainforest',
-        wetland_tundra: 'Wetland Tundra',
-        white_spruce: 'White Spruce',
-      }
-
       let symbols = {
-        not_modeled: 'Not Modeled',
-        barren_lichen_moss: 'square',
-        black_spruce: 'diamond',
-        deciduous_forest: 'cross',
-        graminoid_tundra: 'x',
-        shrub_tundra: 'triangle-up',
-        temperate_rainforest: 'triangle-down',
-        wetland_tundra: 'pentagon',
-        white_spruce: 'hexagon',
+        'Not Modeled': 'Not Modeled',
+        'Barren/Lichen/Moss': 'square',
+        'Black Spruce': 'diamond',
+        'Deciduous Forest': 'cross',
+        'Graminoid Tundra': 'x',
+        'Shrub Tundra': 'triangle-up',
+        'Temperate Rainforest': 'triangle-down',
+        'Wetland Tundra': 'pentagon',
+        'White Spruce': 'hexagon',
       }
 
       types.forEach(type => {
@@ -142,7 +130,7 @@ export default {
         let trace = {
           type: 'scatter',
           mode: 'markers',
-          name: traceLabels[type],
+          name: type,
           hoverinfo: 'x+y+z+text',
           hovertemplate: '%{y:.2f}%',
           marker: {

--- a/components/reports/wildfire/ReportVegChangeChart.vue
+++ b/components/reports/wildfire/ReportVegChangeChart.vue
@@ -1,15 +1,36 @@
 <template>
   <div class="wildfire-chart-wrapper">
-    <div class="is-size-6">
-      <b-field label="Projected Data">
-        <b-radio v-model="plotType" name="vegChangePlotType" native-value="box"
-          >Box Plot</b-radio
+    <div class="is-flex">
+      <b-field label="Model" class="px-3">
+        <div>
+          <b-radio
+            v-model="veg_model_selection"
+            name="veg_model_selection"
+            native-value="NCAR-CCSM4"
+            >NCAR CCSM4</b-radio
+          >
+        </div>
+        <div>
+          <b-radio
+            v-model="veg_model_selection"
+            name="veg_model_selection"
+            native-value="MRI-CGCM3"
+            >MRI CGCM3</b-radio
+          >
+        </div>
+      </b-field>
+      <b-field label="Scenario" class="px-3">
+        <b-radio
+          v-model="veg_scenario_selection"
+          name="veg_scenario_selection"
+          native-value="rcp45"
+          >RCP 4.5</b-radio
         >
         <b-radio
-          v-model="plotType"
-          name="vegChangePlotType"
-          native-value="scatter"
-          >Scatter Plot</b-radio
+          v-model="veg_scenario_selection"
+          name="veg_scenario_selection"
+          native-value="rcp85"
+          >RCP 8.5</b-radio
         >
       </b-field>
     </div>
@@ -19,12 +40,12 @@
 <script>
 import _ from 'lodash'
 import { mapGetters } from 'vuex'
-import { getPlotSettings, getLayout, getFooter } from '../../../utils/charts'
+import { getPlotSettings, getLayout, getFooter } from '~/utils/charts'
 import {
   getHistoricalTrace,
   getProjectedTraces,
   allZeros,
-} from '../../../utils/wildfire_charts'
+} from '~/utils/wildfire_charts'
 export default {
   name: 'ReportVegChangeChart',
   mounted() {
@@ -33,6 +54,8 @@ export default {
   data() {
     return {
       plotType: 'box',
+      veg_model_selection: 'NCAR-CCSM4',
+      veg_scenario_selection: 'rcp85',
     }
   },
   computed: {
@@ -45,7 +68,10 @@ export default {
     vegChangeData: function () {
       this.renderPlot()
     },
-    plotType: function () {
+    veg_model_selection: function () {
+      this.renderPlot()
+    },
+    veg_scenario_selection: function () {
       this.renderPlot()
     },
   },
@@ -56,33 +82,78 @@ export default {
         return
       }
 
-      let title = 'Vegetation change, ' + this.place
-      let yAxisLabel = 'Annual chance of vegetation change (%)'
+      let title = 'Vegetation type, ' + this.place
+      let yAxisLabel = 'Vegetation type coverage (%)'
       let layout = getLayout(title, yAxisLabel)
-
-      // Prevent all-zero charts from showing negative y-axis.
-      // Subtract a small buffer from 0 value to avoid cropping scatter marker.
-      if (allZeros(vegChangeData, 'rvc')) {
-        layout['yaxis']['range'] = [-0.1, 2]
-      }
 
       let dataTraces = []
 
-      let historicalTrace = getHistoricalTrace(
-        vegChangeData,
-        'rvc',
-        this.plotType
-      )
-      if (historicalTrace != null) {
-        dataTraces.push(historicalTrace)
+      let types = [
+        'not_modeled',
+        'barren_lichen_moss',
+        'black_spruce',
+        'deciduous_forest',
+        'graminoid_tundra',
+        'shrub_tundra',
+        'temperate_rainforest',
+        'wetland_tundra',
+        'white_spruce',
+      ]
+
+      let traceLabels = {
+        not_modeled: 'Not Modeled',
+        barren_lichen_moss: 'Barren/Lichen/Moss',
+        black_spruce: 'Black Spruce',
+        deciduous_forest: 'Deciduous Forest',
+        graminoid_tundra: 'Graminoid Tundra',
+        shrub_tundra: 'Shrub Tundra',
+        temperate_rainforest: 'Temperate Rainforest',
+        wetland_tundra: 'Wetland Tundra',
+        white_spruce: 'White Spruce',
       }
 
-      let projectedTraces = getProjectedTraces(
-        vegChangeData,
-        'rvc',
-        this.plotType
-      )
-      dataTraces = dataTraces.concat(projectedTraces)
+      let symbols = {
+        not_modeled: 'Not Modeled',
+        barren_lichen_moss: 'square',
+        black_spruce: 'diamond',
+        deciduous_forest: 'cross',
+        graminoid_tundra: 'x',
+        shrub_tundra: 'triangle-up',
+        temperate_rainforest: 'triangle-down',
+        wetland_tundra: 'pentagon',
+        white_spruce: 'hexagon',
+      }
+
+      types.forEach(type => {
+        let yValues = []
+        let eras = ['1950-2008', '2010-2039', '2040-2069', '2070-2099']
+        eras.forEach(era => {
+          if (era == '1950-2008') {
+            yValues.push(vegChangeData[era]['CRU-TS']['historical'][type]['vt'])
+          } else {
+            yValues.push(
+              vegChangeData[era][this.veg_model_selection][
+                this.veg_scenario_selection
+              ][type]['vt']
+            )
+          }
+        })
+
+        let trace = {
+          type: 'scatter',
+          mode: 'markers',
+          name: traceLabels[type],
+          hoverinfo: 'x+y+z+text',
+          hovertemplate: '%{y:.2f}%',
+          marker: {
+            size: 8,
+            symbol: symbols[type],
+          },
+          x: ['1950-2008', '2010-2039', '2040-2069', '2070-2099'],
+          y: yValues,
+        }
+        dataTraces.push(trace)
+      })
 
       let footerLines = [
         'Projected values are taken from ALFRESCO model output.',

--- a/components/reports/wildfire/ReportVegChangeChart.vue
+++ b/components/reports/wildfire/ReportVegChangeChart.vue
@@ -101,7 +101,7 @@ export default {
       ]
 
       let symbols = {
-        'Not Modeled': 'Not Modeled',
+        'Not Modeled': 'circle',
         'Barren/Lichen/Moss': 'square',
         'Black Spruce': 'diamond',
         'Deciduous Forest': 'cross',
@@ -110,6 +110,18 @@ export default {
         'Temperate Rainforest': 'triangle-down',
         'Wetland Tundra': 'pentagon',
         'White Spruce': 'hexagon',
+      }
+
+      let colors = {
+        'Not Modeled': '#1d77b4',
+        'Barren/Lichen/Moss': '#ff7f0f',
+        'Black Spruce': '#2ba02b',
+        'Deciduous Forest': '#d62828',
+        'Graminoid Tundra': '#9467bd',
+        'Shrub Tundra': '#8b564c',
+        'Temperate Rainforest': '#e377c2',
+        'Wetland Tundra': '#7f7f7f',
+        'White Spruce': '#bbbd21',
       }
 
       types.forEach(type => {
@@ -127,20 +139,50 @@ export default {
           }
         })
 
-        let trace = {
+        let historicalTrace = {
           type: 'scatter',
           mode: 'markers',
           name: type,
           hoverinfo: 'x+y+z+text',
           hovertemplate: '%{y:.2f}%',
+          showlegend: false,
           marker: {
             size: 8,
             symbol: symbols[type],
+            color: colors[type],
           },
-          x: ['1950-2008', '2010-2039', '2040-2069', '2070-2099'],
-          y: yValues,
+          x: eras,
+          y: [yValues[0]],
         }
-        dataTraces.push(trace)
+
+        let projectedTrace = {
+          type: 'scatter',
+          mode: 'markers',
+          name: type,
+          hoverinfo: 'x+y+z+text',
+          hovertemplate: '%{y:.2f}% <b>(%{customdata}%)</b>',
+          marker: {
+            size: 8,
+            symbol: symbols[type],
+            color: colors[type],
+          },
+          x: eras,
+          y: [null].concat(yValues.slice(1)),
+          customdata: [null],
+        }
+
+        let historicalValue = yValues[0]
+        yValues.slice(1).forEach(value => {
+          let diff = value - historicalValue
+          if (diff >= 0) {
+            diff = '+' + diff.toFixed(2)
+          } else {
+            diff = diff.toFixed(2)
+          }
+          projectedTrace['customdata'].push(diff)
+        })
+
+        dataTraces.push(historicalTrace, projectedTrace)
       })
 
       let footerLines = [

--- a/components/reports/wildfire/ReportVegChangeChart.vue
+++ b/components/reports/wildfire/ReportVegChangeChart.vue
@@ -61,6 +61,7 @@ export default {
   computed: {
     ...mapGetters({
       vegChangeData: 'wildfire/veg_change',
+      vegTypes: 'wildfire/vegTypes',
       place: 'place/name',
     }),
   },
@@ -88,18 +89,6 @@ export default {
 
       let dataTraces = []
 
-      let typeLabels = {
-        not_modeled: 'Not Modeled',
-        barren_lichen_moss: 'Barren/Lichen/Moss',
-        black_spruce: 'Black Spruce',
-        deciduous_forest: 'Deciduous Forest',
-        graminoid_tundra: 'Graminoid Tundra',
-        shrub_tundra: 'Shrub Tundra',
-        temperate_rainforest: 'Temperate Rainforest',
-        wetland_tundra: 'Wetland Tundra',
-        white_spruce: 'White Spruce',
-      }
-
       let symbols = {
         not_modeled: 'circle',
         barren_lichen_moss: 'square',
@@ -112,19 +101,7 @@ export default {
         white_spruce: 'hexagon',
       }
 
-      let colors = {
-        not_modeled: '#a6cee3',
-        barren_lichen_moss: '#ff7f00',
-        black_spruce: '#1f78b4',
-        deciduous_forest: '#33a02c',
-        graminoid_tundra: '#e31a1c',
-        shrub_tundra: '#fb9a99',
-        temperate_rainforest: '#cab2d6',
-        wetland_tundra: '#fdbf6f',
-        white_spruce: '#b2df8a',
-      }
-
-      Object.keys(typeLabels).forEach(type => {
+      Object.keys(this.vegTypes).forEach(type => {
         let yValues = []
         let eras = ['1950-2008', '2010-2039', '2040-2069', '2070-2099']
         eras.forEach(era => {
@@ -142,14 +119,14 @@ export default {
         let historicalTrace = {
           type: 'scatter',
           mode: 'markers',
-          name: typeLabels[type],
+          name: this.vegTypes[type]['label'],
           hoverinfo: 'x+y+z+text',
           hovertemplate: '%{y:.2f}%',
           showlegend: false,
           marker: {
             size: 8,
             symbol: symbols[type],
-            color: colors[type],
+            color: this.vegTypes[type]['color'],
           },
           x: eras,
           y: [yValues[0]],
@@ -158,13 +135,13 @@ export default {
         let projectedTrace = {
           type: 'scatter',
           mode: 'markers',
-          name: typeLabels[type],
+          name: this.vegTypes[type]['label'],
           hoverinfo: 'x+y+z+text',
           hovertemplate: '%{y:.2f}% <b>(%{customdata}%)</b>',
           marker: {
             size: 8,
             symbol: symbols[type],
-            color: colors[type],
+            color: this.vegTypes[type]['color'],
           },
           x: eras,
           y: [null].concat(yValues.slice(1)),

--- a/components/reports/wildfire/ReportVegChangeChart.vue
+++ b/components/reports/wildfire/ReportVegChangeChart.vue
@@ -113,15 +113,15 @@ export default {
       }
 
       let colors = {
-        'Not Modeled': '#1d77b4',
-        'Barren/Lichen/Moss': '#ff7f0f',
-        'Black Spruce': '#2ba02b',
-        'Deciduous Forest': '#d62828',
-        'Graminoid Tundra': '#9467bd',
-        'Shrub Tundra': '#8b564c',
-        'Temperate Rainforest': '#e377c2',
-        'Wetland Tundra': '#7f7f7f',
-        'White Spruce': '#bbbd21',
+        'Not Modeled': '#a6cee3',
+        'Barren/Lichen/Moss': '#ff7f00',
+        'Black Spruce': '#1f78b4',
+        'Deciduous Forest': '#33a02c',
+        'Graminoid Tundra': '#e31a1c',
+        'Shrub Tundra': '#fb9a99',
+        'Temperate Rainforest': '#cab2d6',
+        'Wetland Tundra': '#fdbf6f',
+        'White Spruce': '#b2df8a',
       }
 
       types.forEach(type => {

--- a/components/reports/wildfire/ReportVegChangeMap.vue
+++ b/components/reports/wildfire/ReportVegChangeMap.vue
@@ -1,44 +1,36 @@
 <template>
-  <div class="has-text-centered has-text-weight-bold">
-    <span v-html="title"></span>
-    <div :id="mapID" class="veg-change-minimap"></div>
+  <div>
+    <div class="map-title has-text-centered">
+      <div>
+        <span class="has-text-weight-bold">{{ mapEra }}<br /></span>
+        <span v-if="mapModel">{{ mapModel }}<br class="narrow-br" /></span>
+        <span>{{ mapScenario }}</span>
+      </div>
+    </div>
+    <div :id="mapID" class="minimap"></div>
   </div>
 </template>
 
 <style lang="scss" scoped>
-.veg-change-minimap {
-  height: 15vw;
-  width: 100%;
+@media (max-width: 1215px) {
+  .map-title {
+    min-height: 84px;
+  }
+}
+@media (min-width: 1216px) {
+  .map-title {
+    min-height: 60px;
+  }
+  .narrow-br {
+    display: none;
+  }
 }
 </style>
 
 <script>
 import _ from 'lodash'
 import { mapGetters } from 'vuex'
-import { getBaseMapAndLayers, addGeoJSONtoMap } from '../../../utils/maps'
-
-let models = [
-  '5 Model Average',
-  'GFDL CM3',
-  'GISS E2-R',
-  'IPSL CM5A-LR',
-  'MRI CGCM3',
-  'NCAR CCSM4',
-]
-
-let scenarios = ['RCP 4.5', 'RCP 6.0', 'RCP 8.5']
-
-let eras = [
-  '2010-2019',
-  '2020-2029',
-  '2030-2039',
-  '2040-2049',
-  '2050-2059',
-  '2060-2069',
-  '2070-2079',
-  '2080-2089',
-  '2090-2099',
-]
+import { getBaseMapAndLayers, addGeoJSONtoMap } from '~/utils/maps'
 
 export default {
   name: 'ReportVegChangeMap',
@@ -47,21 +39,21 @@ export default {
     ...mapGetters({
       latLng: 'place/latLng',
       geoJSON: 'place/geoJSON',
+      eras: 'wildfire/eras',
+      models: 'wildfire/models',
+      scenarios: 'wildfire/scenarios',
     }),
-    title() {
-      if (this.historical == 'true') {
-        return 'CRU TS 4.0,<br />1950-2008'
-      }
-      return (
-        models[this.model] +
-        ',<br />' +
-        scenarios[this.scenario] +
-        ', ' +
-        eras[this.era]
-      )
-    },
     mapID() {
       return 'veg_change_' + this.scenario + '_' + this.model + '_' + this.era
+    },
+    mapEra() {
+      return this.eras[this.era]
+    },
+    mapModel() {
+      return this.models[this.model] + ', '
+    },
+    mapScenario() {
+      return this.scenarios[this.scenario]
     },
   },
   data() {
@@ -85,6 +77,7 @@ export default {
       this.map.removeLayer(this.baseLayer)
       this.baseLayer = this.getBaseLayer()
       this.map.addLayer(this.baseLayer)
+      this.baseLayer.bringToBack()
     },
     // After geoJSON is loaded, display on map.
     geoJSON: function () {
@@ -99,15 +92,10 @@ export default {
         version: '1.3.0',
         styles: 'climate_impact_reports',
       }
-      if (this.historical == 'true') {
-        layerOptions['layers'] = 'relative_vegetation_change_historical'
-        layerOptions['dim_era'] = this.era
-      } else {
-        layerOptions['layers'] = 'relative_vegetation_change_future'
-        layerOptions['dim_era'] = this.era
-        layerOptions['dim_model'] = this.model
-        layerOptions['dim_scenario'] = this.scenario
-      }
+      layerOptions['layers'] = 'mode_vegetation'
+      layerOptions['dim_era'] = this.era
+      layerOptions['dim_model'] = this.model
+      layerOptions['dim_scenario'] = this.scenario
       return new L.tileLayer.wms(process.env.rasdamanUrl, layerOptions)
     },
   },

--- a/components/reports/wildfire/ReportVegChangeMap.vue
+++ b/components/reports/wildfire/ReportVegChangeMap.vue
@@ -40,7 +40,7 @@ export default {
       latLng: 'place/latLng',
       geoJSON: 'place/geoJSON',
       eras: 'wildfire/eras',
-      models: 'wildfire/models',
+      models: 'wildfire/vegModels',
       scenarios: 'wildfire/scenarios',
     }),
     mapID() {
@@ -50,7 +50,11 @@ export default {
       return this.eras[this.era]
     },
     mapModel() {
-      return this.models[this.model] + ', '
+      if (this.models[this.model] != '') {
+        return this.models[this.model] + ', '
+      } else {
+        return ''
+      }
     },
     mapScenario() {
       return this.scenarios[this.scenario]

--- a/components/reports/wildfire/ReportVegChangeMaps.vue
+++ b/components/reports/wildfire/ReportVegChangeMaps.vue
@@ -7,14 +7,14 @@
     <div class="is-size-6 mb-4">
       <b-field label="Model">
         <b-radio
-          v-model="veg_model_selection"
-          name="veg_model_selection"
+          v-model="veg_maps_model_selection"
+          name="veg_maps_model_selection"
           native-value="1"
           >NCAR CCSM4</b-radio
         >
         <b-radio
-          v-model="veg_model_selection"
-          name="veg_model_selection"
+          v-model="veg_maps_model_selection"
+          name="veg_maps_model_selection"
           native-value="5"
           >MRI CGCM3</b-radio
         >
@@ -25,25 +25,49 @@
         <ReportVegChangeMap model="0" scenario="0" era="0" />
       </div>
       <div class="minimap-container my-4 p-1">
-        <ReportVegChangeMap :model="veg_model_selection" scenario="1" era="1" />
+        <ReportVegChangeMap
+          :model="veg_maps_model_selection"
+          scenario="1"
+          era="1"
+        />
       </div>
       <div class="minimap-container my-4 p-1">
-        <ReportVegChangeMap :model="veg_model_selection" scenario="1" era="2" />
+        <ReportVegChangeMap
+          :model="veg_maps_model_selection"
+          scenario="1"
+          era="2"
+        />
       </div>
       <div class="minimap-container my-4 p-1">
-        <ReportVegChangeMap :model="veg_model_selection" scenario="1" era="3" />
+        <ReportVegChangeMap
+          :model="veg_maps_model_selection"
+          scenario="1"
+          era="3"
+        />
       </div>
     </div>
     <div class="columns is-flex-direction-row is-centered">
       <div class="minimap-container my-4 p-1"></div>
       <div class="minimap-container my-4 p-1">
-        <ReportVegChangeMap :model="veg_model_selection" scenario="3" era="1" />
+        <ReportVegChangeMap
+          :model="veg_maps_model_selection"
+          scenario="3"
+          era="1"
+        />
       </div>
       <div class="minimap-container my-4 p-1">
-        <ReportVegChangeMap :model="veg_model_selection" scenario="3" era="2" />
+        <ReportVegChangeMap
+          :model="veg_maps_model_selection"
+          scenario="3"
+          era="2"
+        />
       </div>
       <div class="minimap-container my-4 p-1">
-        <ReportVegChangeMap :model="veg_model_selection" scenario="3" era="3" />
+        <ReportVegChangeMap
+          :model="veg_maps_model_selection"
+          scenario="3"
+          era="3"
+        />
       </div>
     </div>
     <div class="legend">
@@ -150,7 +174,7 @@ export default {
   },
   data() {
     return {
-      veg_model_selection: 1,
+      veg_maps_model_selection: 1,
     }
   },
 }

--- a/components/reports/wildfire/ReportVegChangeMaps.vue
+++ b/components/reports/wildfire/ReportVegChangeMaps.vue
@@ -131,31 +131,31 @@
   margin-right: 8px;
 }
 .color-0 {
-  background-color: #cccccc;
+  background-color: #a6cee3;
 }
 .color-1 {
-  background-color: #009459;
+  background-color: #1f78b4;
 }
 .color-2 {
-  background-color: #72cb88;
+  background-color: #b2df8a;
 }
 .color-3 {
-  background-color: #fdfeec;
+  background-color: #33a02c;
 }
 .color-4 {
-  background-color: #ac916c;
+  background-color: #fb9a99;
 }
 .color-5 {
-  background-color: #ede0ce;
+  background-color: #e31a1c;
 }
 .color-6 {
-  background-color: #0d51fd;
+  background-color: #fdbf6f;
 }
 .color-7 {
-  background-color: #f2a56e;
+  background-color: #ff7f00;
 }
 .color-8 {
-  background-color: #6de1e9;
+  background-color: #cab2d6;
 }
 </style>
 

--- a/components/reports/wildfire/ReportVegChangeMaps.vue
+++ b/components/reports/wildfire/ReportVegChangeMaps.vue
@@ -1,68 +1,137 @@
 <template>
   <section class="section">
-    <h5 class="veg-change-minimaps-title has-text-centered">
-      Relative vegetation change,
+    <h5 class="minimaps-section-title has-text-centered">
+      Vegetation change,
       <span v-html="place"></span>
     </h5>
-    <div class="columns">
-      <div class="column is-flex">
-        <div class="veg-change-minimaps-map" />
-        <ReportVegChangeMap
-          historical="true"
-          era="1"
-          class="veg-change-minimaps-map"
-        />
-        <ReportVegChangeMap
-          historical="false"
-          scenario="0"
-          model="0"
-          era="4"
-          class="veg-change-minimaps-map"
-        />
-        <ReportVegChangeMap
-          historical="false"
-          scenario="0"
-          model="0"
-          era="8"
-          class="veg-change-minimaps-map"
-        />
-        <div class="veg-change-minimaps-map" />
+    <div class="is-size-6 mb-4">
+      <b-field label="Model">
+        <b-radio
+          v-model="veg_model_selection"
+          name="veg_model_selection"
+          native-value="1"
+          >NCAR CCSM4</b-radio
+        >
+        <b-radio
+          v-model="veg_model_selection"
+          name="veg_model_selection"
+          native-value="5"
+          >MRI CGCM3</b-radio
+        >
+      </b-field>
+    </div>
+    <div class="columns is-flex-direction-row is-centered">
+      <div class="minimap-container my-4 p-1">
+        <ReportVegChangeMap model="0" scenario="0" era="0" />
+      </div>
+      <div class="minimap-container my-4 p-1">
+        <ReportVegChangeMap :model="veg_model_selection" scenario="1" era="1" />
+      </div>
+      <div class="minimap-container my-4 p-1">
+        <ReportVegChangeMap :model="veg_model_selection" scenario="1" era="2" />
+      </div>
+      <div class="minimap-container my-4 p-1">
+        <ReportVegChangeMap :model="veg_model_selection" scenario="1" era="3" />
       </div>
     </div>
-    <div class="columns">
-      <div class="column is-flex">
-        <div class="veg-change-minimaps-map" />
-        <div class="veg-change-minimaps-map" />
-        <ReportVegChangeMap
-          historical="false"
-          scenario="2"
-          model="0"
-          era="4"
-          class="veg-change-minimaps-map"
-        />
-        <ReportVegChangeMap
-          historical="false"
-          scenario="2"
-          model="0"
-          era="8"
-          class="veg-change-minimaps-map"
-        />
-        <div class="veg-change-minimaps-map" />
+    <div class="columns is-flex-direction-row is-centered">
+      <div class="minimap-container my-4 p-1"></div>
+      <div class="minimap-container my-4 p-1">
+        <ReportVegChangeMap :model="veg_model_selection" scenario="3" era="1" />
+      </div>
+      <div class="minimap-container my-4 p-1">
+        <ReportVegChangeMap :model="veg_model_selection" scenario="3" era="2" />
+      </div>
+      <div class="minimap-container my-4 p-1">
+        <ReportVegChangeMap :model="veg_model_selection" scenario="3" era="3" />
+      </div>
+    </div>
+    <div class="legend">
+      <div class="color is-flex is-flex-direction-row">
+        <div class="swatch color-0" />
+        <div>Not Modeled</div>
+      </div>
+      <div class="color is-flex is-flex-direction-row">
+        <div class="swatch color-1" />
+        <div>Black Spruce</div>
+      </div>
+      <div class="color is-flex is-flex-direction-row">
+        <div class="swatch color-2" />
+        <div>White Spruce</div>
+      </div>
+      <div class="color is-flex is-flex-direction-row">
+        <div class="swatch color-3" />
+        <div>Deciduous Forest</div>
+      </div>
+      <div class="color is-flex is-flex-direction-row">
+        <div class="swatch color-4" />
+        <div>Shrub Tundra</div>
+      </div>
+      <div class="color is-flex is-flex-direction-row">
+        <div class="swatch color-5" />
+        <div>Graminoid Tundra</div>
+      </div>
+      <div class="color is-flex is-flex-direction-row">
+        <div class="swatch color-6" />
+        <div>Wetland Tundra</div>
+      </div>
+      <div class="color is-flex is-flex-direction-row">
+        <div class="swatch color-7" />
+        <div>Barren/Lichen/Moss</div>
+      </div>
+      <div class="color is-flex is-flex-direction-row">
+        <div class="swatch color-8" />
+        <div>Temperate Rainforest</div>
       </div>
     </div>
   </section>
 </template>
 
 <style lang="scss" scoped>
-.veg-change-minimaps-title {
-  font-size: 150%;
-  padding-bottom: 1rem;
+.legend {
+  overflow: hidden;
+  max-width: 600px;
+  margin: 20px auto;
+  line-height: 1.2;
 }
-.veg-change-minimaps-map {
-  height: 17vw;
-  min-width: 10vw;
-  width: 20%;
-  margin: 5px;
+.color {
+  width: 200px;
+  float: left;
+  margin: 4px 0;
+}
+.swatch {
+  width: 20px;
+  height: 20px;
+  border: 1px solid #999999;
+  border-radius: 3px;
+  margin-right: 8px;
+}
+.color-0 {
+  background-color: #cccccc;
+}
+.color-1 {
+  background-color: #009459;
+}
+.color-2 {
+  background-color: #72cb88;
+}
+.color-3 {
+  background-color: #fdfeec;
+}
+.color-4 {
+  background-color: #ac916c;
+}
+.color-5 {
+  background-color: #ede0ce;
+}
+.color-6 {
+  background-color: #0d51fd;
+}
+.color-7 {
+  background-color: #f2a56e;
+}
+.color-8 {
+  background-color: #6de1e9;
 }
 </style>
 
@@ -78,6 +147,11 @@ export default {
     ...mapGetters({
       place: 'place/name',
     }),
+  },
+  data() {
+    return {
+      veg_model_selection: 1,
+    }
   },
 }
 </script>

--- a/components/reports/wildfire/ReportVegChangeMaps.vue
+++ b/components/reports/wildfire/ReportVegChangeMaps.vue
@@ -71,41 +71,12 @@
       </div>
     </div>
     <div class="legend">
-      <div class="color is-flex is-flex-direction-row">
-        <div class="swatch color-0" />
-        <div>Not Modeled</div>
-      </div>
-      <div class="color is-flex is-flex-direction-row">
-        <div class="swatch color-1" />
-        <div>Black Spruce</div>
-      </div>
-      <div class="color is-flex is-flex-direction-row">
-        <div class="swatch color-2" />
-        <div>White Spruce</div>
-      </div>
-      <div class="color is-flex is-flex-direction-row">
-        <div class="swatch color-3" />
-        <div>Deciduous Forest</div>
-      </div>
-      <div class="color is-flex is-flex-direction-row">
-        <div class="swatch color-4" />
-        <div>Shrub Tundra</div>
-      </div>
-      <div class="color is-flex is-flex-direction-row">
-        <div class="swatch color-5" />
-        <div>Graminoid Tundra</div>
-      </div>
-      <div class="color is-flex is-flex-direction-row">
-        <div class="swatch color-6" />
-        <div>Wetland Tundra</div>
-      </div>
-      <div class="color is-flex is-flex-direction-row">
-        <div class="swatch color-7" />
-        <div>Barren/Lichen/Moss</div>
-      </div>
-      <div class="color is-flex is-flex-direction-row">
-        <div class="swatch color-8" />
-        <div>Temperate Rainforest</div>
+      <div
+        class="color is-flex is-flex-direction-row"
+        v-for="vegType in vegTypes"
+      >
+        <div class="swatch" :style="'background-color: ' + vegType['color']" />
+        <div>{{ vegType['label'] }}</div>
       </div>
     </div>
   </section>
@@ -130,33 +101,6 @@
   border-radius: 3px;
   margin-right: 8px;
 }
-.color-0 {
-  background-color: #a6cee3;
-}
-.color-1 {
-  background-color: #1f78b4;
-}
-.color-2 {
-  background-color: #b2df8a;
-}
-.color-3 {
-  background-color: #33a02c;
-}
-.color-4 {
-  background-color: #fb9a99;
-}
-.color-5 {
-  background-color: #e31a1c;
-}
-.color-6 {
-  background-color: #fdbf6f;
-}
-.color-7 {
-  background-color: #ff7f00;
-}
-.color-8 {
-  background-color: #cab2d6;
-}
 </style>
 
 <script>
@@ -170,6 +114,7 @@ export default {
   computed: {
     ...mapGetters({
       place: 'place/name',
+      vegTypes: 'wildfire/vegTypes',
     }),
   },
   data() {

--- a/components/reports/wildfire/WildfireReport.vue
+++ b/components/reports/wildfire/WildfireReport.vue
@@ -41,7 +41,7 @@
     </div>
     <DownloadCsvButton
       text="Download vegetation change data as CSV"
-      endpoint="veg_change"
+      endpoint="veg_type"
       class="mt-3 mb-5"
     />
   </div>

--- a/components/reports/wildfire/WildfireReport.vue
+++ b/components/reports/wildfire/WildfireReport.vue
@@ -4,10 +4,10 @@
       <h4 class="title is-3">Wildfire</h4>
       <div class="is-size-5 mb-6">
         <p>
-          The following charts show the historical and projected relative
-          flammability and vegetation change for this location. Values represent
-          the percentage of times the pixel at this location has burned, or
-          changed dominant vegetation type, for varios models and scenarios.
+          The following charts show the historical and projected flammability
+          and vegetation change for this location. Values represent the
+          percentage of times the pixel at this location has burned, or changed
+          dominant vegetation type, for varios models and scenarios.
           <nuxt-link :to="{ name: 'data', hash: '#datasets' }"
             >See information about the dataset shown here.</nuxt-link
           >

--- a/components/reports/wildfire/WildfireReport.vue
+++ b/components/reports/wildfire/WildfireReport.vue
@@ -23,6 +23,18 @@
       endpoint="flammability"
       class="mt-3 mb-5"
     />
+    <div class="content">
+      <div class="is-size-5 mt-6">
+        <p>
+          Due to the inherent uncertainty involved in predicting wildfire, the
+          maps below should not be interpreted as vegetation predictions at
+          specific locations, but rather as an indicator of likely general
+          trends in vegetation type over time. Each map-pixel shows the most
+          commonly predicted vegetation type (modal value) based on 200 model
+          runs per year across all years in the map's date range.
+        </p>
+      </div>
+    </div>
     <ReportVegChangeMaps />
     <div class="chart-wrapper">
       <ReportVegChangeChart />

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -43,7 +43,7 @@ export default {
 
   // Global CSS: https://go.nuxtjs.dev/config-css
   // Main is the entrypoint for all SCSS in our app.
-  css: ['@/assets/scss/main.scss'],
+  css: ['@/assets/scss/main.scss', '@/assets/scss/minimaps.scss'],
 
   // Plugins to run before rendering page: https://go.nuxtjs.dev/config-plugins
   plugins: [

--- a/pages/data.vue
+++ b/pages/data.vue
@@ -62,7 +62,22 @@
         </ul>
         <h3 class="title is-4">Wildfire</h3>
         <ul>
-          <li>TBD</li>
+          <li>
+            <strong>Flammability</strong>. A summarized data product using the
+            same underlying data shown in this app is available here:
+            <a
+              href="http://ckan.snap.uaf.edu/dataset/alfresco-model-outputs-relative-flammability"
+              >ALFRESCO Model outputs - Relative Flammability</a
+            >.
+          </li>
+          <li>
+            <strong>Vegetation</strong>. A summarized data product using the
+            same underlying data shown in this app is available here:
+            <a
+              href="http://ckan.snap.uaf.edu/dataset/alfresco-model-outputs-relative-vegetation-change"
+              >ALFRESCO Model outputs - Relative Vegetation Change</a
+            >.
+          </li>
         </ul>
         <h3 class="title is-4">Elevation</h3>
         <p>
@@ -79,8 +94,11 @@
         </p>
         <p>
           Note that the precision of the data shown in this tool depends on the
-          grid resolution (pixel size) of the underlying dataset.  Temperature and precipitation products are at 2km resolution, the GIPL outputs are 4km and ALFRESCO outputs are at 1km resolution.</p>
+          grid resolution (pixel size) of the underlying dataset. Temperature
+          and precipitation products are at 2km resolution, the GIPL outputs are
+          4km and ALFRESCO outputs are at 1km resolution.
         </p>
+
         <h2 id="places" class="title is-3">
           What places are available in this tool?
         </h2>
@@ -96,14 +114,27 @@
           </li>
           <li>
             <strong>protected areas</strong> such as National Parks, National
-            Forests, Wilderness Areas and more, searchable by name and agency
-            (NPS, USFS, etc),
+            Forests, Wilderness Areas, National Wildlife Refuges, State Parks
+            and more, searchable by name and agency (NPS, USFS, etc),
           </li>
           <li>
-            <strong>Alaska Native Corporation geographic boundaries</strong>...?
+            <strong
+              ><a
+                href="https://dhss.alaska.gov/ocs/Documents/icwa/AKNativeRegionalCorps.pdf"
+                >Alaska Native Corporation geographic boundaries</a
+              ></strong
+            >
           </li>
-          <li><strong>Fire Management Units...?</strong></li>
-          <li><strong>Ethnolinguistic regions...?</strong></li>
+          <li><strong>Fire Management Units</strong></li>
+          <li><strong><a href="https://uaf.edu/anlc/resources/mapping_alaskas_native_languages.php">Ethnolinguistic regions</a></strong></li>
+          <li>
+            <strong
+              ><a
+                href="https://www.ncdc.noaa.gov/news/climate-division-data-now-available-alaska"
+                >Alaska Climate Divisions</a
+              ></strong
+            >
+          </li>
         </ul>
         <h2 class="title is-3">Data API access</h2>
         <p>
@@ -122,8 +153,8 @@
           <a href="mailto:uaf-snap-data-tools@alaska.edu"
             >uaf-snap-data-tools@alaska.edu</a
           >
-          with questions about these data, data access, or using these data in your
-          work.
+          with questions about these data, data access, or using these data in
+          your work.
         </p>
       </div>
     </div>

--- a/store/permafrost.js
+++ b/store/permafrost.js
@@ -123,6 +123,18 @@ export const state = () => ({
 })
 
 export const getters = {
+  eras() {
+    return ['1995', '2011-2040', '2036-2065', '2061–2090', '2086–2100']
+  },
+  models() {
+    return {
+      3: 'NCAR CCSM4',
+      4: 'MRI CGCM3',
+    }
+  },
+  scenarios() {
+    return ['CRU TS 3.1', 'RCP 4.5', 'RCP 8.5']
+  },
   permafrostData(state) {
     return state.permafrostData
   },

--- a/store/place.js
+++ b/store/place.js
@@ -210,8 +210,50 @@ export const actions = {
         context.getters.latLng[1]
 
       await this.$http.$get(queryUrl).then(res => {
+        // Change the object structure to flatten & sort the areas
+        let ssr = []
+        _.each(res.climate_divisions_near, place => {
+          ssr.push(place)
+        })
+        _.each(res.corporations_near, place => {
+          ssr.push(place)
+        })
+        _.each(res.fire_management_units_near, place => {
+          ssr.push(place)
+        })
+        _.each(res.hucs_near, place => {
+          ssr.push(place)
+        })
+        _.each(res.protected_areas_near, place => {
+          ssr.push(place)
+        })
+
+        ssr.sort((a, b) => {
+          return a.name > b.name
+        })
+
+        // Sort the community names, if present
+        let communities = []
+        if (res.communities) {
+          // Restructure communities into an array to sort
+          _.each(res.communities, community => {
+            communities.push(community)
+          })
+          communities.sort((a, b) => {
+            return a.name > b.name
+          })
+        }
+        // Specifically make the communities key false if no matching communities
+        // were found.
+        if (_.isEmpty(communities)) {
+          communities = false
+        }
         Object.freeze(res) // remove reactivity of Vue, this is static
-        context.commit('setSearchResults', res)
+        context.commit('setSearchResults', {
+          areas: ssr,
+          communities: communities,
+          total_bounds: res.total_bounds,
+        })
       })
     }
   },

--- a/store/wildfire.js
+++ b/store/wildfire.js
@@ -28,6 +28,46 @@ export const getters = {
   scenarios() {
     return ['Historical', 'RCP 4.5', 'RCP 6.0', 'RCP 8.5']
   },
+  vegTypes() {
+    return {
+      not_modeled: {
+        label: 'Not Modeled',
+        color: '#a6cee3',
+      },
+      barren_lichen_moss: {
+        label: 'Barren/Lichen/Moss',
+        color: '#ff7f00',
+      },
+      black_spruce: {
+        label: 'Black Spruce',
+        color: '#1f78b4',
+      },
+      deciduous_forest: {
+        label: 'Deciduous Forest',
+        color: '#33a02c',
+      },
+      graminoid_tundra: {
+        label: 'Graminoid Tundra',
+        color: '#e31a1c',
+      },
+      shrub_tundra: {
+        label: 'Shrub Tundra',
+        color: '#fb9a99',
+      },
+      temperate_rainforest: {
+        label: 'Temperate Rainforest',
+        color: '#cab2d6',
+      },
+      wetland_tundra: {
+        label: 'Wetland Tundra',
+        color: '#fdbf6f',
+      },
+      white_spruce: {
+        label: 'White Spruce',
+        color: '#b2df8a',
+      },
+    }
+  },
   flammability(state, getters, rootState, rootGetters) {
     return state.flammability
   },

--- a/store/wildfire.js
+++ b/store/wildfire.js
@@ -13,30 +13,20 @@ export const state = () => ({
 
 export const getters = {
   eras() {
-    return [
-      '2010-2019',
-      '2020-2029',
-      '2030-2039',
-      '2040-2049',
-      '2050-2059',
-      '2060-2069',
-      '2070-2079',
-      '2080-2089',
-      '2090-2099',
-    ]
+    return ['1950-2008', '2010-2039', '2040-2069', '2070-2099']
   },
   models() {
     return [
-      '5 Model Average',
+      'CRU TS 4.0',
+      'NCAR CCSM4',
       'GFDL CM3',
       'GISS E2-R',
       'IPSL CM5A-LR',
       'MRI CGCM3',
-      'NCAR CCSM4',
     ]
   },
   scenarios() {
-    return ['RCP 4.5', 'RCP 6.0', 'RCP 8.5']
+    return ['Historical', 'RCP 4.5', 'RCP 6.0', 'RCP 8.5']
   },
   flammability(state, getters, rootState, rootGetters) {
     return state.flammability

--- a/store/wildfire.js
+++ b/store/wildfire.js
@@ -12,6 +12,32 @@ export const state = () => ({
 })
 
 export const getters = {
+  eras() {
+    return [
+      '2010-2019',
+      '2020-2029',
+      '2030-2039',
+      '2040-2049',
+      '2050-2059',
+      '2060-2069',
+      '2070-2079',
+      '2080-2089',
+      '2090-2099',
+    ]
+  },
+  models() {
+    return [
+      '5 Model Average',
+      'GFDL CM3',
+      'GISS E2-R',
+      'IPSL CM5A-LR',
+      'MRI CGCM3',
+      'NCAR CCSM4',
+    ]
+  },
+  scenarios() {
+    return ['RCP 4.5', 'RCP 6.0', 'RCP 8.5']
+  },
   flammability(state, getters, rootState, rootGetters) {
     return state.flammability
   },
@@ -62,13 +88,12 @@ export const actions = {
 
     let vegChangeQueryUrl =
       process.env.apiUrl +
-      '/alfresco/veg_change/' +
+      '/alfresco/veg_type/' +
       context.rootGetters['place/urlFragment']
     let veg_change = await this.$axios.$get(vegChangeQueryUrl).catch(err => {
       let httpError = getHttpError(err)
       context.commit('setVegChangeHttpError', httpError)
     })
-    let convertedVegChange = convertToPercent(veg_change)
-    context.commit('setVegChange', convertedVegChange)
+    context.commit('setVegChange', veg_change)
   },
 }

--- a/store/wildfire.js
+++ b/store/wildfire.js
@@ -15,14 +15,25 @@ export const getters = {
   eras() {
     return ['1950-2008', '2010-2039', '2040-2069', '2070-2099']
   },
-  models() {
+  vegModels() {
     return [
-      'CRU TS 4.0',
+      '',
       'NCAR CCSM4',
       'GFDL CM3',
       'GISS E2-R',
       'IPSL CM5A-LR',
       'MRI CGCM3',
+    ]
+  },
+  flammabilityModels() {
+    return [
+      '',
+      '5modelAvg',
+      'GFDL-CM3',
+      'GISS-E2-R',
+      'IPSL-CM5A-LR',
+      'MRI-CGCM3',
+      'NCAR-CCSM4',
     ]
   },
   scenarios() {


### PR DESCRIPTION
This PR is is a combination of things:
- New vegetation mini-maps that show different vegetation types, not just transitions between them.
- New vegetation charts that show the percentage of each vegetation type.
- Flammability maps are now using the new 30-year era Rasdaman coverage, `alfresco_relative_flammability_30yr`. This coverage is currently only on Apollo but is in the process of being added to Zeus as well.
- The work from PRs #267, #281, #282, #283 has been folded into this PR for the purposes of showing off the latest Climate Impact Reports demo. We wanted to show our work on the dev server before merging into `main`, so several PRs were combined into this branch before we had a chance to review the PRs individually. I'll comment in this PR when I am done reviewing the work that was not mine.

Closes #190.
Closes #201.
Closes #247.
Closes #256.
Closes #269.
Closes #272.
Closes #277.