### PR TITLE
Add specific pan/zoom to permafrost map if a point location is selected

### DIFF
--- a/components/reports/permafrost/ReportMagtMap.vue
+++ b/components/reports/permafrost/ReportMagtMap.vue
@@ -73,6 +73,7 @@ export default {
     this.map = L.map(this.mapID, this.getBaseMapAndLayers())
     if (this.latLng) {
       this.marker = L.marker(this.latLng).addTo(this.map)
+      this.map.flyTo(this.latLng, 4)
     }
   },
   watch: {


### PR DESCRIPTION
Closes #365 

Permafrost maps didn't have code to pan/zoom.

Test this by trying a point location on an island (from the linked issue -- none of these look awesome with the actual data, but it's OK) and verify that the location is panned/zoomed appropriately.  Try an area location and make sure that those still work properly too.