### PR TITLE
Left align color table text in Safari

### DIFF
--- a/components/reports/ColorTable.vue
+++ b/components/reports/ColorTable.vue
@@ -41,6 +41,9 @@
 </template>
 
 <style lang="scss" scoped>
+.content table th:not([align]) {
+  text-align: left;
+}
 .numbers {
   font-family: 'IBM Plex Mono', monospace;
   vertical-align: middle;


### PR DESCRIPTION
Closes #330.

STR:
- Load any report with a Mean Annual Ground Temperature or Flammability color table in Safari.
- Make sure everything in a table cell is left justified.