### PR TITLE
Adds not modeled/NODATA to the flammability legend/table

### DIFF
--- a/components/reports/ColorTable.vue
+++ b/components/reports/ColorTable.vue
@@ -25,6 +25,7 @@
             <span v-else-if="threshold['max'] == rangeMax()"
               >&ge;{{ threshold['min'] }}<span v-html="unitSymbol"
             /></span>
+            <span v-else-if="!threshold['max'] && !threshold['min']">-</span>
             <span v-else
               >&ge;{{ threshold['min'] }}<span v-html="unitSymbol" />, &lt;{{
                 threshold['max']

--- a/store/wildfire.js
+++ b/store/wildfire.js
@@ -46,6 +46,11 @@ export const getters = {
   flammabilityThresholds() {
     return [
       {
+        label: 'Not modeled or no data',
+        color: '#ffffff',
+        interpretation: 'This pixel was not modeled or is not included in the dataset',
+      },
+      {
         label: 'Very Low',
         min: 0.0,
         max: 0.2,


### PR DESCRIPTION
Closes #323 

Open a report and check that the nodata/not modeled category shows up OK for Flammability in the legend table.