### PR TITLE
Update chart titles

### DIFF
--- a/components/reports/permafrost/ReportAltFreezeChart.vue
+++ b/components/reports/permafrost/ReportAltFreezeChart.vue
@@ -43,7 +43,7 @@ export default {
 
       let units = this.units == 'metric' ? 'm' : 'in'
       let precision = this.units == 'metric' ? 2 : 1
-      let title = 'Ground freeze depth, ' + this.place
+      let title = 'Ground freeze depth,<br>' + this.place + ', 1995-2100'
       let yAxisLabel = 'Depth (' + units + ')'
       let layout = getLayout(title, yAxisLabel)
       let dataTraces = []

--- a/components/reports/permafrost/ReportAltThawChart.vue
+++ b/components/reports/permafrost/ReportAltThawChart.vue
@@ -43,7 +43,7 @@ export default {
 
       let units = this.units == 'metric' ? 'm' : 'in'
       let precision = this.units == 'metric' ? 2 : 1
-      let title = 'Active layer thickness, ' + this.place
+      let title = 'Active layer thickness,<br>' + this.place + ', 1995-2100'
       let yAxisLabel = 'Thickness (' + units + ')'
       let layout = getLayout(title, yAxisLabel)
       let dataTraces = []

--- a/components/reports/permafrost/ReportMagtChart.vue
+++ b/components/reports/permafrost/ReportMagtChart.vue
@@ -43,7 +43,7 @@ export default {
 
       let units = this.units == 'metric' ? 'ºC' : 'ºF'
       let precision = this.units == 'metric' ? 2 : 1
-      let title = 'Mean annual ground temperature, ' + this.place
+      let title = 'Mean annual ground temperature,<br>' + this.place + ', 1950-2100'
       let yAxisLabel = 'Temperature (' + units + ')'
       let layout = getLayout(title, yAxisLabel)
       let dataTraces = []

--- a/components/reports/permafrost/ReportMagtMaps.vue
+++ b/components/reports/permafrost/ReportMagtMaps.vue
@@ -2,7 +2,7 @@
   <section class="section">
     <h5 class="minimaps-section-title has-text-centered">
       Mean annual ground temperature,
-      <span v-html="place"></span>
+      <span v-html="place"></span>, 1995&ndash;2100
     </h5>
     <div class="is-size-6 mb-4">
       <b-field label="Model">

--- a/components/reports/precipitation/ReportPrecipChart.vue
+++ b/components/reports/precipitation/ReportPrecipChart.vue
@@ -60,7 +60,7 @@ export default {
       dataTraces = dataTraces.concat(projectedTraces)
 
       let title =
-        'Historical and projected precipitation (' + seasons[this.season] + ')'
+        'Precipitation, ' + this.place + ', 1950-2099, ' + seasons[this.season]
       let yAxisLabel = 'Precipitation (' + units + ')'
       let layout = getLayout(title, yAxisLabel)
 

--- a/components/reports/precipitation/ReportPrecipTable.vue
+++ b/components/reports/precipitation/ReportPrecipTable.vue
@@ -3,7 +3,7 @@
     <table class="table report-table" v-if="reportData">
       <caption>
         Precipitation,
-        <span v-html="place"></span>
+        <span v-html="place"></span>, 1950&ndash;2099
       </caption>
       <thead>
         <tr>

--- a/components/reports/temperature/ReportTempChart.vue
+++ b/components/reports/temperature/ReportTempChart.vue
@@ -16,7 +16,7 @@ import {
   getHistoricalTrace,
   getHistoricalRegion,
   getProjectedTraces,
-  seasons
+  seasons,
 } from '../../../utils/climate_charts'
 
 export default {
@@ -67,7 +67,11 @@ export default {
       dataTraces = dataTraces.concat(projectedTraces)
 
       let title =
-        'Historical and projected temperature (' + seasons[this.season] + ')'
+        'Temperature, ' +
+        this.place +
+        ', 1950-2099, ' +
+        seasons[this.season]
+
       let yAxisLabel = 'Temperature (' + units + ')'
       let layout = getLayout(title, yAxisLabel)
 

--- a/components/reports/temperature/ReportTempTable.vue
+++ b/components/reports/temperature/ReportTempTable.vue
@@ -3,7 +3,7 @@
     <table class="table report-table" v-if="reportData">
       <caption>
         Temperature,
-        <span v-html="place"></span>
+        <span v-html="place"></span>, 1950&ndash;2099
       </caption>
       <thead>
         <tr>

--- a/components/reports/wildfire/ReportFlammabilityChart.vue
+++ b/components/reports/wildfire/ReportFlammabilityChart.vue
@@ -23,6 +23,8 @@ export default {
       flammabilityData: 'wildfire/flammability',
       flamThresholds: 'wildfire/flammabilityThresholds',
       place: 'place/name',
+      isPointLocation: 'place/isPointLocation',
+      huc12Id: 'wildfire/huc12Id',
     }),
   },
   watch: {
@@ -37,7 +39,11 @@ export default {
         return
       }
 
-      let title = 'Flammability, ' + this.place + ', 1950-2099'
+      let name = this.isPointLocation
+        ? '<br>' + this.place + ' (HUC12 ID ' + this.huc12Id + ')'
+        : this.place
+
+      let title = 'Flammability, ' + name + ', 1950-2099'
       let yAxisLabel = 'Annual chance of burning (%)'
       let layout = getLayout(title, yAxisLabel)
 

--- a/components/reports/wildfire/ReportFlammabilityChart.vue
+++ b/components/reports/wildfire/ReportFlammabilityChart.vue
@@ -37,7 +37,7 @@ export default {
         return
       }
 
-      let title = 'Flammability, ' + this.place
+      let title = 'Flammability, ' + this.place + ', 1950-2099'
       let yAxisLabel = 'Annual chance of burning (%)'
       let layout = getLayout(title, yAxisLabel)
 

--- a/components/reports/wildfire/ReportFlammabilityMaps.vue
+++ b/components/reports/wildfire/ReportFlammabilityMaps.vue
@@ -2,7 +2,7 @@
   <section class="section">
     <h5 class="minimaps-section-title has-text-centered">
       Flammability,
-      <span v-html="place"></span>
+      <span v-html="place"></span>, 1950&ndash;2099
     </h5>
     <div class="is-size-6 mb-4">
       <b-field label="Model">

--- a/components/reports/wildfire/ReportVegChangeChart.vue
+++ b/components/reports/wildfire/ReportVegChangeChart.vue
@@ -83,7 +83,7 @@ export default {
         return
       }
 
-      let title = 'Vegetation type, ' + this.place
+      let title = 'Vegetation type, ' + this.place + ', 1950-2099'
       let yAxisLabel = 'Vegetation type coverage (%)'
       let layout = getLayout(title, yAxisLabel)
 

--- a/components/reports/wildfire/ReportVegChangeChart.vue
+++ b/components/reports/wildfire/ReportVegChangeChart.vue
@@ -63,6 +63,8 @@ export default {
       vegChangeData: 'wildfire/veg_change',
       vegTypes: 'wildfire/vegTypes',
       place: 'place/name',
+      isPointLocation: 'place/isPointLocation',
+      huc12Id: 'wildfire/huc12Id',
     }),
   },
   watch: {
@@ -83,7 +85,10 @@ export default {
         return
       }
 
-      let title = 'Vegetation type, ' + this.place + ', 1950-2099'
+      // Put the name of the HUC12 if it's a point location.
+      let name = this.isPointLocation ? '<br>' + this.place + ' (HUC12 ID ' + this.huc12Id + ')' : this.place
+
+      let title = 'Vegetation type, ' + name + ', 1950-2099'
       let yAxisLabel = 'Vegetation type coverage (%)'
       let layout = getLayout(title, yAxisLabel)
 

--- a/components/reports/wildfire/ReportVegChangeMaps.vue
+++ b/components/reports/wildfire/ReportVegChangeMaps.vue
@@ -1,8 +1,8 @@
 <template>
   <section class="section">
     <h5 class="minimaps-section-title has-text-centered">
-      Vegetation change,
-      <span v-html="place"></span>
+      Vegetation type,
+      <span v-html="place"></span>, 1950&ndash;2099
     </h5>
     <div class="is-size-6 mb-4">
       <b-field label="Model">

--- a/components/reports/wildfire/WildfireReport.vue
+++ b/components/reports/wildfire/WildfireReport.vue
@@ -17,6 +17,11 @@
           location has burned in model simulations. All data shown, including
           historical time periods, are model ouputs.
         </p>
+        <p v-if="this.isPointLocation">
+          Data shown in the charts below are for the region of the HUC 12 watershed which contains the
+          pixel location for <span v-html="place"></span> (HUC ID
+          <span v-html="huc12Id"></span>).
+        </p>
         <p>
           <nuxt-link :to="{ name: 'data', hash: '#datasets' }"
             >See information about the dataset shown here.</nuxt-link
@@ -141,6 +146,9 @@ export default {
   computed: {
     ...mapGetters({
       flamThresholds: 'wildfire/flammabilityThresholds',
+      isPointLocation: 'place/isPointLocation',
+      huc12Id: 'wildfire/huc12Id',
+      place: 'place/name',
     }),
   },
   methods: {

--- a/utils/maps.js
+++ b/utils/maps.js
@@ -21,7 +21,7 @@ export const getBaseMapAndLayers = function () {
   var config = {
     zoom: 0,
     minZoom: 0,
-    maxZoom: 7,
+    maxZoom: 6,
     center: [64.7, -155],
     scrollWheelZoom: false,
     dragging: false,


### PR DESCRIPTION
Closes #331 
Closes #275 
Ref #290 

 * Improves titles by ensuring that the [What] [Where] [When] template is followed for all chart titles.
 * Adds line breaks to chart titles to reduce the chance of them being too wide (#290, this isn't a complete fix)
 * Adds guarding code to prevent zoom level from being too high, which causes an app-breaking bug ("infinite tiles")
 * Adds HUC12 info to Flam/Veg chart titles + intro.
