### PR TITLE
Removes "interactive" mouse cursor from data map polygons

### DIFF
--- a/components/reports/MiniMap.vue
+++ b/components/reports/MiniMap.vue
@@ -30,18 +30,19 @@ export default {
   },
   props: ['polystyle'],
   computed: {
-    // The 'vivid' style is the default (blue border/background).
     polygonStyle() {
-      if (this.polystyle == 'vivid') {
-        return {}
+      // The 'vivid' style is the default (blue border/background).
+      let geoJSONOptions = {
+        interactive: false, // outlines of areas should not be interactive
       }
-      return {
-        style: {
+      if (this.polystyle != 'vivid') {
+        geoJSONOptions.style = {
           stroke: false,
           color: '#000000',
           fillOpacity: 0.3,
-        },
+        }
       }
+      return geoJSONOptions
     },
     ...mapGetters({
       latLng: 'place/latLng',

--- a/utils/maps.js
+++ b/utils/maps.js
@@ -38,6 +38,7 @@ export const getBaseMapAndLayers = function () {
 export const addGeoJSONtoMap = function (zoomOutDelta = 0) {
   if (this.geoJSON) {
     this.geoJSONLayer = L.geoJSON(this.geoJSON, {
+      interactive: false,
       style: {
         color: '#444444',
         weight: 2,


### PR DESCRIPTION
Closes #287 

To test:

 - Load Fairbanks.
 - The initial MiniMap shouldn't have a hover effect on the shaded gray polygon.  (But you can still drag/pan the map -- I think this is OK here because it's sometimes helpful to get more spatial context)
 - Check the Permafrost, Wildfire, and Beetle minimaps.  None should have a hover effect on the associated HUC12.
 - Now check an area, 1908030601
 - Permafrost won't be shown & the outline is this region, not a default HUC12.
 - Initial Minimap, Wildfire, Beetle minimaps should not have a hover effect on the polygon.

