### PR TITLE
Zoom out beetle mini-maps 2 levels after fitting bounds to HUC-12

### DIFF
--- a/components/reports/beetles/ReportBeetleRiskMap.vue
+++ b/components/reports/beetles/ReportBeetleRiskMap.vue
@@ -84,7 +84,7 @@ export default {
   },
   mounted() {
     this.getBaseMapAndLayers = getBaseMapAndLayers.bind(this)
-    this.addGeoJSONtoMap = addGeoJSONtoMap.bind(this)
+    this.addGeoJSONtoMap = addGeoJSONtoMap.bind(this, 2)
     this.map = L.map(this.mapID, this.getBaseMapAndLayers())
     if (this.latLng) {
       this.marker = L.marker(this.latLng).addTo(this.map)

--- a/utils/maps.js
+++ b/utils/maps.js
@@ -34,7 +34,7 @@ export const getBaseMapAndLayers = function () {
   return config
 }
 
-export const addGeoJSONtoMap = function () {
+export const addGeoJSONtoMap = function (zoomOutDelta = 0) {
   if (this.geoJSON) {
     this.geoJSONLayer = L.geoJSON(this.geoJSON, {
       style: {
@@ -44,5 +44,8 @@ export const addGeoJSONtoMap = function () {
       },
     }).addTo(this.map)
     this.map.fitBounds(this.geoJSONLayer.getBounds())
+    if (zoomOutDelta > 0) {
+      this.map.zoomOut(zoomOutDelta)
+    }
   }
 }


### PR DESCRIPTION
Closes #451.

This PR configures the beetle mini-maps to zoom out two levels after Leaflet has finished fitting the bounds to the HUC-12. The goal here is to show more of the low-resolution beetle data at once in each mini-map.