### PR TITLE
Sets report radio button placement to match across all subsections. Widens gap between each item for clarity.

### DIFF
--- a/components/Report.vue
+++ b/components/Report.vue
@@ -267,8 +267,8 @@
 .back {
   margin-bottom: 2rem;
 }
-.b-radio.radio:not(.button) {
-  margin-right: 1rem;
+::v-deep .b-radio.radio:not(.button) {
+  margin-right: 1.5rem;
 }
 .camera-icon {
   display: inline-block;


### PR DESCRIPTION
This PR sets the report radio button CSS formatting to match across all subsections of the report. Additionally, for clarity for which button represents which item, we've widened the right margin slightly.

Fixes #408 