### PR TITLE
Fix cropping of legend text in exported chart PNGs

### DIFF
--- a/utils/charts.js
+++ b/utils/charts.js
@@ -106,6 +106,9 @@ export const getLayout = function (title, yAxisLabel) {
     showlegend: true,
     legend: {
       x: 1.03,
+      font: {
+        family: 'sans-serif',
+      },
     },
     margin: {
       t: 30 + titleOffset,


### PR DESCRIPTION
Closes #86.

Currently, the legend text for all Plotly charts on NCR ends up getting cropped off the right side when the chart is exported to PNG. See issue #86 for an example image. This PR fixes this issue.

This turned out to be a font issue. The font used for the legend text on the web app was not available when Plotly exported the charts to PNG. A wider font was used instead, which is why the legend text in exported PNGs was consistently too wide for the available space. This PR fixes the issue by choosing a font that works the same for both the web app and exported PNG.

To test, choose a location in NCR and export each of the charts on the page by clicking the camera icon in the upper right corner. The legend text should no longer be cropped on the right side on any chart.

**Note: Attempting to export the temperature chart to PNG will fail for unrelated reasons. It turns out the `&ndash;` HTML entity in the temperature chart footer is what causes the export to fail. This has been fixed in PR #494.**