### PR TITLE
Display vegetation type bars and legend in alphabetical order

### DIFF
--- a/components/reports/wildfire/ReportVegChangeChart.vue
+++ b/components/reports/wildfire/ReportVegChangeChart.vue
@@ -139,7 +139,9 @@ export default {
           y: yValues,
         }
 
-        dataTraces.push(trace)
+        // Stacked bar charts display traces in reverse order, so use unshift
+        // instead of push to add items in reverse order.
+        dataTraces.unshift(trace)
       })
 
       layout['xaxis']['tickmode'] = 'array'


### PR DESCRIPTION
Closes #465.

It turns out that, for stacked bar charts specifically, Plotly displays traces in reverse order. To counteract this, this PR uses `unshift` instead of `push` to add traces to the traces array in reverse order for the vegetation type chart.

To test, load any location with a vegetation type chart and verify that the legend is in alphabetical order. You'll notice that the colored regions of the stacked bar charts are in reverse order vs. before, too, to match the order of the legend.