### PR TITLE
Fixes the beetle maps to properly add the GeoJSON to the maps and zoom out from the fitBounds function.

### DIFF
--- a/components/reports/beetles/ReportBeetleRiskMap.vue
+++ b/components/reports/beetles/ReportBeetleRiskMap.vue
@@ -89,6 +89,10 @@ export default {
     if (this.latLng) {
       this.marker = L.marker(this.latLng).addTo(this.map)
       this.map.panTo(this.latLng)
+    } else if (this.geoJSON != undefined) {
+      this.map.whenReady(() => {
+        this.addGeoJSONtoMap()
+      })
     }
   },
   watch: {

--- a/utils/maps.js
+++ b/utils/maps.js
@@ -20,6 +20,7 @@ export const getBaseMapAndLayers = function () {
   // Map base configuration
   var config = {
     zoom: 0,
+    zoomSnap: 0.1,
     minZoom: 0,
     maxZoom: 6,
     center: [64.7, -155],


### PR DESCRIPTION
This PR checks to see if the GeoJSON has already been loaded before the beetle maps are available and adds the GeoJSON to the map when it has loaded in the DOM. Additionally, it adds the zoomSnap configuration option to the defaults of the maps to allow for the fitBounds function to update the zoom level along with allowing us to zoom out in fractional amounts. This change was required for a large number of AOI polygons due to how the fitBounds was zooming into the area.

To test, try many different areas with beetle data to confirm that we are seeing the maps in the beetle section zoomed out 2 zoom levels away from the polygon. This could be done via console logs or visual inspection as the AOI will be centered and smaller than the normal fitBounds function provides.