### PR TITLE
Add dynamic line breaks to temp, precip, thaw, and freeze chart titles to fix width issues

### DIFF
--- a/components/reports/permafrost/ReportAltFreezeChart.vue
+++ b/components/reports/permafrost/ReportAltFreezeChart.vue
@@ -6,13 +6,18 @@
 <script>
 import _ from 'lodash'
 import { mapGetters } from 'vuex'
-import { getPlotSettings, getLayout, getFooter } from '../../../utils/charts'
+import {
+  getPlotSettings,
+  buildTitle,
+  getLayout,
+  getFooter,
+} from '~/utils/charts'
 import {
   getHistoricalTrace,
   getHistoricalLine,
   getProjectedTraces,
   detectEmptyColumns,
-} from '../../../utils/permafrost_charts'
+} from '~/utils/permafrost_charts'
 
 export default {
   name: 'ReportAltFreezeChart',
@@ -43,7 +48,13 @@ export default {
 
       let units = this.units == 'metric' ? 'm' : 'in'
       let precision = this.units == 'metric' ? 2 : 1
-      let title = 'Ground freeze depth,<br>' + this.place + ', 1995-2100'
+
+      let title = buildTitle({
+        dataLabel: 'Ground freeze depth',
+        dateRange: '1995-2100',
+        place: this.place,
+      })
+
       let yAxisLabel = 'Depth (' + units + ')'
       let layout = getLayout(title, yAxisLabel)
       let dataTraces = []

--- a/components/reports/permafrost/ReportAltThawChart.vue
+++ b/components/reports/permafrost/ReportAltThawChart.vue
@@ -6,13 +6,18 @@
 <script>
 import _ from 'lodash'
 import { mapGetters } from 'vuex'
-import { getPlotSettings, getLayout, getFooter } from '../../../utils/charts'
+import {
+  getPlotSettings,
+  buildTitle,
+  getLayout,
+  getFooter,
+} from '~/utils/charts'
 import {
   getHistoricalTrace,
   getHistoricalLine,
   getProjectedTraces,
   detectEmptyColumns,
-} from '../../../utils/permafrost_charts'
+} from '~/utils/permafrost_charts'
 
 export default {
   name: 'ReportAltThawChart',
@@ -43,7 +48,13 @@ export default {
 
       let units = this.units == 'metric' ? 'm' : 'in'
       let precision = this.units == 'metric' ? 2 : 1
-      let title = 'Active layer thickness,<br>' + this.place + ', 1995-2100'
+
+      let title = buildTitle({
+        dataLabel: 'Active layer thickness',
+        dateRange: '1995-2100',
+        place: this.place,
+      })
+
       let yAxisLabel = 'Thickness (' + units + ')'
       let layout = getLayout(title, yAxisLabel)
       let dataTraces = []

--- a/components/reports/permafrost/ReportMagtChart.vue
+++ b/components/reports/permafrost/ReportMagtChart.vue
@@ -49,11 +49,11 @@ export default {
       let units = this.units == 'metric' ? 'ºC' : 'ºF'
       let precision = this.units == 'metric' ? 2 : 1
 
-      let title = buildTitle(
-        'Mean annual ground temperature',
-        '1950-2100',
-        this.place
-      )
+      let title = buildTitle({
+        dataLabel: 'Mean annual ground temperature',
+        dateRange: '1950-2100',
+        place: this.place,
+      })
 
       let yAxisLabel = 'Temperature (' + units + ')'
       let layout = getLayout(title, yAxisLabel)

--- a/components/reports/precipitation/ReportPrecipChart.vue
+++ b/components/reports/precipitation/ReportPrecipChart.vue
@@ -5,13 +5,18 @@
 <script>
 import _ from 'lodash'
 import { mapGetters } from 'vuex'
-import { getPlotSettings, getLayout, getFooter } from '../../../utils/charts'
+import {
+  getPlotSettings,
+  buildTitle,
+  getLayout,
+  getFooter,
+} from '~/utils/charts'
 import {
   getHistoricalTrace,
   getHistoricalRegion,
   getProjectedTraces,
   seasons,
-} from '../../../utils/climate_charts'
+} from '~/utils/climate_charts'
 
 export default {
   name: 'ReportPrecipChart',
@@ -59,8 +64,13 @@ export default {
       )
       dataTraces = dataTraces.concat(projectedTraces)
 
-      let title =
-        'Precipitation, ' + this.place + ', 1950-2099, ' + seasons[this.season]
+      let title = buildTitle({
+        dataLabel: 'Precipitation',
+        dateRange: '1950-2099',
+        place: this.place,
+        season: seasons[this.season],
+      })
+
       let yAxisLabel = 'Precipitation (' + units + ')'
       let layout = getLayout(title, yAxisLabel)
 

--- a/components/reports/temperature/ReportTempChart.vue
+++ b/components/reports/temperature/ReportTempChart.vue
@@ -11,13 +11,18 @@
 <script>
 import _ from 'lodash'
 import { mapGetters } from 'vuex'
-import { getPlotSettings, getLayout, getFooter } from '../../../utils/charts'
+import {
+  getPlotSettings,
+  buildTitle,
+  getLayout,
+  getFooter,
+} from '~/utils/charts'
 import {
   getHistoricalTrace,
   getHistoricalRegion,
   getProjectedTraces,
   seasons,
-} from '../../../utils/climate_charts'
+} from '~/utils/climate_charts'
 
 export default {
   name: 'ReportTempChart',
@@ -66,11 +71,12 @@ export default {
       )
       dataTraces = dataTraces.concat(projectedTraces)
 
-      let title =
-        'Temperature, ' +
-        this.place +
-        ', 1950-2099, ' +
-        seasons[this.season]
+      let title = buildTitle({
+        dataLabel: 'Temperature',
+        dateRange: '1950-2099',
+        place: this.place,
+        season: seasons[this.season],
+      })
 
       let yAxisLabel = 'Temperature (' + units + ')'
       let layout = getLayout(title, yAxisLabel)

--- a/components/reports/wildfire/ReportFlammabilityChart.vue
+++ b/components/reports/wildfire/ReportFlammabilityChart.vue
@@ -44,13 +44,12 @@ export default {
         return
       }
 
-      let title = buildTitle(
-        'Flammability',
-        '1950-2099',
-        this.place,
-        this.huc12Id,
-        this.isPointLocation
-      )
+      let title = buildTitle({
+        dataLabel: 'Flammability',
+        dateRange: '1950-2099',
+        place: this.place,
+        huc12Id: this.huc12Id,
+      })
 
       let yAxisLabel = 'Annual chance of burning (%)'
       let layout = getLayout(title, yAxisLabel)

--- a/components/reports/wildfire/ReportVegChangeChart.vue
+++ b/components/reports/wildfire/ReportVegChangeChart.vue
@@ -91,13 +91,12 @@ export default {
         return
       }
 
-      let title = buildTitle(
-        'Vegetation type',
-        '1950-2099',
-        this.place,
-        this.huc12Id,
-        this.isPointLocation
-      )
+      let title = buildTitle({
+        dataLabel: 'Vegetation type',
+        dateRange: '1950-2099',
+        place: this.place,
+        huc12Id: this.huc12Id,
+      })
 
       let yAxisLabel = 'Vegetation type coverage (%)'
       let layout = getLayout(title, yAxisLabel)

--- a/utils/charts.js
+++ b/utils/charts.js
@@ -16,19 +16,23 @@ export const getPlotSettings = function () {
   }
 }
 
-export const buildTitle = function (
-  dataLabel,
-  dateRange,
-  place,
-  huc12Id = null,
-  isPointLocation = false
-) {
+export const buildTitle = function (params) {
+  let dataLabel = params['dataLabel']
+  let dateRange = params['dateRange']
+  let place = params['place']
+  let huc12Id = params['huc12Id']
+  let season = params['season']
+
   let title = dataLabel + ',<br>'
   let huc12Label = ''
   if (huc12Id) {
     huc12Label = '(HUC12 ID ' + huc12Id + ')'
   }
   let totalLength = place.length + huc12Label.length + dateRange.length
+
+  if (season) {
+    totalLength += season.length
+  }
 
   if (totalLength > 60) {
     title += place
@@ -50,6 +54,10 @@ export const buildTitle = function (
       title += ' ' + huc12Label
     }
     title += ', ' + dateRange
+  }
+
+  if (season) {
+    title += ', ' + season
   }
 
   return title


### PR DESCRIPTION
Closes #290.

I think this PR finally solves all of the chart title width cropping issues for all charts. The following chart title widths had not been fixed yet:

- Temperature
- Precipitation
- Active layer thickness
- Ground freeze

This PR fixes the charts above by using the same (slightly reworked) dynamic line break `buildTitle` function that is already being used for the ALFRESCO and MAGT charts.

To test, make sure none of the charts have cropped (too wide) titles. I tested against these reports:

http://localhost:3000/report/community/AK375#results
http://localhost:3000/report/community/AK454#results
http://localhost:3000/report/community/AK309#results
http://localhost:3000/report/community/AK234#results
http://localhost:3000/report/community/AK93#results
http://localhost:3000/report/community/AK384#results