### PR TITLE
Adds new URL for Alaska Climate Divisions

### DIFF
--- a/pages/data.vue
+++ b/pages/data.vue
@@ -1,7 +1,6 @@
 <template>
   <section class="section">
     <div class="content-wrapper">
-
       <BetaFeedback />
 
       <div class="content is-size-5">
@@ -161,18 +160,23 @@
                 href="https://uaf.edu/anlc/resources/mapping_alaskas_native_languages.php"
                 >Ethnolinguistic regions</a
               ></strong
-            > of Alaska
+            >
+            of Alaska
           </li>
           <li>
             <strong
-              ><a
-                href="https://www.ncdc.noaa.gov/news/climate-division-data-now-available-alaska"
+              ><a href="https://sites.google.com/a/alaska.edu/climatedivisions/"
                 >Alaska Climate Divisions</a
               ></strong
             >
           </li>
-          <li><strong>First Nation Traditional Territories of the Yukon</strong></li>
-          <li><strong>Alaska Game Management Units (GMUs)</strong>, e.g. GMU19a, etc.</li>
+          <li>
+            <strong>First Nation Traditional Territories of the Yukon</strong>
+          </li>
+          <li>
+            <strong>Alaska Game Management Units (GMUs)</strong>, e.g. GMU19a,
+            etc.
+          </li>
         </ul>
         <h2 id="access-api" class="title is-3">Data API access</h2>
         <p>


### PR DESCRIPTION
This PR changes the broken URL for the Alaska Climate Divisions. This is available from http://localhost:3000/data

Fixes #406 