### PR TITLE
Fixes hard-coded snowpack level on historical beetle data

### DIFF
--- a/components/reports/beetles/ReportBeetleRiskTable.vue
+++ b/components/reports/beetles/ReportBeetleRiskTable.vue
@@ -11,7 +11,7 @@
         <div class="historical">
           Historical modeled climate protection (Daymet, 1988&ndash;2017) is
           <strong>{{
-            reportData['1988-2017']['Daymet']['Historical']['low'][
+            reportData['1988-2017']['Daymet']['Historical'][snowpack][
               'climate-protection'
             ]
           }}</strong


### PR DESCRIPTION
This PR changes the hard-coded value for snowpack when querying the historical values in the tables for climate protection from spruce beetles. This will instead use the value of the snowpack variable to match the rest of the table.

Closes #461 