### PR TITLE
Add code to support First Nations, Game Management Units

### DIFF
--- a/components/PlaceSelector.vue
+++ b/components/PlaceSelector.vue
@@ -64,6 +64,18 @@
                 >
                   Fire Management Unit
                 </span>
+                <span
+                  class="area-additional-info"
+                  v-if="props.option.type == 'first_nation'"
+                >
+                  First Nation Traditional Territory
+                </span>
+                <span
+                  class="area-additional-info"
+                  v-if="props.option.type == 'game_management_unit'"
+                >
+                  Game Management Unit
+                </span>
               </div>
             </template>
           </b-autocomplete>

--- a/pages/data.vue
+++ b/pages/data.vue
@@ -154,14 +154,14 @@
               ></strong
             >
           </li>
-          <li><strong>Fire Management Units</strong></li>
+          <li><strong>Alaska Fire Management Units</strong></li>
           <li>
             <strong
               ><a
                 href="https://uaf.edu/anlc/resources/mapping_alaskas_native_languages.php"
                 >Ethnolinguistic regions</a
               ></strong
-            >
+            > of Alaska
           </li>
           <li>
             <strong
@@ -171,6 +171,8 @@
               ></strong
             >
           </li>
+          <li><strong>First Nation Traditional Territories of the Yukon</strong></li>
+          <li><strong>Alaska Game Management Units (GMUs)</strong>, e.g. GMU19a, etc.</li>
         </ul>
         <h2 id="access-api" class="title is-3">Data API access</h2>
         <p>

--- a/store/place.js
+++ b/store/place.js
@@ -134,6 +134,10 @@ export const getters = {
           return area.name + ' (Ethnolinguistic Region)'
         case 'fire_zone':
           return area.name + ' (Fire Management Unit)'
+        case 'first_nation':
+          return area.name + ' (First Nation Traditional Territory)'
+        case 'game_management_unit':
+          return area.name + ' (Game Management Unit)'
         default:
           return area.name
       }

--- a/utils/path.js
+++ b/utils/path.js
@@ -8,7 +8,9 @@ export const getAppPathFragment = function (type, id) {
     type == 'corporation' ||
     type == 'climate_division' ||
     type == 'ethnolinguistic_region' ||
-    type == 'fire_zone'
+    type == 'fire_zone' ||
+    type == 'first_nation' ||
+    type == 'game_management_unit'
   ) {
     path = '/report/area/' + id
   } else {


### PR DESCRIPTION
Closes #328

Run a local copy of the API on `main` (pull in any updates to get the API code needed).  To test this PR, search for some First Nation and Game Management Units; go to `localhost:5000/places/all` and pick some (they're at the end of the generated GeoJSON).  I'm not specifying which ones to try because you may find an issue I missed with the ones I tried.

Check three places for each of these:

 * Autocompleter should show appropriate small-caps "labels" describing what the type of place is,
 * Title of the place should include the same "label" on the report, charts (check for length!)
 * The Data page has more text added to Places to indicate that these places are available.

