### PR TITLE
Fix vegetation mini-map era mislabel by separating flammability and vegetation eras

### DIFF
--- a/components/reports/wildfire/ReportFlammabilityMap.vue
+++ b/components/reports/wildfire/ReportFlammabilityMap.vue
@@ -39,7 +39,7 @@ export default {
     ...mapGetters({
       latLng: 'place/latLng',
       geoJSON: 'place/geoJSON',
-      eras: 'wildfire/eras',
+      eras: 'wildfire/flammabilityEras',
       models: 'wildfire/flammabilityModels',
       scenarios: 'wildfire/scenarios',
     }),

--- a/components/reports/wildfire/ReportVegChangeChart.vue
+++ b/components/reports/wildfire/ReportVegChangeChart.vue
@@ -60,6 +60,7 @@ export default {
   },
   computed: {
     ...mapGetters({
+      vegEras: 'wildfire/vegEras',
       vegChangeData: 'wildfire/veg_change',
       vegTypes: 'wildfire/vegTypes',
       place: 'place/name',
@@ -103,8 +104,7 @@ export default {
 
       Object.keys(this.vegTypes).forEach(type => {
         let yValues = []
-        let eras = ['1950-2008', '2010-2039', '2040-2069', '2070-2099']
-        eras.forEach(era => {
+        this.vegEras.forEach(era => {
           if (era == '1950-2008') {
             yValues.push(vegChangeData[era]['MODEL-SPINUP']['historical'][type])
           } else {
@@ -128,7 +128,7 @@ export default {
             symbol: symbols[type],
             color: this.vegTypes[type]['color'],
           },
-          x: eras,
+          x: this.vegEras,
           y: [yValues[0]],
         }
 
@@ -143,7 +143,7 @@ export default {
             symbol: symbols[type],
             color: this.vegTypes[type]['color'],
           },
-          x: eras,
+          x: this.vegEras,
           y: [null].concat(yValues.slice(1)),
           customdata: [null],
         }

--- a/components/reports/wildfire/ReportVegChangeMap.vue
+++ b/components/reports/wildfire/ReportVegChangeMap.vue
@@ -39,7 +39,7 @@ export default {
     ...mapGetters({
       latLng: 'place/latLng',
       geoJSON: 'place/geoJSON',
-      eras: 'wildfire/eras',
+      vegEras: 'wildfire/vegEras',
       models: 'wildfire/vegModels',
       scenarios: 'wildfire/scenarios',
     }),
@@ -47,7 +47,7 @@ export default {
       return 'veg_change_' + this.scenario + '_' + this.model + '_' + this.era
     },
     mapEra() {
-      return this.eras[this.era]
+      return this.vegEras[this.era]
     },
     mapModel() {
       if (this.models[this.model] != '') {

--- a/store/wildfire.js
+++ b/store/wildfire.js
@@ -13,8 +13,11 @@ export const state = () => ({
 })
 
 export const getters = {
-  eras() {
+  flammabilityEras() {
     return ['1950-1979', '1980-2008', '2010-2039', '2040-2069', '2070-2099']
+  },
+  vegEras() {
+    return ['1950-2008', '2010-2039', '2040-2069', '2070-2099']
   },
   vegModels() {
     return [


### PR DESCRIPTION
This fixes the vegetation mini-map era labels. Before this change, the mini-maps were mislabeled with the following eras:

- 1950-1979
- 1980-2008
- 2010-2039
- 2040-2069

With this change, the labels have been correct to be:

- 1950-2008
- 2010-2039
- 2040-2069
- 2070-2099

This bug occurred because we split the historical flammability into two eras, and the vegetation mini-maps were using the same set of eras for their labels.