### PR TITLE
Fix area/community name sort bug in Chrome

### DIFF
--- a/store/place.js
+++ b/store/place.js
@@ -228,9 +228,7 @@ export const actions = {
           ssr.push(place)
         })
 
-        ssr.sort((a, b) => {
-          return a.name > b.name
-        })
+        ssr = _.sortBy(ssr, ['name'])
 
         // Sort the community names, if present
         let communities = []
@@ -239,9 +237,7 @@ export const actions = {
           _.each(res.communities, community => {
             communities.push(community)
           })
-          communities.sort((a, b) => {
-            return a.name > b.name
-          })
+          communities = _.sortBy(communities, ['name'])
         }
         // Specifically make the communities key false if no matching communities
         // were found.


### PR DESCRIPTION
Revisiting and doing a proper review of #281 (which was swept up in our demo branch previously), I discovered that area and community names are not being sorted properly in Chrome even though they are sorted properly in Firefox and Safari. This is because our custom sort function returns a boolean instead of an integer, which is technically incorrect but still works in Firefox and Safari.

Lodash provides a function that does this for us, so I've switched to that.

To test, see how communities and areas are sorted between the `main` branch and this branch in Chrome, here:

http://localhost:3000/search/61.77/-148.78#map-search
