### PR TITLE
Adds Ethnolinguistic Regions and First Nations Traditional Territories to search results from clicking on map.

### DIFF
--- a/components/SearchResults.vue
+++ b/components/SearchResults.vue
@@ -125,6 +125,9 @@ export default {
         case 'borough':
           placeType = 'Borough'
           break
+        case 'ethnolinguistic_region':
+          placeType = 'Ethnolinguistic Region'
+          break
         default: // Do nothing, don't decorate protected areas
       }
       return placeType

--- a/store/place.js
+++ b/store/place.js
@@ -255,7 +255,7 @@ export const actions = {
         _.each(res.game_management_units_near, place => {
           ssr.push(place)
         })
-        _.each(res.first_nations_near, place => {
+        _.each(res.ca_first_nations_near, place => {
           ssr.push(place)
         })
         _.each(res.akcensus_areas_near, place => {

--- a/store/place.js
+++ b/store/place.js
@@ -264,6 +264,9 @@ export const actions = {
         _.each(res.ak_boros_near, place => {
           ssr.push(place)
         })
+        _.each(res.ethnolinguistic_regions_near, place => {
+          ssr.push(place)
+        })
 
         ssr = _.sortBy(ssr, ['name'])
 


### PR DESCRIPTION
This adds the missing Ethnolinguistic Regions to the search results when clicking on the map. These were being properly returned by the API but simply not identified by the front end application.

Also fixes the First Nations Traditional Territory in the search results. These were returned differently from the API than was being requested by the web application.

Fixes #395