### PR TITLE
Exclude "not modeled or no data" flammability category from chart y-axis categories

### DIFF
--- a/components/reports/wildfire/ReportFlammabilityChart.vue
+++ b/components/reports/wildfire/ReportFlammabilityChart.vue
@@ -193,6 +193,14 @@ export default {
       let thresholdShapes = []
       let thresholdAnnotations = []
       this.flamThresholds.forEach(flamThreshold => {
+        // Ignore the "Not modeled or no data" category.
+        if (
+          flamThreshold['min'] == undefined ||
+          flamThreshold['max'] == undefined
+        ) {
+          return
+        }
+
         if (
           _.min(displayedValues) > flamThreshold['max'] ||
           _.max(displayedValues) < flamThreshold['min']


### PR DESCRIPTION
Closes #388.

To test, load reports for several locations from the `main` branch. For many (most?) locations, the flammability chart category color bar will not extend to the full height of the y-axis. This is because the new "not modeled or no data" category does not include min/max values.

Switch to the `flammability_nodata_yaxis` branch and the flammability y-axis category color bar should extend to the full height of the y-axis, and the chart's y-axis should span the range of plotted data without extra padding.