### PR TITLE
Fix some console errors when searching (+ some linting)

### DIFF
--- a/components/Map.vue
+++ b/components/Map.vue
@@ -190,10 +190,10 @@ export default {
 
             let defaultStyle, highlightedStyle
             // Set up the layer styles for HUC/Protected area
-            if(area.type == 'huc') {
+            if (area.type == 'huc') {
               defaultStyle = hucDefaultStyle
               highlightedStyle = hucHighlightedStyle
-            } else if(area.type == 'protected_area') {
+            } else if (area.type == 'protected_area') {
               defaultStyle = protectedAreaDefaultStyle
               highlightedStyle = protectedAreaHighlightedStyle
             }

--- a/components/MapWrapper.vue
+++ b/components/MapWrapper.vue
@@ -3,7 +3,10 @@
 		<div class="container">
 			<div class="section pullup content fullbleed">
 				<h4>Find a place by clicking on the map</h4>
-				<p><strong>Click the map</strong> to pick a location.  Nearby communities, protected areas and watersheds will be shown.</p>
+				<p>
+					<strong>Click the map</strong> to pick a location. Nearby communities,
+					protected areas and watersheds will be shown.
+				</p>
 			</div>
 		</div>
 		<div id="map-search">
@@ -83,30 +86,24 @@ export default {
 			mapSearchIsVisible: 'mapSearchIsVisible',
 		}),
 	},
-	mounted() {
-		// Flush any cached search results when this component
-		// is mounted.
-		this.$store.commit('place/clearSearchResults')
-	},
 	async fetch() {
-		await this.$store
-			.dispatch('place/search', {
-				lat: this.lat,
-				lng: this.lng,
-			})
-			.then(res => {
-				// Some work remains TBD here.
-			})
-			.catch(e => {
-				if (e.statusCode == 500) {
-					throw 'The server had a problem trying to execute this request.'
-				} else if (e.statusCode == 404) {
-					throw 'No results were found for this place.'
-				} else {
-					console.error(e) // at least get the error in the console.
-					throw 'Something unexpected went wrong.'
-				}
-			})
+		if (this.mapSearchIsVisible) {
+			await this.$store
+				.dispatch('place/search')
+				.then(res => {
+					// Some work remains TBD here.
+				})
+				.catch(e => {
+					if (e.statusCode == 500) {
+						throw 'The server had a problem trying to execute this request.'
+					} else if (e.statusCode == 404) {
+						throw 'No results were found for this place.'
+					} else {
+						console.error(e) // at least get the error in the console.
+						throw 'Something unexpected went wrong.'
+					}
+				})
+		}
 	},
 }
 </script>

--- a/store/place.js
+++ b/store/place.js
@@ -221,6 +221,9 @@ export const actions = {
   },
 
   async search(context) {
+    // Flush any prior results.
+    context.commit('clearSearchResults')
+    
     if (context.getters.latLng) {
       let queryUrl =
         process.env.apiUrl +


### PR DESCRIPTION
Fixes #367 
Fixes #372 

STR:
On Main branch: Load the app, open the console, reload to ensure you see all the network activity in the network tab of the console.  You should see a request to the search endpoint of the API.

Then click the map to search.  Next, click somewhere else on the map that shows the search results.  You should see a console error, `_this.searchResults is undefined`.  Try clicking elsewhere on the map and it won't work (no new search is triggered).

Switch to this branch.  Repeat the first step.  You shouldn't see a request to the search endpoint of the API.  Repeat the second step.  You shouldn't see a console error.  Click somewhere else on the map.  You should be able to repeatedly trigger a search for new places when the search results are visible.

Finally, click on a search result and go to the report page.  Then click the browser's back button.  You should get back to the search results page with no errors in the console.

Double check the linked issues to ensure that this branch correctly fixes them.


