### PR TITLE
Adds local storage capture of API calls to reduce trips to API

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -105,6 +105,7 @@ export default {
     rasdamanUrl:
       process.env.RASDAMAN_URL || 'https://zeus.snap.uaf.edu/rasdaman/ows',
     apiUrl: process.env.SNAP_API_URL || 'https://earthmaps.io',
+    localStorageExpiration: process.env.LS_EXP || 4,
   },
 
   // Router customizations

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -105,7 +105,7 @@ export default {
     rasdamanUrl:
       process.env.RASDAMAN_URL || 'https://zeus.snap.uaf.edu/rasdaman/ows',
     apiUrl: process.env.SNAP_API_URL || 'https://earthmaps.io',
-    localStorageExpiration: process.env.LS_EXP || 4,
+    localStorageExpiration: 4,
   },
 
   // Router customizations

--- a/package-lock.json
+++ b/package-lock.json
@@ -10649,6 +10649,11 @@
         }
       }
     },
+    "nuxt-storage": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/nuxt-storage/-/nuxt-storage-1.2.2.tgz",
+      "integrity": "sha512-quJbZ87NO7QRCSp7YZolot6VwktciSLuTS/sRl8NPz5rAWA84U5Py0y9FmAsbKTiaqJtFcCKSaJGzky948jA3w=="
+    },
     "nuxt-umami": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/nuxt-umami/-/nuxt-umami-1.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "nuxt": "^2.14.12",
     "nuxt-buefy": "^0.4.4",
     "nuxt-leaflet": "0.0.25",
+    "nuxt-storage": "^1.2.2",
     "nuxt-umami": "^1.2.3",
     "parse-dms": "0.0.5",
     "plotly.js-dist-min": "^2.3.1",

--- a/store/beetle.js
+++ b/store/beetle.js
@@ -1,6 +1,6 @@
 // This store manages ALFRESCO data!
 import _ from 'lodash'
-import { localStorage } from '../utils/localstorage'
+import { localStorage, checkForError } from '../utils/localstorage'
 import nuxtStorage from 'nuxt-storage'
 
 export const state = () => ({
@@ -88,7 +88,7 @@ export const actions = {
 
     let returnedData = await localStorage(queryUrl, localKey, errorKey)
 
-    if (nuxtStorage.localStorage.getData(errorKey)) {
+    if (checkForError(errorKey)) {
       context.commit('setHttpError', nuxtStorage.localStorage.getData(errorKey))
     } else {
       context.commit('setBeetleData', returnedData)

--- a/store/climate.js
+++ b/store/climate.js
@@ -1,7 +1,7 @@
 // This store fetches/manages "climate" variables (taspr = temp + precip)
 import _ from 'lodash'
 import { convertToInches, convertToFahrenheit } from '../utils/convert'
-import { localStorage } from '../utils/localstorage'
+import { localStorage, checkForError } from '../utils/localstorage'
 import nuxtStorage from 'nuxt-storage'
 
 // Helper functions
@@ -81,7 +81,7 @@ export const actions = {
 
     let returnedData = await localStorage(queryUrl, localKey, errorKey)
 
-    if (nuxtStorage.localStorage.getData(errorKey)) {
+    if (checkForError(errorKey)) {
       context.commit('setHttpError', nuxtStorage.localStorage.getData(errorKey))
     } else {
       context.commit('setClimateData', returnedData)

--- a/store/climate.js
+++ b/store/climate.js
@@ -2,6 +2,7 @@
 import _ from 'lodash'
 import { convertToInches, convertToFahrenheit } from '../utils/convert'
 import { getHttpError } from '../utils/http_errors'
+import nuxtStorage from 'nuxt-storage'
 
 // Helper functions
 var convertReportData = function (climateData) {
@@ -71,14 +72,55 @@ export const mutations = {
 
 export const actions = {
   async fetch(context) {
-    let queryUrl =
-      process.env.apiUrl +
-      '/taspr/' +
-      context.rootGetters['place/urlFragment']()
-    let climateData = await this.$axios.$get(queryUrl).catch(err => {
-      let httpError = getHttpError(err)
-      context.commit('setHttpError', httpError)
-    })
-    context.commit('setClimateData', climateData)
+    if (
+      nuxtStorage.localStorage.getData(
+        'climateData-' + context.rootGetters['place/urlFragment']()
+      )
+    ) {
+      context.commit(
+        'setClimateData',
+        nuxtStorage.localStorage.getData(
+          'climateData-' + context.rootGetters['place/urlFragment']()
+        )
+      )
+    } else {
+      let climateData = null
+      if (
+        nuxtStorage.localStorage.getData(
+          'climateError-' + context.rootGetters['place/urlFragment']()
+        )
+      ) {
+        context.commit(
+          'setHttpError',
+          nuxtStorage.localStorage.getData(
+            'climateError-' + context.rootGetters['place/urlFragment']()
+          )
+        )
+      } else {
+        let queryUrl =
+          process.env.apiUrl +
+          '/taspr/' +
+          context.rootGetters['place/urlFragment']()
+        climateData = await this.$axios.$get(queryUrl).catch(err => {
+          let httpError = getHttpError(err)
+          nuxtStorage.localStorage.setData(
+            'climateError-' + context.rootGetters['place/urlFragment'](),
+            httpError,
+            4,
+            'h'
+          )
+          context.commit('setHttpError', httpError)
+        })
+      }
+      if (climateData != null) {
+        nuxtStorage.localStorage.setData(
+          'climateData-' + context.rootGetters['place/urlFragment'](),
+          climateData,
+          4,
+          'h'
+        )
+        context.commit('setClimateData', climateData)
+      }
+    }
   },
 }

--- a/store/elevation.js
+++ b/store/elevation.js
@@ -1,5 +1,5 @@
 import { convertToFeet } from '../utils/convert'
-import { localStorage } from '../utils/localstorage'
+import { localStorage, checkForError } from '../utils/localstorage'
 import nuxtStorage from 'nuxt-storage'
 
 export const state = () => ({
@@ -68,7 +68,7 @@ export const actions = {
 
     let returnedData = await localStorage(queryUrl, localKey, errorKey)
 
-    if (nuxtStorage.localStorage.getData(errorKey)) {
+    if (checkForError(errorKey)) {
       context.commit('setHttpError', nuxtStorage.localStorage.getData(errorKey))
     } else {
       context.commit('setElevation', returnedData)

--- a/store/indicators.js
+++ b/store/indicators.js
@@ -1,7 +1,7 @@
 // this store manages NCAR 12km indicator data
 import _ from 'lodash'
 import { convertMmToInches, convertValueToFahrenheit } from '../utils/convert'
-import { localStorage } from '../utils/localstorage'
+import { localStorage, checkForError } from '../utils/localstorage'
 import nuxtStorage from 'nuxt-storage'
 
 var convertTemperatureData = function (obj) {
@@ -92,7 +92,7 @@ export const actions = {
 
     let returnedData = await localStorage(queryUrl, localKey, errorKey)
 
-    if (nuxtStorage.localStorage.getData(errorKey)) {
+    if (checkForError(errorKey)) {
       context.commit('setHttpError', nuxtStorage.localStorage.getData(errorKey))
     } else {
       context.commit('setIndicatorData', returnedData)

--- a/store/permafrost.js
+++ b/store/permafrost.js
@@ -2,7 +2,7 @@
 
 import _ from 'lodash'
 import { convertToInches, convertToFahrenheit } from '../utils/convert'
-import { localStorage } from '../utils/localstorage'
+import { localStorage, checkForError } from '../utils/localstorage'
 import nuxtStorage from 'nuxt-storage'
 
 // Store, namespaced as `permafrost/`
@@ -146,7 +146,7 @@ export const actions = {
 
     let returnedData = await localStorage(queryUrl, localKey, errorKey)
 
-    if (nuxtStorage.localStorage.getData(errorKey)) {
+    if (checkForError(errorKey)) {
       context.commit('setHttpError', nuxtStorage.localStorage.getData(errorKey))
     } else {
       context.commit('setPermafrostData', returnedData)

--- a/store/place.js
+++ b/store/place.js
@@ -1,5 +1,6 @@
 // Shim for dev/testing
 import _ from 'lodash'
+import nuxtStorage from 'nuxt-storage'
 
 // Store, namespaced as `place/`
 export const state = () => ({
@@ -215,14 +216,15 @@ export const actions = {
 
   async fetchPlaces(context) {
     // If we've already fetched this, don't do that again.
-    if (context.state.places) {
-      return
+    if (nuxtStorage.localStorage.getData('places')) {
+      context.commit('setPlaces', nuxtStorage.localStorage.getData('places'))
+    } else {
+      // TODO: add error handling here for 404 (no data) etc.
+      let queryUrl = process.env.apiUrl + '/places/all'
+      let places = await this.$http.$get(queryUrl)
+      nuxtStorage.localStorage.setData('places', places, 4, 'h')
+      context.commit('setPlaces', places)
     }
-
-    // TODO: add error handling here for 404 (no data) etc.
-    let queryUrl = process.env.apiUrl + '/places/all'
-    let places = await this.$http.$get(queryUrl)
-    context.commit('setPlaces', places)
   },
 
   async search(context) {

--- a/store/place.js
+++ b/store/place.js
@@ -1,6 +1,6 @@
 // Shim for dev/testing
 import _ from 'lodash'
-import nuxtStorage from 'nuxt-storage'
+import { localStorage } from '../utils/localstorage'
 
 // Store, namespaced as `place/`
 export const state = () => ({
@@ -215,16 +215,13 @@ export const actions = {
   },
 
   async fetchPlaces(context) {
-    // If we've already fetched this, don't do that again.
-    if (nuxtStorage.localStorage.getData('places')) {
-      context.commit('setPlaces', nuxtStorage.localStorage.getData('places'))
-    } else {
-      // TODO: add error handling here for 404 (no data) etc.
-      let queryUrl = process.env.apiUrl + '/places/all'
-      let places = await this.$http.$get(queryUrl)
-      nuxtStorage.localStorage.setData('places', places, 4, 'h')
-      context.commit('setPlaces', places)
-    }
+    let queryUrl = process.env.apiUrl + '/places/all'
+
+    let localKey = 'places'
+
+    let returnedData = await localStorage(queryUrl, localKey)
+
+    context.commit('setPlaces', returnedData)
   },
 
   async search(context) {

--- a/store/wildfire.js
+++ b/store/wildfire.js
@@ -1,7 +1,7 @@
 // This store manages ALFRESCO data!
 import _ from 'lodash'
 import { convertToPercent } from '../utils/convert'
-import { localStorage } from '../utils/localstorage'
+import { localStorage, checkForError } from '../utils/localstorage'
 import nuxtStorage from 'nuxt-storage'
 
 // Store, namespaced as `climate/`
@@ -204,7 +204,7 @@ export const actions = {
 
     let returnedData = await localStorage(queryUrl, localKey, errorKey)
 
-    if (nuxtStorage.localStorage.getData(errorKey)) {
+    if (checkForError(errorKey)) {
       context.commit(
         'setFlammabilityHttpError',
         nuxtStorage.localStorage.getData(errorKey)
@@ -225,7 +225,7 @@ export const actions = {
 
     returnedData = await localStorage(queryUrl, localKey, errorKey)
 
-    if (nuxtStorage.localStorage.getData(errorKey)) {
+    if (checkForError(errorKey)) {
       context.commit(
         'setVegChangeHttpError',
         nuxtStorage.localStorage.getData(errorKey)

--- a/store/wildfire.js
+++ b/store/wildfire.js
@@ -1,8 +1,7 @@
 // This store manages ALFRESCO data!
 import _ from 'lodash'
-import { getHttpError } from '../utils/http_errors'
 import { convertToPercent } from '../utils/convert'
-import { objectTypeSpreadProperty } from '@babel/types'
+import { localStorage } from '../utils/localstorage'
 import nuxtStorage from 'nuxt-storage'
 
 // Store, namespaced as `climate/`
@@ -187,136 +186,52 @@ export const actions = {
     // to use the special `/local` endpoint & pass
     // a parameter to the `urlFragment` getter to return
     // the correct structure.
-
-    if (
-      nuxtStorage.localStorage.getData(
-        'flammability-' +
-          context.rootGetters['place/urlFragment'](
-            context.rootGetters['place/isPointLocation']
-          )
-      )
-    ) {
-      context.commit(
-        'setFlammability',
-        nuxtStorage.localStorage.getData(
-          'flammability-' +
-            context.rootGetters['place/urlFragment'](
-              context.rootGetters['place/isPointLocation']
-            )
-        )
-      )
-    } else {
-      let flammability = null
-      if (
-        nuxtStorage.localStorage.getData(
-          'flammabilityError-' + context.rootGetters['place/urlFragment']()
-        )
-      ) {
-        context.commit(
-          'setHttpError',
-          nuxtStorage.localStorage.getData(
-            'flammabilityError-' + context.rootGetters['place/urlFragment']()
-          )
-        )
-      } else {
-        let local = ''
-        if (context.rootGetters['place/isPointLocation']) {
-          local = 'local/'
-        }
-
-        let flammabilityQueryUrl =
-          process.env.apiUrl +
-          '/alfresco/flammability/' +
-          local +
-          context.rootGetters['place/urlFragment'](
-            context.rootGetters['place/isPointLocation']
-          )
-        flammability = await this.$axios
-          .$get(flammabilityQueryUrl)
-          .catch(err => {
-            let httpError = getHttpError(err)
-            nuxtStorage.localStorage.setData(
-              'flammabilityError-' + context.rootGetters['place/urlFragment']()
-            )
-            context.commit('setFlammabilityHttpError', httpError)
-          })
-      }
-      if (flammability != null) {
-        let convertedFlammability = convertToPercent(flammability)
-        nuxtStorage.localStorage.setData(
-          'flammability-' +
-            context.rootGetters['place/urlFragment'](
-              context.rootGetters['place/isPointLocation']
-            ),
-          convertedFlammability,
-          4,
-          'h'
-        )
-        context.commit('setFlammability', convertedFlammability)
-      }
+    let local = ''
+    if (context.rootGetters['place/isPointLocation']) {
+      local = 'local/'
     }
 
-    if (
-      nuxtStorage.localStorage.getData(
-        'vegChange-' +
-          context.rootGetters['place/urlFragment'](
-            context.rootGetters['place/isPointLocation']
-          )
+    let queryUrl =
+      process.env.apiUrl +
+      '/alfresco/flammability/' +
+      local +
+      context.rootGetters['place/urlFragment'](
+        context.rootGetters['place/isPointLocation']
       )
-    ) {
+    let localKey = 'flammability-' + context.rootGetters['place/urlFragment']()
+    let errorKey =
+      'flammabilityError-' + context.rootGetters['place/urlFragment']()
+
+    let returnedData = await localStorage(queryUrl, localKey, errorKey)
+
+    if (nuxtStorage.localStorage.getData(errorKey)) {
       context.commit(
-        'setVegChange',
-        nuxtStorage.localStorage.getData(
-          'vegChange-' +
-            context.rootGetters['place/urlFragment'](
-              context.rootGetters['place/isPointLocation']
-            )
-        )
+        'setFlammabilityHttpError',
+        nuxtStorage.localStorage.getData(errorKey)
       )
     } else {
-      let veg_change = null
-      if (
-        nuxtStorage.localStorage.getData(
-          'vegChangeError-' + context.rootGetters['place/urlFragment']()
-        )
-      ) {
-        context.commit(
-          'setHttpError',
-          nuxtStorage.localStorage.getData(
-            'vegChangeError-' + context.rootGetters['place/urlFragment']()
-          )
-        )
-      } else {
-        let vegChangeQueryUrl =
-          process.env.apiUrl +
-          '/alfresco/veg_type/' +
-          local +
-          context.rootGetters['place/urlFragment'](
-            context.rootGetters['place/isPointLocation']
-          )
-        veg_change = await this.$axios.$get(vegChangeQueryUrl).catch(err => {
-          let httpError = getHttpError(err)
-          nuxtStorage.localStorage.setData(
-            'vegChangeError-' + context.rootGetters['place/urlFragment'](),
-            httpError,
-            4,
-            'h'
-          )
-          context.commit('setVegChangeHttpError', httpError)
-        })
-      }
-      if (veg_change != null) {
-        nuxtStorage.localStorage.setData(
-          'vegChange-' +
-            context.rootGetters['place/urlFragment'](
-              context.rootGetters['place/isPointLocation']
-            ),
-          veg_change,
-          4,
-          'h'
-        )
-        context.commit('setVegChange', veg_change)
-      }
+      context.commit('setFlammability', convertToPercent(returnedData))
+    }
+
+    queryUrl =
+      process.env.apiUrl +
+      '/alfresco/veg_type/' +
+      local +
+      context.rootGetters['place/urlFragment'](
+        context.rootGetters['place/isPointLocation']
+      )
+    localKey = 'vegChange-' + context.rootGetters['place/urlFragment']()
+    errorKey = 'vegChangeError-' + context.rootGetters['place/urlFragment']()
+
+    returnedData = await localStorage(queryUrl, localKey, errorKey)
+
+    if (nuxtStorage.localStorage.getData(errorKey)) {
+      context.commit(
+        'setVegChangeHttpError',
+        nuxtStorage.localStorage.getData(errorKey)
+      )
+    } else {
+      context.commit('setVegChange', returnedData)
     }
   },
 }

--- a/utils/localstorage.js
+++ b/utils/localstorage.js
@@ -3,6 +3,21 @@ import { getHttpError } from './http_errors'
 import $axios from 'axios'
 import nuxtStorage from 'nuxt-storage'
 
+export const checkForError = function (errorKey) {
+  // This checks if the local storage error exists and if it is a
+  // 400, 404, or 422 error. If it isn't, we will retry the API endpoint.
+  if (
+    nuxtStorage.localStorage.getData(errorKey) &&
+    (nuxtStorage.localStorage.getData(errorKey) == 'bad_request' ||
+      nuxtStorage.localStorage.getData(errorKey) == 'no_data' ||
+      nuxtStorage.localStorage.getData(errorKey) == 'invalid_coordinates')
+  ) {
+    return true
+  } else {
+    return false
+  }
+}
+
 export const localStorage = async function (
   queryUrl,
   localKey,
@@ -12,7 +27,7 @@ export const localStorage = async function (
     return nuxtStorage.localStorage.getData(localKey)
   } else {
     let returnedData = null
-    if (nuxtStorage.localStorage.getData(errorKey)) {
+    if (checkForError(errorKey)) {
       return returnedData
     } else {
       returnedData = await $axios

--- a/utils/localstorage.js
+++ b/utils/localstorage.js
@@ -18,11 +18,21 @@ export const localStorage = async function (
       returnedData = await $axios
         .get(queryUrl, { timeout: 60000 })
         .catch(err => {
-          nuxtStorage.localStorage.setData(errorKey, getHttpError(err), 4, 'h')
+          nuxtStorage.localStorage.setData(
+            errorKey,
+            getHttpError(err),
+            process.env.localStorageExpiration,
+            'h'
+          )
         })
     }
     if (returnedData != null) {
-      nuxtStorage.localStorage.setData(localKey, returnedData.data, 4, 'h')
+      nuxtStorage.localStorage.setData(
+        localKey,
+        returnedData.data,
+        process.env.localStorageExpiration,
+        'h'
+      )
     }
     return returnedData.data
   }

--- a/utils/localstorage.js
+++ b/utils/localstorage.js
@@ -1,0 +1,29 @@
+import _ from 'lodash'
+import { getHttpError } from './http_errors'
+import $axios from 'axios'
+import nuxtStorage from 'nuxt-storage'
+
+export const localStorage = async function (
+  queryUrl,
+  localKey,
+  errorKey = null
+) {
+  if (nuxtStorage.localStorage.getData(localKey)) {
+    return nuxtStorage.localStorage.getData(localKey)
+  } else {
+    let returnedData = null
+    if (nuxtStorage.localStorage.getData(errorKey)) {
+      return returnedData
+    } else {
+      returnedData = await $axios
+        .get(queryUrl, { timeout: 60000 })
+        .catch(err => {
+          nuxtStorage.localStorage.setData(errorKey, getHttpError(err), 4, 'h')
+        })
+    }
+    if (returnedData != null) {
+      nuxtStorage.localStorage.setData(localKey, returnedData.data, 4, 'h')
+    }
+    return returnedData.data
+  }
+}


### PR DESCRIPTION
This PR adds the local storage caching of all sections in the report for NCR. For all API calls, there is a call to cache the returned results in local storage along with pulling from that cache if it exists. 


Closes #495 