### PR TITLE
Makes map sticky when search results are visible

### DIFF
--- a/components/MapWrapper.vue
+++ b/components/MapWrapper.vue
@@ -11,7 +11,11 @@
     </div>
     <div id="map-search">
       <div class="is-flex is-flex-direction-row">
-        <div id="map--wrapper" v-bind:class="{ minimized: mapSearchIsVisible }">
+        <div
+          id="map--wrapper"
+          v-bind:class="{ minimized: mapSearchIsVisible }"
+          v-bind:style="mapStyleObject"
+        >
           <Map />
         </div>
         <div
@@ -79,6 +83,15 @@ export default {
   name: 'MapWrapper',
   components: { Map, SearchResults },
   computed: {
+    mapStyleObject() {
+      if (this.mapSearchIsVisible) {
+        return {
+          position: 'sticky',
+          top: 0,
+        }
+      }
+      return {}
+    },
     ...mapGetters({
       searchResults: 'place/searchResults',
       mapSearchIsVisible: 'mapSearchIsVisible',


### PR DESCRIPTION
Closes #435 

To test:

 - First go to existing version of tool and do a map search by clicking on/near Fbx
 - Scroll down -- observe that there's a lot of results, but the map scrolls up and off the screen
 - Switch to this branch and do the same thing.
 - Scroll down and observe that the map is sticky and stays in the viewport until you're past that whole section.