### PR TITLE
Updates README with CLI commands for CloudFront invalidation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ in the AWS CloudFront web interface, then go to:
 
 Invalidations → Create invalidation
 
-Use the following invalidation path:
+Use the following CLI command:
 
 ```
-/*
+aws cloudfront create-invalidation --distribution_id EZEXS6RHS812M --paths "/*"
 ```
 
 For detailed explanation on how things work, check out


### PR DESCRIPTION
This adds information about how to invalidate the CloudFront cache for the Northern Climate Reports application.

Closes #391 