### PR TITLE
Text & chart title updates

### DIFF
--- a/components/Report.vue
+++ b/components/Report.vue
@@ -52,7 +52,7 @@
             >
             <span v-else
               >Data for the tables and charts below have been averaged across
-              the spatial extent of {{ place }}.</span
+              the spatial extent of {{ grammarFragment }} {{ place }}.</span
             >
           </p>
           <p v-if="elevation">
@@ -246,11 +246,11 @@
   </div>
 </template>
 <style lang="scss" scoped>
-  .area-warning {
-    border-left: 0.25rem solid #aaa;
-    padding-left: 1rem;
-    margin-bottom: 1rem;
-  }
+.area-warning {
+  border-left: 0.25rem solid #aaa;
+  padding-left: 1rem;
+  margin-bottom: 1rem;
+}
 .centered {
   text-align: center;
 }
@@ -311,6 +311,20 @@ export default {
     }
   },
   computed: {
+    // Returns grammar fragments needed to improve
+    // readability of the report for different place types.
+    grammarFragment() {
+      switch (this.type) {
+        case 'protected_area':
+        case 'corporation':
+        case 'climate_division':
+        case 'fire_zone':
+          return 'the'
+          break
+        default:
+          return ''
+      }
+    },
     elevationUnits() {
       return this.units == 'imperial' ? 'ft' : 'm'
     },

--- a/components/reports/QualitativeText.vue
+++ b/components/reports/QualitativeText.vue
@@ -467,6 +467,17 @@ export default {
         case 'huc':
           prefix = '<p>In the <strong>' + this.hucName + '</strong>'
           break
+        case 'protected_area':
+        case 'climate_division':
+        case 'fire_zone':
+          prefix = '<p>In the <strong>' + this.place + '</strong>'
+          break
+        case 'corporation':
+        case 'ethnolinguistic_region':
+        case 'first_nation':
+        case 'game_management_unit':
+          prefix = '<p>In <strong>' + this.place + '</strong>'
+          break
         default:
           prefix = '<p>At <strong>' + this.place + '</strong>'
           break

--- a/components/reports/precipitation/PrecipReport.vue
+++ b/components/reports/precipitation/PrecipReport.vue
@@ -5,7 +5,7 @@
       <div class="is-size-5">
         <p>
           This section shows projections for average (mean) precipitation,
-          compared with a historical range (1950&ndash;2009). Results are
+          compared with a historical range (1950&ndash;2009, CRU TS 4.0). Results are
           averaged by season (three month averages) for two specific climate
           models (MRI CGCM3 and NCAR CCSM4) as well as average of five models
           which perform well in Alaska and the Arctic.

--- a/components/reports/precipitation/ReportPrecipChart.vue
+++ b/components/reports/precipitation/ReportPrecipChart.vue
@@ -82,7 +82,7 @@ export default {
       layout.shapes.push(historicalRegion)
 
       let footerLines = [
-        'The boxplot represents the interquartile range (IQR) of historical means for the season, from 1950-2009.',
+        'The boxplot represents the interquartile range (IQR) of historical means for the season, from 1950-2009 (CRU TS 4.0).',
         'The shaded gray region shows the extent of common variation for the historical period.',
         'The line inside the boxplot represents the median historical precipitation.',
       ]

--- a/components/reports/temperature/ReportTempChart.vue
+++ b/components/reports/temperature/ReportTempChart.vue
@@ -89,7 +89,7 @@ export default {
       layout.shapes.push(historicalRegion)
 
       let footerLines = [
-        'The boxplot represents the interquartile range (IQR) of historical means for the season, from 1950-2009.',
+        'The boxplot represents the interquartile range (IQR) of historical means for the season, from 1950-2009 (CRU TS 4.0).',
         'The shaded gray region shows the extent of common variation for the historical period.',
         'The line inside the boxplot represents the median historical temperature.',
       ]

--- a/components/reports/temperature/TempReport.vue
+++ b/components/reports/temperature/TempReport.vue
@@ -5,7 +5,7 @@
       <div class="is-size-5">
         <p>
           This section shows projections for average (mean) temperature,
-          compared with a historical range (1950&ndash;2009). Results are
+          compared with a historical range (1950&ndash;2009, CRU TS 4.0). Results are
           averaged by season (three month averages) for two specific climate
           models (MRI CGCM3 and NCAR CCSM4) as well as average of five models
           which perform well in Alaska and the Arctic.

--- a/components/reports/wildfire/ReportFlammabilityMap.vue
+++ b/components/reports/wildfire/ReportFlammabilityMap.vue
@@ -4,6 +4,7 @@
       <div>
         <span class="has-text-weight-bold">{{ mapEra }}<br /></span>
         <span v-if="mapModel">{{ mapModel }}<br class="narrow-br" /></span>
+        <span v-else>(Modeled)<br class="narrow-br" /></span>
         <span>{{ mapScenario }}</span>
       </div>
     </div>

--- a/components/reports/wildfire/ReportVegChangeChart.vue
+++ b/components/reports/wildfire/ReportVegChangeChart.vue
@@ -4,16 +4,16 @@
       <b-field label="Model" class="px-3">
         <div>
           <b-radio
-            v-model="veg_chart_model_selection"
-            name="veg_chart_model_selection"
+            v-model="vegChartModelSelection"
+            name="vegChartModelSelection"
             native-value="NCAR-CCSM4"
             >NCAR CCSM4</b-radio
           >
         </div>
         <div>
           <b-radio
-            v-model="veg_chart_model_selection"
-            name="veg_chart_model_selection"
+            v-model="vegChartModelSelection"
+            name="vegChartModelSelection"
             native-value="MRI-CGCM3"
             >MRI CGCM3</b-radio
           >
@@ -45,11 +45,15 @@ export default {
   },
   data() {
     return {
-      veg_chart_model_selection: 'NCAR-CCSM4',
-      veg_scenario_selection: 'rcp85',
+      vegChartModelSelection: 'NCAR-CCSM4',
     }
   },
   computed: {
+    vegChartModelName() {
+      return this.vegChartModelSelection == 'NCAR-CCSM4'
+        ? 'NCAR CCSM4'
+        : 'MRI CGCM3'
+    },
     ...mapGetters({
       vegEras: 'wildfire/vegEras',
       vegChangeData: 'wildfire/veg_change',
@@ -63,10 +67,7 @@ export default {
     vegChangeData: function () {
       this.renderPlot()
     },
-    veg_chart_model_selection: function () {
-      this.renderPlot()
-    },
-    veg_scenario_selection: function () {
+    vegChartModelSelection: function () {
       this.renderPlot()
     },
   },
@@ -80,6 +81,7 @@ export default {
       let title = buildTitle({
         dataLabel: 'Vegetation type',
         dateRange: '1950-2099',
+        model: this.vegChartModelName,
         place: this.place,
         huc12Id: this.huc12Id,
       })
@@ -105,7 +107,7 @@ export default {
         this.vegEras.forEach(era => {
           if (era != '1950-2008') {
             yValues.push(
-              vegChangeData[era][this.veg_chart_model_selection]['rcp45'][type]
+              vegChangeData[era][this.vegChartModelSelection]['rcp45'][type]
             )
           }
         })
@@ -113,7 +115,7 @@ export default {
         this.vegEras.forEach(era => {
           if (era != '1950-2008') {
             yValues.push(
-              vegChangeData[era][this.veg_chart_model_selection]['rcp85'][type]
+              vegChangeData[era][this.vegChartModelSelection]['rcp85'][type]
             )
           }
         })

--- a/components/reports/wildfire/ReportVegChangeMap.vue
+++ b/components/reports/wildfire/ReportVegChangeMap.vue
@@ -4,6 +4,7 @@
       <div>
         <span class="has-text-weight-bold">{{ mapEra }}<br /></span>
         <span v-if="mapModel">{{ mapModel }}<br class="narrow-br" /></span>
+        <span v-else>(Modeled)<br class="narrow-br" /></span>
         <span>{{ mapScenario }}</span>
       </div>
     </div>

--- a/components/reports/wildfire/WildfireReport.vue
+++ b/components/reports/wildfire/WildfireReport.vue
@@ -65,12 +65,16 @@
     <div class="content">
       <div class="is-size-5 mt-6">
         <p>
-          Due to the inherent uncertainty involved in predicting wildfire, the
+          Due to the inherent uncertainty involved in predicting vegetation
+          transitions driven by climate and wildfire or by climate alone, the
           maps below should not be interpreted as vegetation predictions at
           specific locations, but rather as an indicator of likely general
-          trends in vegetation type over time. Each map&ndash;pixel shows the
-          most commonly predicted vegetation type (modal value) based on 200
-          model runs per year across all years in the map&rsquo;s date range.
+          trends in ecological suitability for particular vegetation type over
+          time. Each map&ndash;pixel shows the most commonly predicted
+          vegetation type (modal value) based on 200 model runs per year across
+          all years in the map&rsquo;s date range. Some ecological regions in
+          the far north are projected to undergo marked changes, and others
+          little or no change.
         </p>
       </div>
     </div>

--- a/utils/charts.js
+++ b/utils/charts.js
@@ -22,6 +22,7 @@ export const buildTitle = function (params) {
   let place = params['place']
   let huc12Id = params['huc12Id']
   let season = params['season']
+  let model = params['model']
 
   let title = dataLabel + ',<br>'
   let huc12Label = ''
@@ -32,6 +33,10 @@ export const buildTitle = function (params) {
 
   if (season) {
     totalLength += season.length
+  }
+
+  if (model) {
+    totalLength += model.length
   }
 
   if (totalLength > 60) {
@@ -59,6 +64,8 @@ export const buildTitle = function (params) {
   if (season) {
     title += ', ' + season
   }
+
+  if (model) title += ', ' + model
 
   return title
 }


### PR DESCRIPTION
Closes #375
Closes #327
Closes #333
Closes #362
Closes #274

Check the text block above the veg change charts, it should read as in ticket #375.

Check the temp/precip sections.  The intro text should mention CRU TS 4.0, and also in the footer of each respective chart (#327).

Check the minimaps for both flammability and vegetation type.  The titles for the historical minimaps should read (Modeled) Historical.

Check the title of the Veg change chart.  It should include the selected model (NCAR or MRI).

For ticket #274, check the first line of the qualitative text and the first block of text in the introduction to the report for these place types:

Protected area:
http://localhost:3000/report/area/BLM36#results

Native Corporation
http://localhost:3000/report/area/NC2#results

Climate division
http://localhost:3000/report/area/CD5#results

Fire Zone
http://localhost:3000/report/area/FIRE5#results

First Nation
http://localhost:3000/report/area/FNTT4#results

Game Management Unit
http://localhost:3000/report/area/GMU18#results

The text should read "At, " "In the," or "In" in the first line of the qualitative text depending on context, and similarly, there will be different grammar fragments in the first line of the report introduction.  This isn't perfect in every case, but it's better than it was before.