### PR TITLE
Move category/color table into reusable component, use it for MAGT category/color table, and make slight improvements to veg color key

### DIFF
--- a/components/reports/ColorTable.vue
+++ b/components/reports/ColorTable.vue
@@ -1,0 +1,91 @@
+<template>
+  <div class="content">
+    <table class="table">
+      <thead>
+        <tr>
+          <th scope="col" style="min-width: 16rem">Category</th>
+          <th scope="col" style="min-width: 10rem">{{ unitLabel }}</th>
+          <th scope="col" v-if="showInterpretation()">Interpretation</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="(threshold, index) in thresholds">
+          <th scope="row" class="category">
+            <div
+              class="swatch"
+              :class="{ bordered: ifBordered(index) }"
+              :style="{ 'background-color': threshold['color'] }"
+            />
+            {{ threshold['label'] }}
+          </th>
+          <td class="numbers">
+            <span v-if="threshold['min'] == rangeMin()"
+              >&lt;{{ threshold['max'] }}<span v-html="unitSymbol"
+            /></span>
+            <span v-else-if="threshold['max'] == rangeMax()"
+              >&ge;{{ threshold['min'] }}<span v-html="unitSymbol"
+            /></span>
+            <span v-else
+              >&ge;{{ threshold['min'] }}<span v-html="unitSymbol" />, &lt;{{
+                threshold['max']
+              }}<span v-html="unitSymbol"
+            /></span>
+          </td>
+          <td v-if="showInterpretation()">
+            {{ threshold['interpretation'] }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.numbers {
+  font-family: 'IBM Plex Mono', monospace;
+  vertical-align: middle;
+}
+.category {
+  vertical-align: middle;
+}
+.swatch {
+  width: 20px;
+  height: 20px;
+  margin-right: 8px;
+  display: inline-block;
+  vertical-align: middle;
+  margin-bottom: 2px;
+
+  &.bordered {
+    border: 1px solid #ccc;
+  }
+}
+</style>
+
+<script>
+import _ from 'lodash'
+import { mapGetters } from 'vuex'
+
+export default {
+  name: 'ColorTable',
+  props: ['thresholds', 'unitLabel', 'unitSymbol', 'borderedColors'],
+  methods: {
+    ifBordered(index) {
+      // Add border around pale colors to increase visibility
+      return _.includes(this.borderedColors, index)
+    },
+    showInterpretation() {
+      let interpretations = this.thresholds.map(x => x['interpretation'])
+      return !interpretations.every(_.isUndefined)
+    },
+    rangeMin() {
+      let minimums = this.thresholds.map(x => x['min'])
+      return _.min(minimums)
+    },
+    rangeMax() {
+      let maximums = this.thresholds.map(x => x['max'])
+      return _.max(maximums)
+    },
+  },
+}
+</script>

--- a/components/reports/permafrost/PermafrostReport.vue
+++ b/components/reports/permafrost/PermafrostReport.vue
@@ -60,6 +60,15 @@
       </div>
     </div>
     <ReportMagtMaps />
+    <div class="content mb-6">
+      <p>This table is a legend for the maps above.</p>
+      <ColorTable
+        unitLabel="Mean Annual Ground Temperature"
+        :unitSymbol="unitSymbol"
+        :thresholds="magtThresholds"
+        :borderedColors="[3, 4]"
+      />
+    </div>
 
     <div v-if="reportData">
       <div class="content">
@@ -133,6 +142,7 @@
 </style>
 <script>
 import ReportMagtMaps from './ReportMagtMaps'
+import ColorTable from '~/components/reports/ColorTable'
 import ReportAltThawChart from './ReportAltThawChart'
 import ReportAltFreezeChart from './ReportAltFreezeChart'
 import ReportMagtChart from './ReportMagtChart'
@@ -144,6 +154,7 @@ export default {
   name: 'PermafrostReport',
   components: {
     ReportMagtMaps,
+    ColorTable,
     ReportAltThawChart,
     ReportAltFreezeChart,
     ReportMagtChart,
@@ -160,12 +171,16 @@ export default {
     depthFragment() {
       return this.units == 'imperial' ? 'about 10ft' : '3m'
     },
+    unitSymbol() {
+      return this.units == 'imperial' ? '&deg;F' : '&deg;C'
+    },
     ...mapGetters({
       units: 'units',
       reportData: 'permafrost/permafrostData',
       permafrostPresent: 'permafrost/present',
       permafrostDisappears: 'permafrost/disappears',
       permafrostUncertain: 'permafrost/uncertain',
+      magtThresholds: 'permafrost/magtThresholds',
     }),
   },
 }

--- a/components/reports/permafrost/ReportMagtMaps.vue
+++ b/components/reports/permafrost/ReportMagtMaps.vue
@@ -52,58 +52,8 @@
         <ReportMagtMap scenario="2" :model="magt_model_selection" era="4" />
       </div>
     </div>
-    <table class="magt-legend">
-      <tbody>
-        <tr>
-          <td class="legend-20-below px-2">
-            <span class="is-pulled-left">
-              <span v-html="legendRedMin"></span>
-            </span>
-            <span class="is-pulled-right">
-              <span v-html="legendRedMax"></span>
-            </span>
-          </td>
-          <td class="legend-0 has-text-centered">
-            <span v-html="legendWhite"></span>
-          </td>
-          <td class="legend-20-above px-2">
-            <span class="is-pulled-left">
-              <span v-html="legendBlueMin"></span>
-            </span>
-            <span class="is-pulled-right">
-              <span v-html="legendBlueMax"></span>
-            </span>
-          </td>
-        </tr>
-      </tbody>
-    </table>
   </section>
 </template>
-
-<style lang="scss" scoped>
-.magt-legend {
-  width: 800px;
-  height: 26px;
-  border: 1px solid #999;
-  margin: 40px auto 0 auto;
-  font-weight: 700;
-  color: #fff;
-  text-shadow: 0 0 3px #000;
-  .legend-20-below {
-    width: 47.5%;
-    background: linear-gradient(90deg, #0000ffff 0%, #a0a0ffff 100%);
-  }
-  .legend-0 {
-    color: #000;
-    text-shadow: none;
-    width: 5%;
-  }
-  .legend-20-above {
-    width: 47.5%;
-    background: linear-gradient(90deg, #ffa0a0ff 0%, #ff0000ff 100%);
-  }
-}
-</style>
 
 <script>
 import ReportMagtMap from './ReportMagtMap'
@@ -115,24 +65,8 @@ export default {
   },
   computed: {
     ...mapGetters({
-      units: 'units',
       place: 'place/name',
     }),
-    legendRedMin() {
-      return this.units == 'imperial' ? '-4&deg;F' : '-20&deg;C'
-    },
-    legendRedMax() {
-      return this.units == 'imperial' ? '30.2&deg;F' : '-1&deg;C'
-    },
-    legendWhite() {
-      return this.units == 'imperial' ? '32&deg;F' : '0&deg;C'
-    },
-    legendBlueMin() {
-      return this.units == 'imperial' ? '33.8&deg;F' : '1&deg;C'
-    },
-    legendBlueMax() {
-      return this.units == 'imperial' ? '68&deg;F' : '20&deg;C'
-    },
   },
   data() {
     return {

--- a/components/reports/wildfire/ReportVegChangeMaps.vue
+++ b/components/reports/wildfire/ReportVegChangeMaps.vue
@@ -73,9 +73,13 @@
     <div class="legend">
       <div
         class="color is-flex is-flex-direction-row"
-        v-for="vegType in vegTypes"
+        v-for="(vegType, key, index) in vegTypes"
       >
-        <div class="swatch" :style="'background-color: ' + vegType['color']" />
+        <div
+          class="swatch"
+          :class="{ bordered: ifBordered(index) }"
+          :style="'background-color: ' + vegType['color']"
+        />
         <div>{{ vegType['label'] }}</div>
       </div>
     </div>
@@ -85,20 +89,24 @@
 <style lang="scss" scoped>
 .legend {
   overflow: hidden;
-  max-width: 600px;
+  max-width: 660px;
   margin: 20px auto;
   line-height: 1.2;
 }
 .color {
-  width: 200px;
+  width: 220px;
+  padding: 0 10px;
   float: left;
   margin: 4px 0;
 }
 .swatch {
   width: 20px;
   height: 20px;
-  border: 1px solid #999999;
   margin-right: 8px;
+
+  &.bordered {
+    border: 1px solid #ccc;
+  }
 }
 </style>
 
@@ -115,6 +123,14 @@ export default {
       place: 'place/name',
       vegTypes: 'wildfire/vegTypes',
     }),
+  },
+  methods: {
+    ifBordered(index) {
+      // Add border around pale colors to increase visibility
+      let bordered = [0]
+      console.log(index)
+      return _.includes(bordered, index)
+    },
   },
   data() {
     return {

--- a/components/reports/wildfire/ReportVegChangeMaps.vue
+++ b/components/reports/wildfire/ReportVegChangeMaps.vue
@@ -128,7 +128,6 @@ export default {
     ifBordered(index) {
       // Add border around pale colors to increase visibility
       let bordered = [0]
-      console.log(index)
       return _.includes(bordered, index)
     },
   },

--- a/components/reports/wildfire/WildfireReport.vue
+++ b/components/reports/wildfire/WildfireReport.vue
@@ -32,41 +32,12 @@
         categories are also used in the short blurb in the introduction to this
         report.
       </p>
-      <table class="table">
-        <thead>
-          <tr>
-            <th scope="col" style="min-width: 10rem">Category</th>
-            <th scope="col" style="min-width: 10rem">Flammability</th>
-            <th scope="col">Interpretation</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-for="flamThreshold in flamThresholds">
-            <th scope="row" class="category">
-              <div
-                class="swatch"
-                :class="{ bordered: ifBordered(flamThreshold) }"
-                :style="{ 'background-color': flamThreshold['color'] }"
-              />
-              {{ flamThreshold['label'] }}
-            </th>
-            <td class="numbers">
-              <span v-if="flamThreshold['min'] == 0"
-                >&lt;{{ flamThreshold['max'] }}&#37;</span
-              >
-              <span v-else-if="flamThreshold['max'] == 100"
-                >&ge;{{ flamThreshold['min'] }}&#37;</span
-              >
-              <span v-else
-                >&ge;{{ flamThreshold['min'] }}&#37;, &lt;{{
-                  flamThreshold['max']
-                }}&#37;</span
-              >
-            </td>
-            <td>{{ flamThreshold['interpretation'] }}</td>
-          </tr>
-        </tbody>
-      </table>
+      <ColorTable
+        unitLabel="Flammability"
+        unitSymbol="%"
+        :thresholds="flamThresholds"
+        :borderedColors="[0]"
+      />
     </div>
 
     <div class="chart-wrapper">
@@ -127,6 +98,7 @@ import ReportFlammabilityChart from './ReportFlammabilityChart'
 import ReportVegChangeMaps from './ReportVegChangeMaps'
 import ReportVegChangeChart from './ReportVegChangeChart'
 import DownloadCsvButton from '~/components/reports/DownloadCsvButton'
+import ColorTable from '~/components/reports/ColorTable'
 import { mapGetters } from 'vuex'
 
 export default {
@@ -137,18 +109,12 @@ export default {
     ReportVegChangeMaps,
     ReportVegChangeChart,
     DownloadCsvButton,
+    ColorTable,
   },
   computed: {
     ...mapGetters({
       flamThresholds: 'wildfire/flammabilityThresholds',
     }),
-  },
-  methods: {
-    ifBordered(flamThreshold) {
-      // Just want the very-low category to have a border
-      // to improve visibility
-      return flamThreshold.min == 0
-    },
   },
 }
 </script>

--- a/store/permafrost.js
+++ b/store/permafrost.js
@@ -135,6 +135,68 @@ export const getters = {
   scenarios() {
     return ['CRU TS 3.1', 'RCP 4.5', 'RCP 8.5']
   },
+  magtThresholds(state, getters, rootState, rootGetters) {
+    let thresholds = [
+      {
+        label: 'Continuous Permafrost',
+        min: -20,
+        max: -6,
+        color: '#2166ac',
+      },
+      {
+        label: 'Cold Discontinuous',
+        min: -6,
+        max: -4,
+        color: '#4393c3',
+      },
+      {
+        label: 'Discontinuous',
+        min: -4,
+        max: -2,
+        color: '#92c5de',
+      },
+      {
+        label: 'Cold Sporadic',
+        min: -2,
+        max: -1,
+        color: '#d1e5f0',
+      },
+      {
+        label: 'Sporadic',
+        min: -1,
+        max: 0,
+        color: '#f7f7f7',
+      },
+      {
+        label: 'Permafrost Possible',
+        min: 0,
+        max: 1,
+        color: '#fddbc7',
+      },
+      {
+        label: 'Permafrost Unlikely',
+        min: 1,
+        max: 2,
+        color: '#f4a582',
+      },
+      {
+        label: 'No Permafrost',
+        min: 2,
+        max: 20,
+        color: '#d6604d',
+      },
+    ]
+    let keys = ['min', 'max']
+    thresholds.forEach(threshold => {
+      keys.forEach(key => {
+        threshold[key] =
+          rootGetters.units == 'imperial'
+            ? parseFloat((threshold[key] * 1.8 + 32).toFixed())
+            : threshold[key]
+      })
+    })
+    return thresholds
+  },
   permafrostData(state) {
     return state.permafrostData
   },


### PR DESCRIPTION
Closes #321.
Xref: #305.

This PR moves the flammability category & color key / table into a new component, which is now also used for the permafrost MAGT mini-map category & color table (replacing the previous MAGT map legend). Unlike the flammability category & color table, the MAGT table is set up to convert units between imperial and metric for the temperature thresholds.

I thought about also turning the vegetation type color key into a table, but since there is no threshold information to go along with it, there wouldn't be much information to put in a vegetation type color table. I did add a little bit more whitespace to the vegetation color key, however.

STR:
- Point to Rasdaman on Apollo to see the MAGT mini-maps using the new color map. `export RASDAMAN_URL=https://apollo.snap.uaf.edu/rasdaman/ows` Note: The flammability and veg type mini-maps will be blank when loading from Apollo. If you need to see those, unset `RASDAMAN_URL`.
- Load a report for any location that has both permafrost and flammability data and make sure both of these sections have color tables (and they both look similar to each other)

The title of this PR is sufficient for the git merge comment.