### PR TITLE
Hides Beetle section if no data is available

### DIFF
--- a/components/Report.vue
+++ b/components/Report.vue
@@ -176,7 +176,7 @@
               <a href="#wildfire">Wildfire</a> charts of flammability and
               vegetation change with with multiple models and scenarios
             </li>
-            <li>
+            <li v-if="beetleData">
               <a href="#beetle-risk">Spruce Beetle Risk</a> visualizes the
               climate&ndash;related risk of spruce beetles in forested areas of
               Alaska
@@ -215,6 +215,10 @@
                 <strong>Vegetation change:</strong>
                 {{ httpErrors[vegChangeHttpError] }}
               </li>
+              <li v-if="beetleHttpError">
+                <strong>Beetle climate protection:</strong>
+                {{ httpErrors[beetleHttpError] }}
+              </li>
             </ul>
           </div>
         </div>
@@ -244,7 +248,7 @@
         </div>
       </section>
       <section class="section is-hidden-touch">
-        <div id="beetle-risk">
+        <div id="beetle-risk" v-if="beetleData">
           <BeetleRiskReport />
         </div>
         <BackToTopButton />
@@ -400,11 +404,13 @@ export default {
       permafrostData: 'permafrost/permafrostData',
       flammabilityData: 'wildfire/flammability',
       vegChangeData: 'wildfire/veg_change',
+      beetleData: 'beetle/beetleData',
       climateHttpError: 'climate/httpError',
       elevationHttpError: 'elevation/httpError',
       permafrostHttpError: 'permafrost/httpError',
       flammabilityHttpError: 'wildfire/flammabilityHttpError',
       vegChangeHttpError: 'wildfire/vegChangeHttpError',
+      beetleHttpError: 'beetle/httpError',
       isPointLocation: 'place/isPointLocation',
     }),
   },

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -364,8 +364,13 @@ export default {
       return true
     },
     dataMissing() {
+      // Get an array of data types present for the selected location
+      // (Temperature, Permafrost, Beetle Climate Protection, etc.)
       let types = this.presentDataTypes()
-      if (types.length < 5) {
+
+      // If there are less than 6 data types present, the corresponding
+      // section(s) of the report page will be hidden.
+      if (types.length < 6) {
         return true
       }
       return false
@@ -377,6 +382,7 @@ export default {
         this.elevationHttpError,
         this.flammabilityHttpError,
         this.vegChangeHttpError,
+        this.beetleHttpError,
       ]
 
       if (this.type == 'latLng') {

--- a/store/beetle.js
+++ b/store/beetle.js
@@ -48,6 +48,9 @@ export const getters = {
       },
     ]
   },
+  httpError(state) {
+    return state.httpError
+  },
 }
 
 export const mutations = {


### PR DESCRIPTION
This PR hides the Beetle Risk section if no data is available at the given location. 

To test, choose a place on the north slope which has not been modeled (for obvious reasons) and ensure that the beetle section does not show up. Additionally, choose a place which has been modeled such as around Fairbanks, and ensure that the beetle section is available.

Closes #433 