### PR TITLE
Use estimated depth for imperial units for PF, adjust text to clarify ground freeze

### DIFF
--- a/components/reports/QualitativeText.vue
+++ b/components/reports/QualitativeText.vue
@@ -73,7 +73,7 @@ export default {
       }
     },
     depthFragment() {
-      return this.units == 'imperial' ? '9.8ft' : '3m'
+      return this.units == 'imperial' ? 'about 10ft' : '3m'
     },
     qualitativeText() {
       return this.generateText()

--- a/components/reports/permafrost/PermafrostReport.vue
+++ b/components/reports/permafrost/PermafrostReport.vue
@@ -71,7 +71,9 @@
           >
             Projected permafrost active layer thickness and ground freeze depth
             through the end of the century are shown below. The active layer is
-            the layer of soil above permafrost that thaws seasonally.
+            the layer of soil above permafrost that thaws seasonally. Ground
+            freeze is the maximum depth to which winter freeze occurs in
+            non-permafrost areas.
           </span>
           <span
             v-show="
@@ -88,7 +90,8 @@
             "
           >
             Projected ground freeze depth through the end of the century is
-            shown below.
+            shown below. Ground freeze is the maximum depth to which winter
+            freeze occurs in non-permafrost areas.
           </span>
           <span v-show="permafrostUncertain"
             >A chart of the historical and projected mean annual ground
@@ -155,7 +158,7 @@ export default {
         : '&#x00B1;1&deg;C'
     },
     depthFragment() {
-      return this.units == 'imperial' ? '9.8ft' : '3m'
+      return this.units == 'imperial' ? 'about 10ft' : '3m'
     },
     ...mapGetters({
       units: 'units',


### PR DESCRIPTION
Closes #241 

Test this by noting that "about 10ft" shows up instead of "9.8ft" for estimated depths.  Check combinations of places with different kinds of permafrost presence (permafrost present + disappears, permafrost present + stays, permafrost not present, uncertain) to validate the text blocks.

