### PR TITLE
Adds new URL for Ethnolinguistic Regions

### DIFF
--- a/pages/data.vue
+++ b/pages/data.vue
@@ -1,7 +1,6 @@
 <template>
   <section class="section">
     <div class="content-wrapper">
-
       <BetaFeedback />
 
       <div class="content is-size-5">
@@ -157,11 +156,11 @@
           <li><strong>Alaska Fire Management Units</strong></li>
           <li>
             <strong
-              ><a
-                href="https://uaf.edu/anlc/resources/mapping_alaskas_native_languages.php"
+              ><a href="https://www.uaf.edu/anla/collections/map/"
                 >Ethnolinguistic regions</a
               ></strong
-            > of Alaska
+            >
+            of Alaska
           </li>
           <li>
             <strong
@@ -171,8 +170,13 @@
               ></strong
             >
           </li>
-          <li><strong>First Nation Traditional Territories of the Yukon</strong></li>
-          <li><strong>Alaska Game Management Units (GMUs)</strong>, e.g. GMU19a, etc.</li>
+          <li>
+            <strong>First Nation Traditional Territories of the Yukon</strong>
+          </li>
+          <li>
+            <strong>Alaska Game Management Units (GMUs)</strong>, e.g. GMU19a,
+            etc.
+          </li>
         </ul>
         <h2 id="access-api" class="title is-3">Data API access</h2>
         <p>


### PR DESCRIPTION
This PR adds a new URL for the Ethnolinguistic Regions in the http://localhost:3000/data page.

Fixes #405 