### PR TITLE
Fix differing percent deltas

### DIFF
--- a/components/reports/QualitativeText.vue
+++ b/components/reports/QualitativeText.vue
@@ -174,7 +174,7 @@ export default {
 
         // Check if this temperature difference is the highest out of all the seasons thus far.
         if (annualHighestTempChange < seasonOutput['maxTempDiff']) {
-          annualHighestTempChange = seasonOutput['maxTempDiff']
+          annualHighestTempChange = parseFloat(seasonOutput['maxTempDiff']).toFixed(0)
           seasonWithHighestTempChange = seasonOutput['season']
         }
 

--- a/components/reports/precipitation/ReportPrecipTable.vue
+++ b/components/reports/precipitation/ReportPrecipTable.vue
@@ -57,12 +57,12 @@
             {{ reportData['2040_2069']['DJF']['MRI-CGCM3']['rcp45']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
               :future="
-                reportData['2040_2069']['DJF']['MRI-CGCM3']['rcp45']['pr']
+                rawReportData['2040_2069']['DJF']['MRI-CGCM3']['rcp45']['pr']
               "
             />
           </td>
@@ -70,23 +70,23 @@
             {{ reportData['2040_2069']['DJF']['CCSM4']['rcp45']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
-              :future="reportData['2040_2069']['DJF']['CCSM4']['rcp45']['pr']"
+              :future="rawReportData['2040_2069']['DJF']['CCSM4']['rcp45']['pr']"
             />
           </td>
           <td>
             {{ reportData['2040_2069']['DJF']['MRI-CGCM3']['rcp85']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
               :future="
-                reportData['2040_2069']['DJF']['MRI-CGCM3']['rcp85']['pr']
+                rawReportData['2040_2069']['DJF']['MRI-CGCM3']['rcp85']['pr']
               "
             />
           </td>
@@ -94,23 +94,23 @@
             {{ reportData['2040_2069']['DJF']['CCSM4']['rcp85']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
-              :future="reportData['2040_2069']['DJF']['CCSM4']['rcp85']['pr']"
+              :future="rawReportData['2040_2069']['DJF']['CCSM4']['rcp85']['pr']"
             />
           </td>
           <td>
             {{ reportData['2070_2099']['DJF']['MRI-CGCM3']['rcp45']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
               :future="
-                reportData['2070_2099']['DJF']['MRI-CGCM3']['rcp45']['pr']
+                rawReportData['2070_2099']['DJF']['MRI-CGCM3']['rcp45']['pr']
               "
             />
           </td>
@@ -118,23 +118,23 @@
             {{ reportData['2070_2099']['DJF']['CCSM4']['rcp45']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
-              :future="reportData['2070_2099']['DJF']['CCSM4']['rcp45']['pr']"
+              :future="rawReportData['2070_2099']['DJF']['CCSM4']['rcp45']['pr']"
             />
           </td>
           <td>
             {{ reportData['2070_2099']['DJF']['MRI-CGCM3']['rcp85']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
               :future="
-                reportData['2070_2099']['DJF']['MRI-CGCM3']['rcp85']['pr']
+                rawReportData['2070_2099']['DJF']['MRI-CGCM3']['rcp85']['pr']
               "
             />
           </td>
@@ -142,11 +142,11 @@
             {{ reportData['2070_2099']['DJF']['CCSM4']['rcp85']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['DJF']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
-              :future="reportData['2070_2099']['DJF']['CCSM4']['rcp85']['pr']"
+              :future="rawReportData['2070_2099']['DJF']['CCSM4']['rcp85']['pr']"
             />
           </td>
         </tr>
@@ -163,12 +163,12 @@
             {{ reportData['2040_2069']['MAM']['MRI-CGCM3']['rcp45']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
               :future="
-                reportData['2040_2069']['MAM']['MRI-CGCM3']['rcp45']['pr']
+                rawReportData['2040_2069']['MAM']['MRI-CGCM3']['rcp45']['pr']
               "
             />
           </td>
@@ -176,23 +176,23 @@
             {{ reportData['2040_2069']['MAM']['CCSM4']['rcp45']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
-              :future="reportData['2040_2069']['MAM']['CCSM4']['rcp45']['pr']"
+              :future="rawReportData['2040_2069']['MAM']['CCSM4']['rcp45']['pr']"
             />
           </td>
           <td>
             {{ reportData['2040_2069']['MAM']['MRI-CGCM3']['rcp85']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
               :future="
-                reportData['2040_2069']['MAM']['MRI-CGCM3']['rcp85']['pr']
+                rawReportData['2040_2069']['MAM']['MRI-CGCM3']['rcp85']['pr']
               "
             />
           </td>
@@ -200,23 +200,23 @@
             {{ reportData['2040_2069']['MAM']['CCSM4']['rcp85']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
-              :future="reportData['2040_2069']['MAM']['CCSM4']['rcp85']['pr']"
+              :future="rawReportData['2040_2069']['MAM']['CCSM4']['rcp85']['pr']"
             />
           </td>
           <td>
             {{ reportData['2070_2099']['MAM']['MRI-CGCM3']['rcp45']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
               :future="
-                reportData['2070_2099']['MAM']['MRI-CGCM3']['rcp45']['pr']
+                rawReportData['2070_2099']['MAM']['MRI-CGCM3']['rcp45']['pr']
               "
             />
           </td>
@@ -224,23 +224,23 @@
             {{ reportData['2070_2099']['MAM']['CCSM4']['rcp45']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
-              :future="reportData['2070_2099']['MAM']['CCSM4']['rcp45']['pr']"
+              :future="rawReportData['2070_2099']['MAM']['CCSM4']['rcp45']['pr']"
             />
           </td>
           <td>
             {{ reportData['2070_2099']['MAM']['MRI-CGCM3']['rcp85']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
               :future="
-                reportData['2070_2099']['MAM']['MRI-CGCM3']['rcp85']['pr']
+                rawReportData['2070_2099']['MAM']['MRI-CGCM3']['rcp85']['pr']
               "
             />
           </td>
@@ -248,11 +248,11 @@
             {{ reportData['2070_2099']['MAM']['CCSM4']['rcp85']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['MAM']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
-              :future="reportData['2070_2099']['MAM']['CCSM4']['rcp85']['pr']"
+              :future="rawReportData['2070_2099']['MAM']['CCSM4']['rcp85']['pr']"
             />
           </td>
         </tr>
@@ -269,12 +269,12 @@
             {{ reportData['2040_2069']['JJA']['MRI-CGCM3']['rcp45']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
               :future="
-                reportData['2040_2069']['JJA']['MRI-CGCM3']['rcp45']['pr']
+                rawReportData['2040_2069']['JJA']['MRI-CGCM3']['rcp45']['pr']
               "
             />
           </td>
@@ -282,23 +282,23 @@
             {{ reportData['2040_2069']['JJA']['CCSM4']['rcp45']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
-              :future="reportData['2040_2069']['JJA']['CCSM4']['rcp45']['pr']"
+              :future="rawReportData['2040_2069']['JJA']['CCSM4']['rcp45']['pr']"
             />
           </td>
           <td>
             {{ reportData['2040_2069']['JJA']['MRI-CGCM3']['rcp85']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
               :future="
-                reportData['2040_2069']['JJA']['MRI-CGCM3']['rcp85']['pr']
+                rawReportData['2040_2069']['JJA']['MRI-CGCM3']['rcp85']['pr']
               "
             />
           </td>
@@ -306,23 +306,23 @@
             {{ reportData['2040_2069']['JJA']['CCSM4']['rcp85']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
-              :future="reportData['2040_2069']['JJA']['CCSM4']['rcp85']['pr']"
+              :future="rawReportData['2040_2069']['JJA']['CCSM4']['rcp85']['pr']"
             />
           </td>
           <td>
             {{ reportData['2070_2099']['JJA']['MRI-CGCM3']['rcp45']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
               :future="
-                reportData['2070_2099']['JJA']['MRI-CGCM3']['rcp45']['pr']
+                rawReportData['2070_2099']['JJA']['MRI-CGCM3']['rcp45']['pr']
               "
             />
           </td>
@@ -330,23 +330,23 @@
             {{ reportData['2070_2099']['JJA']['CCSM4']['rcp45']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
-              :future="reportData['2070_2099']['JJA']['CCSM4']['rcp45']['pr']"
+              :future="rawReportData['2070_2099']['JJA']['CCSM4']['rcp45']['pr']"
             />
           </td>
           <td>
             {{ reportData['2070_2099']['JJA']['MRI-CGCM3']['rcp85']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
               :future="
-                reportData['2070_2099']['JJA']['MRI-CGCM3']['rcp85']['pr']
+                rawReportData['2070_2099']['JJA']['MRI-CGCM3']['rcp85']['pr']
               "
             />
           </td>
@@ -354,11 +354,11 @@
             {{ reportData['2070_2099']['JJA']['CCSM4']['rcp85']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['JJA']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
-              :future="reportData['2070_2099']['JJA']['CCSM4']['rcp85']['pr']"
+              :future="rawReportData['2070_2099']['JJA']['CCSM4']['rcp85']['pr']"
             />
           </td>
         </tr>
@@ -375,12 +375,12 @@
             {{ reportData['2040_2069']['SON']['MRI-CGCM3']['rcp45']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
               :future="
-                reportData['2040_2069']['SON']['MRI-CGCM3']['rcp45']['pr']
+                rawReportData['2040_2069']['SON']['MRI-CGCM3']['rcp45']['pr']
               "
             />
           </td>
@@ -388,23 +388,23 @@
             {{ reportData['2040_2069']['SON']['CCSM4']['rcp45']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
-              :future="reportData['2040_2069']['SON']['CCSM4']['rcp45']['pr']"
+              :future="rawReportData['2040_2069']['SON']['CCSM4']['rcp45']['pr']"
             />
           </td>
           <td>
             {{ reportData['2040_2069']['SON']['MRI-CGCM3']['rcp85']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
               :future="
-                reportData['2040_2069']['SON']['MRI-CGCM3']['rcp85']['pr']
+                rawReportData['2040_2069']['SON']['MRI-CGCM3']['rcp85']['pr']
               "
             />
           </td>
@@ -412,23 +412,23 @@
             {{ reportData['2040_2069']['SON']['CCSM4']['rcp85']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
-              :future="reportData['2040_2069']['SON']['CCSM4']['rcp85']['pr']"
+              :future="rawReportData['2040_2069']['SON']['CCSM4']['rcp85']['pr']"
             />
           </td>
           <td>
             {{ reportData['2070_2099']['SON']['MRI-CGCM3']['rcp45']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
               :future="
-                reportData['2070_2099']['SON']['MRI-CGCM3']['rcp45']['pr']
+                rawReportData['2070_2099']['SON']['MRI-CGCM3']['rcp45']['pr']
               "
             />
           </td>
@@ -436,23 +436,23 @@
             {{ reportData['2070_2099']['SON']['CCSM4']['rcp45']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
-              :future="reportData['2070_2099']['SON']['CCSM4']['rcp45']['pr']"
+              :future="rawReportData['2070_2099']['SON']['CCSM4']['rcp45']['pr']"
             />
           </td>
           <td>
             {{ reportData['2070_2099']['SON']['MRI-CGCM3']['rcp85']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
               :future="
-                reportData['2070_2099']['SON']['MRI-CGCM3']['rcp85']['pr']
+                rawReportData['2070_2099']['SON']['MRI-CGCM3']['rcp85']['pr']
               "
             />
           </td>
@@ -460,11 +460,11 @@
             {{ reportData['2070_2099']['SON']['CCSM4']['rcp85']['pr']
             }}<UnitWidget variable="pr" type="light" /><PrecipDiffWidget
               :past="
-                reportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
+                rawReportData['1950_2009']['SON']['CRU-TS40']['CRU_historical'][
                   'pr'
                 ]['mean']
               "
-              :future="reportData['2070_2099']['SON']['CCSM4']['rcp85']['pr']"
+              :future="rawReportData['2070_2099']['SON']['CCSM4']['rcp85']['pr']"
             />
           </td>
         </tr>
@@ -502,6 +502,7 @@ export default {
   computed: {
     ...mapGetters({
       reportData: 'climate/climateData',
+      rawReportData: 'climate/rawClimateData',
       place: 'place/name',
     }),
   },

--- a/store/climate.js
+++ b/store/climate.js
@@ -42,11 +42,15 @@ export const state = () => ({
 })
 
 export const getters = {
+  // Used for performing % delta computations where needed
+  rawClimateData(state) {
+    return state.climateData
+  },
   climateData(state, getters, rootState, rootGetters) {
-    var tempData = _.cloneDeep(state.climateData)
+    var convertedData = _.cloneDeep(state.climateData)
     return rootGetters.units == 'imperial'
-      ? convertReportData(tempData)
-      : tempData
+      ? convertReportData(convertedData)
+      : convertedData
   },
   httpError(state) {
     return state.httpError

--- a/utils/convert.js
+++ b/utils/convert.js
@@ -3,6 +3,7 @@ export const convertToFeet = function (value) {
   return Math.round(value * 3.28084)
 }
 
+// Converts nested data structures
 export const convertToInches = function (
   permafrostData,
   fromUnit,
@@ -27,7 +28,7 @@ export const convertToInches = function (
       switch (fromUnit) {
         // Convert from millimeters.
         case 'mm':
-          return parseFloat((value * 0.03937008).toFixed(1))
+          return convertMmToInches(value)
         // Convert from meters.
         case 'm':
           return parseFloat((value * 39.37008).toFixed(1))
@@ -40,6 +41,12 @@ export const convertToInches = function (
   return t
 }
 
+// Convert a single value
+export const convertMmToInches = function (value) {
+  return parseFloat((value * 0.03937008).toFixed(1))
+}
+
+// Converts nested data structures
 export const convertToFahrenheit = function (
   permafrostData,
   fromUnit,
@@ -64,7 +71,7 @@ export const convertToFahrenheit = function (
       switch (fromUnit) {
         // Convert from Celsius.
         case 'c':
-          return parseFloat((value * 1.8 + 32).toFixed(1))
+          return convertValueToFahrenheit(value)
       }
     },
     {
@@ -72,6 +79,17 @@ export const convertToFahrenheit = function (
     }
   )
   return t
+}
+
+// Convert a single value
+export const convertValueToFahrenheit = function (value) {
+  return parseFloat((value * 1.8 + 32).toFixed(1))
+}
+
+// Convert a single value for a difference (not zero-offset)
+// i.e. for computing (+4 degree) changes
+export const convertDiffValueToFahrenheit = function (value) {
+  return parseFloat((value * 1.8).toFixed(0))
 }
 
 export const convertToPercent = function (wildfireData) {


### PR DESCRIPTION
Fixes #132 

Start by looking for these differences on the `main` branch.  
Check http://localhost:3000/report/community/AK454#results

Imperial
increased precipitation % = 105

Metric
Increased precipitation % = 106

http://localhost:3000/report/community/AK124#results

Imperial
increased precipitation % = 92

Metric
Increased precipitation % = 100

Now switch to this branch.  You should always see the %s matching the metric versions both in the qualitative text as well as in the percent% diff in the temperature chart.

The easiest way to test this is to pick a location, load it in the production site + locally on this branch, then switch between them to look for differences.

No other temperature/precip values should be different, only the %s.  Rounding should be the same as it was, too.