### PR TITLE
Hides permafrost section if no data is present at this location.

### DIFF
--- a/components/Report.vue
+++ b/components/Report.vue
@@ -39,12 +39,14 @@
             <span v-if="type == 'latLng'"
               >The <span v-if="climateData">tables and </span>charts below are
               specific to the gridded data extracted at
-              <span v-html="place"></span>, indicated by a marker on the map above. {{ hucPolyExplanation }}</span
+              <span v-html="place"></span>, indicated by a marker on the map
+              above. {{ hucPolyExplanation }}</span
             >
             <span v-else-if="type == 'community'"
               >The <span v-if="climateData">tables and </span>charts below are
               specific to the gridded data extracted from the location of
-              <span v-html="place"></span>, indicated by a marker on the map above. {{ hucPolyExplanation }}</span
+              <span v-html="place"></span>, indicated by a marker on the map
+              above. {{ hucPolyExplanation }}</span
             >
             <span v-else
               >Data for the tables and charts below have been averaged across
@@ -164,7 +166,7 @@
               multiple models and scenarios, grouped decadally and into mid/late
               century
             </li>
-            <li v-if="permafrostData || type != 'latLng'">
+            <li v-if="permafrostData">
               <a href="#permafrost">Permafrost</a> with specific visualizations
               depending on the presence or absence of permafrost
             </li>
@@ -329,7 +331,8 @@ export default {
     return {
       units: 'imperial',
       httpErrors: httpErrors,
-      hucPolyExplanation: 'The shaded region on the map is the nearest watershed (hydrological unit, level 12) and is only used to summarize wildfire data around this place.'
+      hucPolyExplanation:
+        'The shaded region on the map is the nearest watershed (hydrological unit, level 12) and is only used to summarize wildfire data around this place.',
     }
   },
   computed: {
@@ -403,7 +406,7 @@ export default {
     // it should be 'vivid' (more pronounced).  Used in MiniMap.
     // the polygon.
     polystyle() {
-      if(this.type == 'latLng' || this.type == 'community') {
+      if (this.type == 'latLng' || this.type == 'community') {
         return '' // uses default calm MiniMap style
       }
       return 'vivid'

--- a/components/reports/permafrost/PermafrostReport.vue
+++ b/components/reports/permafrost/PermafrostReport.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="reportData">
     <div class="content">
       <h4 class="title is-3">Permafrost</h4>
       <div class="is-size-5">
@@ -45,15 +45,19 @@
     <div v-else-if="!reportData && type != 'community' && type != 'latLng'">
       <div class="content">
         <div class="is-size-5">
-          As permafrost thaws, the ground depth to the top of the permafrost layer increases.  Because the selected place is an area, not a point location, a chart showing ground depth to the top of the permafrost layer cannot be shown because it varies across the extent of the area.
+          As permafrost thaws, the ground depth to the top of the permafrost
+          layer increases. Because the selected place is an area, not a point
+          location, a chart showing ground depth to the top of the permafrost
+          layer cannot be shown because it varies across the extent of the area.
         </div>
       </div>
     </div>
     <div v-else>
       <div class="content">
         <div class="is-size-5">
-          As permafrost thaws, the ground depth to the top of the permafrost layer increases.  This cannot be shown for this place because because permafrost data is not available for this
-          location.
+          As permafrost thaws, the ground depth to the top of the permafrost
+          layer increases. This cannot be shown for this place because because
+          permafrost data is not available for this location.
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR hides the entirety of the permafrost section if no data is present at this location. 

For testing, look at a few locations that are known to have permafrost such as Fairbanks, along with ones that should have no permafrost data such as Attu.

Fixes #252 