### PR TITLE
Fix the historical x-axis tick label for temperature and precipitation charts

### DIFF
--- a/utils/climate_charts.js
+++ b/utils/climate_charts.js
@@ -66,10 +66,11 @@ export const seasons = {
 export const getHistoricalTrace = function (data, season, variable) {
   let historicalData =
     data[historicalEra][season]['CRU-TS40']['CRU_historical'][variable]
+  let tickLabel = historicalEra.replace('_', '-')
   return {
     type: 'box',
     name: 'Historical (1950-2009)',
-    x: historicalEra,
+    x: [tickLabel],
     q1: [historicalData['q1']],
     median: [historicalData['median']],
     q3: [historicalData['q3']],


### PR DESCRIPTION
Closes #319.
Closes #421.

This PR fixes the x-axis tick label for the historical box plot on the temperature and precipitation charts to show the historical era ("1950-2009") and not 0.