### PR TITLE
Move Beta Feedback into its own component, add it to the report view

### DIFF
--- a/components/App.vue
+++ b/components/App.vue
@@ -4,25 +4,7 @@
       <div v-show="!this.reportIsVisible" class="place-selector">
         <div class="container">
           <section class="section">
-            <b-message
-              title="This is a public beta test of this tool"
-              type="is-warning"
-              aria-close-label="Close message"
-            >
-              Thanks for checking out this tool! Right now, this is a public
-              beta, which means that we&rsquo;re still gathering feedback,
-              testing the data outputs and fixing bugs. We&rsquo;d love to hear
-              your feedback. Email us at
-              <a href="mailto:uaf-snap-data-tools@alaska.edu"
-                >uaf-snap-data-tools@alaska.edu</a
-              >
-              with your thoughts, or
-              <a
-                href="https://uaf.us10.list-manage.com/subscribe?u=e42f589030a3adcaddd9b3304&id=d349c58c8f"
-                >sign up for our occasional newsletter</a
-              >
-              to be notified when this tool is launched.
-            </b-message>
+            <BetaFeedback />
             <div class="columns" id="controls">
               <!-- ID above (#controls) is used as anchor target, don't remove -->
               <div class="column is-one-half">
@@ -49,6 +31,7 @@ import MapWrapper from '~/components/MapWrapper'
 import Report from '~/components/Report'
 import PlaceSelector from '~/components/PlaceSelector'
 import LatLngSelector from '~/components/LatLngSelector'
+import BetaFeedback from '~/components/BetaFeedback'
 
 import { mapGetters } from 'vuex'
 
@@ -59,6 +42,7 @@ export default {
     Report,
     LatLngSelector,
     PlaceSelector,
+    BetaFeedback,
   },
   computed: {
     ...mapGetters(['reportIsVisible']),

--- a/components/BetaFeedback.vue
+++ b/components/BetaFeedback.vue
@@ -1,0 +1,44 @@
+<template>
+	<div class="beta-feedback">
+		<b-message
+			title="This is a public beta test of this tool"
+			type="is-warning"
+			class="beta-feedback-box"
+			aria-close-label="Close message"
+			><p>
+				Thanks for checking out this tool! Right now, this is a public beta,
+				which means that we&rsquo;re still gathering feedback, testing the data
+				outputs and fixing bugs. We&rsquo;d love to hear your feedback!
+				<a href="https://uaf-iarc.typeform.com/to/FN95Zbq2">
+					Take a short feedback survey</a
+				>, or email us at
+				<a href="mailto:uaf-snap-data-tools@alaska.edu"
+					>uaf-snap-data-tools@alaska.edu</a
+				>
+				if you encounter a problem.
+				<a
+					href="https://uaf.us10.list-manage.com/subscribe?u=e42f589030a3adcaddd9b3304&id=d349c58c8f"
+					>Sign up for our occasional newsletter</a
+				>
+				to be notified when this tool is launched.
+			</p>
+		</b-message>
+	</div>
+</template>
+<style lang="scss" scoped>
+::v-deep .message-header p:not(:last-child) {
+	margin-bottom: 0;
+}
+.beta-feedback-box .media-content p {
+	color: #333;
+
+	a {
+		font-weight: 600;
+	}
+}
+</style>
+<script>
+export default {
+	name: 'BetaFeedback',
+}
+</script>

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="results" class="container">
-    <BackButton/>
+    <BackButton />
     <hr />
     <section v-if="$fetchState.pending" class="section content">
       <!-- Drama dots -->
@@ -39,12 +39,16 @@
             <span v-if="type == 'latLng'"
               >The <span v-if="climateData">tables and </span>charts below are
               specific to the gridded data extracted at
-              <span v-html="place"></span>.  The polygon region on the map corresponds to the nearest watershed (hydrological unit, level 12).</span
+              <span v-html="place"></span>. The polygon region on the map
+              corresponds to the nearest watershed (hydrological unit, level
+              12).</span
             >
             <span v-else-if="type == 'community'"
               >The <span v-if="climateData">tables and </span>charts below are
               specific to the gridded data extracted from the location of
-              <span v-html="place"></span>.  The polygon region on the map corresponds to the nearest watershed (hydrological unit, level 12).</span
+              <span v-html="place"></span>. The polygon region on the map
+              corresponds to the nearest watershed (hydrological unit, level
+              12).</span
             >
             <span v-else
               >Data for the tables and charts below have been averaged across
@@ -148,6 +152,9 @@
             </li>
           </ul>
         </div>
+      </section>
+      <section class="content">
+        <BetaFeedback />
       </section>
       <section class="section content py-0 large-screen" v-if="dataMissing">
         <div class="is-size-5">

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -1,6 +1,9 @@
 <template>
   <section class="section">
     <div class="content-wrapper">
+
+      <BetaFeedback />
+
       <div class="content is-size-5">
         <ul class="toc">
           <li>

--- a/pages/data.vue
+++ b/pages/data.vue
@@ -1,6 +1,9 @@
 <template>
   <section class="section">
     <div class="content-wrapper">
+
+      <BetaFeedback />
+
       <div class="content is-size-5">
         <ul class="toc">
           <li>


### PR DESCRIPTION
Closes #318.

This PR adds a link to the feedback form (which may evolve beyond what it is right now), and adds the beta feedback block to the report view in a prominent location as well.  The beta block is also added to the two content pages.

It didn't look or work well as a sticky-header.

Test by observing that the beta feedback block is visible + looks OK in all places (when you first load the page, and also below the report intro, and then at the top of the two content pages).