### PR TITLE
Replace hyphen/&ndash; in Plotly footers with literal en dash character

### DIFF
--- a/components/reports/precipitation/ReportPrecipChart.vue
+++ b/components/reports/precipitation/ReportPrecipChart.vue
@@ -82,7 +82,7 @@ export default {
       layout.shapes.push(historicalRegion)
 
       let footerLines = [
-        'The boxplot represents the interquartile range (IQR) of historical means for the season, from 1950-2009 (CRU TS 4.0).',
+        'The boxplot represents the interquartile range (IQR) of historical means for the season, from 1950–2009 (CRU TS 4.0).',
         'The shaded gray region shows the extent of common variation for the historical period.',
         'The line inside the boxplot represents the median historical precipitation.',
       ]

--- a/components/reports/temperature/ReportTempChart.vue
+++ b/components/reports/temperature/ReportTempChart.vue
@@ -89,7 +89,7 @@ export default {
       layout.shapes.push(historicalRegion)
 
       let footerLines = [
-        'The boxplot represents the interquartile range (IQR) of historical means for the season, from 1950&ndash;2009 (CRU TS 4.0).',
+        'The boxplot represents the interquartile range (IQR) of historical means for the season, from 1950–2009 (CRU TS 4.0).',
         'The shaded gray region shows the extent of common variation for the historical period.',
         'The line inside the boxplot represents the median historical temperature.',
       ]


### PR DESCRIPTION
Closes #486.

This PR replaces the unsupported &ndash; HTML entity in the temperature Plotly chart with a literal en dash character, which Plotly does support. I've also replaced the hyphen in the precipitation chart with a literal en dash character to be consistent with the temperature chart.