### PR TITLE
Change vegetation chart to be a stacked bar chart, with RCPs shown side-by-side on the same chart

### DIFF
--- a/components/reports/wildfire/ReportVegChangeChart.vue
+++ b/components/reports/wildfire/ReportVegChangeChart.vue
@@ -87,10 +87,8 @@ export default {
       let yAxisLabel = 'Vegetation type coverage (%)'
       let layout = getLayout(title, yAxisLabel)
       layout['barmode'] = 'stack'
-      layout['hoverlabel']['bgcolor'] = '#fff'
-      layout['hoverlabel']['color'] = '#000'
       layout['xaxis']['showdividers'] = false
-      layout['yaxis']['hovermode'] = 'closest'
+      layout['hovermode'] = 'closest'
 
       let dataTraces = []
 
@@ -122,15 +120,7 @@ export default {
           },
           hovertemplate: '<b>%{x}</b>: %{y:.2f}%',
           x: [
-            [
-              '1950-2008',
-              '2010-2039',
-              '2010-2039',
-              '2040-2069',
-              '2040-2069',
-              '2070-2099',
-              '2070-2099',
-            ],
+            
             [
               'Historical',
               'RCP 4.5',
@@ -139,6 +129,15 @@ export default {
               'RCP 8.5',
               'RCP 4.5',
               'RCP 8.5',
+            ],
+            [
+              '1950-2008',
+              '2010-2039',
+              '2010-2039',
+              '2040-2069',
+              '2040-2069',
+              '2070-2099',
+              '2070-2099',
             ],
           ],
           y: yValues,

--- a/store/wildfire.js
+++ b/store/wildfire.js
@@ -90,7 +90,7 @@ export const getters = {
     return {
       not_modeled: {
         label: 'Not Modeled',
-        color: '#ffffff',
+        color: '#f8faf0',
       },
       barren_lichen_moss: {
         label: 'Barren/Lichen/Moss',

--- a/utils/charts.js
+++ b/utils/charts.js
@@ -109,17 +109,20 @@ export const getLayout = function (title, yAxisLabel) {
   }
 }
 
-export const getFooter = function (footerLines, layout) {
+export const getFooter = function (footerLines, layout, dynamicWidth = true) {
   let footerOffset = 0.05 * footerLines.length
   let footerY = -0.2 - footerOffset
   let yAxisAnnotationX = -0.04
-  if (window.innerWidth < 1250) {
-    layout['xaxis'] = {
-      tickangle: 45,
+
+  if (dynamicWidth) {
+    if (window.innerWidth < 1250) {
+      layout['xaxis'] = {
+        tickangle: 45,
+      }
+      layout['margin']['b'] = 160
+      footerY = -0.4 - footerOffset
+      yAxisAnnotationX = -0.06
     }
-    layout['margin']['b'] = 160
-    footerY = -0.4 - footerOffset
-    yAxisAnnotationX = -0.06
   }
 
   return {


### PR DESCRIPTION
Closes #346.

View the new stacked bar vegetation chart for any location and make sure all vegetation types show up together in the same hovertext for each era.