### PR TITLE
Add new "No Freeze" category to permafrost data for locations with no permafrost and no ground freeze.

### DIFF
--- a/components/reports/permafrost/PermafrostReport.vue
+++ b/components/reports/permafrost/PermafrostReport.vue
@@ -6,7 +6,10 @@
         <div v-if="reportData">
           <span
             v-show="
-              permafrostPresent && permafrostDisappears && !permafrostUncertain
+              permafrostPresent &&
+              permafrostDisappears &&
+              !permafrostUncertain &&
+              !noFreeze
             "
           >
             Historical data and model projections indicate that
@@ -18,14 +21,19 @@
           </span>
           <span
             v-show="
-              permafrostPresent && !permafrostDisappears && !permafrostUncertain
+              permafrostPresent &&
+              !permafrostDisappears &&
+              !permafrostUncertain &&
+              !noFreeze
             "
             >Historical data and model projections indicate that
             <strong>this place has permafrost.</strong>
           </span>
           <span
             v-show="
-              !permafrostPresent && permafrostDisappears && !permafrostUncertain
+              !permafrostPresent &&
+              (permafrostDisappears || noFreeze) &&
+              !permafrostUncertain
             "
           >
             <strong>
@@ -51,11 +59,8 @@
         </div>
         <div class="mt-5">
           The following maps show the historical and projected mean annual
-          ground temperature (MAGT) over time. In these model outputs, MAGT is
-          projected for the top of the permafrost layer, the depth of which
-          varies by location. Red represents temperatures above freezing, blue
-          represents temperatures below freezing, and white represents
-          temperatures near the freezing point.
+          ground temperature over time. This is the temperature of the soil
+          directly above the permafrost layer.
         </div>
       </div>
     </div>
@@ -102,7 +107,7 @@
             shown below. Ground freeze is the maximum depth to which winter
             freeze occurs in non-permafrost areas.
           </span>
-          <span v-show="permafrostUncertain"
+          <span v-show="permafrostUncertain || noFreeze"
             >A chart of the historical and projected mean annual ground
             temperature is provided below.
           </span>
@@ -114,7 +119,7 @@
       <div class="chart" v-show="this.permafrostDisappears">
         <ReportAltFreezeChart />
       </div>
-      <div class="chart" v-show="this.permafrostUncertain">
+      <div class="chart" v-show="this.permafrostUncertain || this.noFreeze">
         <ReportMagtChart />
       </div>
       <DownloadCsvButton
@@ -180,6 +185,7 @@ export default {
       permafrostPresent: 'permafrost/present',
       permafrostDisappears: 'permafrost/disappears',
       permafrostUncertain: 'permafrost/uncertain',
+      noFreeze: 'permafrost/noFreeze',
       magtThresholds: 'permafrost/magtThresholds',
     }),
   },

--- a/components/reports/permafrost/ReportMagtChart.vue
+++ b/components/reports/permafrost/ReportMagtChart.vue
@@ -69,20 +69,45 @@ export default {
       let projectedTraces = getProjectedTraces(magtData, units, precision)
       dataTraces = dataTraces.concat(projectedTraces)
 
-      layout.shapes.push({
-        type: 'rect',
-        x0: 0,
-        x1: 1,
-        xref: 'paper',
-        y0: freezing - uncertaintyOffset,
-        y1: freezing + uncertaintyOffset,
-        yref: 'y',
-        line: {
-          width: 0,
+      let uncertaintyRectMin = freezing - uncertaintyOffset
+      let uncertaintyRectMax = freezing + uncertaintyOffset
+
+      // Determine if any of the scatter markers are within the uncertainty zone
+      // before drawing the uncertainty rectangle. Otherwise it will stretch out
+      // the y-axis of the chart.
+      let withinUncertainty = _.reduceDeep(
+        magtData,
+        (acc, value) => {
+          if (acc == true) {
+            return acc
+          }
+          if (_.inRange(value, uncertaintyRectMin, uncertaintyRectMax)) {
+            return true
+          } else {
+            return false
+          }
         },
-        fillcolor: '#cccccc',
-        opacity: 0.2,
-      })
+        {
+          leavesOnly: true,
+        }
+      )
+
+      if (withinUncertainty) {
+        layout.shapes.push({
+          type: 'rect',
+          x0: 0,
+          x1: 1,
+          xref: 'paper',
+          y0: uncertaintyRectMin,
+          y1: uncertaintyRectMax,
+          yref: 'y',
+          line: {
+            width: 0,
+          },
+          fillcolor: '#cccccc',
+          opacity: 0.2,
+        })
+      }
 
       let footerLines = [
         'Projected values are taken from GIPL 2.0 model output.',


### PR DESCRIPTION
Closes #341.

This PR covers the rare cases where a location has no permafrost and also no seasonal ground freeze data (historical and projected ALT values are all set to `null`)

To test, load this report on the `main` branch vs. the `alt_all_null_fix` branch:

http://localhost:3000/report/community/AK465

Instead of an empty Ground Freeze chart, you should see a populated Mean Annual Ground Temperature chart. However, unlike other reports that show the Mean Annual Ground Temperature chart ([example](http://localhost:3000/report/60.76/-156.83#results)), the AK465 URL above has text that says:

> There is no permafrost within about 10ft of the ground surface at this location.

Instead of this:

> The presence or absence of permafrost could not be determined for this location because the historical mean annual ground temperature falls within the threshold of uncertainty (30.2–33.8°F).

All other types of permafrost reports for other locations should be the same as before, except I also removed some outdated text that described the old MAGT mini-map colormap, which has been replaced by the color table below the mini-maps.