### PR TITLE
Modifies the text + calms the minimap

### DIFF
--- a/components/Report.vue
+++ b/components/Report.vue
@@ -29,7 +29,7 @@
         <h3 class="title is-3 centered">
           Projected Conditions for <span v-html="place"></span>
         </h3>
-        <MiniMap />
+        <MiniMap polystyle="vivid" />
         <QualitativeText />
       </section>
       <section class="section content pb-0 is-hidden-touch" v-if="dataPresent">

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -29,7 +29,7 @@
         <h3 class="title is-3 centered">
           Projected Conditions for <span v-html="place"></span>
         </h3>
-        <MiniMap polystyle="vivid" />
+        <MiniMap :polystyle="polystyle" />
         <QualitativeText />
       </section>
       <section class="section content pb-0 is-hidden-touch" v-if="dataPresent">
@@ -399,6 +399,16 @@ export default {
     presentDataTypesString() {
       let types = this.presentDataTypes()
       return this.formatTypeString(types)
+    },
+    // If it's a point-based place, the associated HUC12
+    // should be a bit quieter.  If it's a polygon-based place,
+    // it should be 'vivid' (more pronounced).  Used in MiniMap.
+    // the polygon.
+    polystyle() {
+      if(this.type == 'latLng' || this.type == 'community') {
+        return '' // uses default calm MiniMap style
+      }
+      return 'vivid'
     },
     ...mapGetters({
       place: 'place/name',

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -39,7 +39,7 @@
             <span v-if="type == 'latLng'"
               >The <span v-if="climateData">tables and </span>charts below are
               specific to the gridded data extracted at
-              <span v-html="place"></span>, indicated by a marker on the map above.. {{ hucPolyExplanation }}</span
+              <span v-html="place"></span>, indicated by a marker on the map above. {{ hucPolyExplanation }}</span
             >
             <span v-else-if="type == 'community'"
               >The <span v-if="climateData">tables and </span>charts below are

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -39,16 +39,12 @@
             <span v-if="type == 'latLng'"
               >The <span v-if="climateData">tables and </span>charts below are
               specific to the gridded data extracted at
-              <span v-html="place"></span>. The polygon region on the map
-              corresponds to the nearest watershed (hydrological unit, level
-              12).</span
+              <span v-html="place"></span>, indicated by a marker on the map above.. {{ hucPolyExplanation }}</span
             >
             <span v-else-if="type == 'community'"
               >The <span v-if="climateData">tables and </span>charts below are
               specific to the gridded data extracted from the location of
-              <span v-html="place"></span>. The polygon region on the map
-              corresponds to the nearest watershed (hydrological unit, level
-              12).</span
+              <span v-html="place"></span>, indicated by a marker on the map above. {{ hucPolyExplanation }}</span
             >
             <span v-else
               >Data for the tables and charts below have been averaged across
@@ -336,6 +332,7 @@ export default {
     return {
       units: 'imperial',
       httpErrors: httpErrors,
+      hucPolyExplanation: 'The shaded region on the map is the nearest watershed (hydrological unit, level 12) and is only used to summarize wildfire data around this place.'
     }
   },
   computed: {

--- a/components/reports/MiniMap.vue
+++ b/components/reports/MiniMap.vue
@@ -77,7 +77,13 @@ export default {
           })
         })
 
-        let polygon = L.geoJSON(displayedGeoJSON)
+        let polygon = L.geoJSON(displayedGeoJSON, {
+          style: {
+            stroke: false,
+            color: '#000000',
+            fillOpacity: 0.3,
+          },
+        })
         this.geoJSONLayer = polygon.addTo(this.map)
         this.map.fitBounds(this.geoJSONLayer.getBounds())
       }

--- a/components/reports/MiniMap.vue
+++ b/components/reports/MiniMap.vue
@@ -22,17 +22,31 @@ import { mapGetters } from 'vuex'
 
 export default {
   name: 'MiniMap',
-  computed: {
-    ...mapGetters({
-      latLng: 'place/latLng',
-      geoJSON: 'place/geoJSON',
-    }),
-  },
   data() {
     return {
       marker: undefined,
       geoJSONLayer: undefined,
     }
+  },
+  props: ['polystyle'],
+  computed: {
+    // The 'vivid' style is the default (blue border/background).
+    polygonStyle() {
+      if (this.polystyle == 'vivid') {
+        return {}
+      }
+      return {
+        style: {
+          stroke: false,
+          color: '#000000',
+          fillOpacity: 0.3,
+        },
+      }
+    },
+    ...mapGetters({
+      latLng: 'place/latLng',
+      geoJSON: 'place/geoJSON',
+    }),
   },
   mounted() {
     this.map = L.map('report--minimmap--map', this.getBaseMapAndLayers())
@@ -77,13 +91,7 @@ export default {
           })
         })
 
-        let polygon = L.geoJSON(displayedGeoJSON, {
-          style: {
-            stroke: false,
-            color: '#000000',
-            fillOpacity: 0.3,
-          },
-        })
+        let polygon = L.geoJSON(displayedGeoJSON, this.polygonStyle)
         this.geoJSONLayer = polygon.addTo(this.map)
         this.map.fitBounds(this.geoJSONLayer.getBounds())
       }


### PR DESCRIPTION
Closes #399

Test by loading three flavors of places: (1) community (2) lat/lng.  For those cases, the initial mini-map should be style a bit more "calmly" (the polygon region is shaded dark, not blue/outline so it's easier to see the marker + emphasizes the marker.  The first sentence of the intro addresses the meaning of the shaded region.

For flavor (3) load a polygon-based location.  This time the polygon should look "default" (blue w/ border).