### PR TITLE
Fix vegetation mini-map model positions to match Rasdaman and remove spaces from flammability model names

### DIFF
--- a/components/reports/wildfire/ReportVegChangeMaps.vue
+++ b/components/reports/wildfire/ReportVegChangeMaps.vue
@@ -9,13 +9,13 @@
         <b-radio
           v-model="veg_maps_model_selection"
           name="veg_maps_model_selection"
-          native-value="1"
+          native-value="5"
           >NCAR CCSM4</b-radio
         >
         <b-radio
           v-model="veg_maps_model_selection"
           name="veg_maps_model_selection"
-          native-value="5"
+          native-value="4"
           >MRI CGCM3</b-radio
         >
       </b-field>
@@ -118,7 +118,7 @@ export default {
   },
   data() {
     return {
-      veg_maps_model_selection: 1,
+      veg_maps_model_selection: 5,
     }
   },
 }

--- a/store/wildfire.js
+++ b/store/wildfire.js
@@ -19,22 +19,22 @@ export const getters = {
   vegModels() {
     return [
       '', // Leave historical blank.
-      'NCAR CCSM4',
       'GFDL CM3',
       'GISS E2-R',
       'IPSL CM5A-LR',
       'MRI CGCM3',
+      'NCAR CCSM4',
     ]
   },
   flammabilityModels() {
     return [
       '', // Leave historical blank.
       '5modelAvg',
-      'GFDL-CM3',
-      'GISS-E2-R',
-      'IPSL-CM5A-LR',
-      'MRI-CGCM3',
-      'NCAR-CCSM4',
+      'GFDL CM3',
+      'GISS E2-R',
+      'IPSL CM5A-LR',
+      'MRI CGCM3',
+      'NCAR CCSM4',
     ]
   },
   scenarios() {


### PR DESCRIPTION
To test to make sure the vegetation mini-maps are now loading the correct models, here are screenshots taken from the corresponding vegetation mode GeoTIFFs around Chena Hot Springs area in QGIS for comparison:

**2070-2099, MRI-CGCM3, RCP 8.5**
<img width="230" alt="2070-2099_MRI-CGCM3_rcp85" src="https://user-images.githubusercontent.com/2566292/164116027-f953772b-2f51-4f7f-969a-7cb56a7a56c9.png">

**2070-2099, NCAR-CCSM4, RCP 8.5**
<img width="230" alt="2070-2099_NCAR-CCSM4_rcp85" src="https://user-images.githubusercontent.com/2566292/164116048-d541c44c-044c-4876-9654-10780afb40f7.png">

