### PR TITLE
Hides temperature and precipitation indicators section if data is unavailable

### DIFF
--- a/components/Report.vue
+++ b/components/Report.vue
@@ -231,8 +231,11 @@
           <PrecipReport />
         </div>
       </section>
-      <section class="section is-hidden-touch">
-        <div id="permafrost" v-if="permafrostData || type != 'latLng'">
+      <section
+        class="section is-hidden-touch"
+        v-if="permafrostData || type != 'latLng'"
+      >
+        <div id="permafrost">
           <PermafrostReport />
         </div>
       </section>
@@ -244,11 +247,11 @@
           <WildfireReport />
         </div>
       </section>
-      <section class="section is-hidden-touch">
-        <div id="climate-protection-beetles" v-if="beetleData">
+      <section class="section is-hidden-touch" v-if="beetleData">
+        <div id="climate-protection-beetles">
           <BeetleRiskReport />
+          <BackToTopButton />
         </div>
-        <BackToTopButton />
       </section>
       <section
         class="section is-hidden-fullhd is-hidden-widescreen is-hidden-desktop"
@@ -262,7 +265,6 @@
         </div>
       </section>
       <hr />
-      <BackButton />
     </div>
   </div>
 </template>

--- a/components/reports/precipitation/PrecipReport.vue
+++ b/components/reports/precipitation/PrecipReport.vue
@@ -48,13 +48,6 @@
     </div>
     <ReportPrecipChart :season="precip_season" />
     <ReportPrecipTable />
-    <div class="content">
-      <h4 class="title is-4 mt-6">Precipitation Indicators</h4>
-      <div class="is-size-5">
-        &ldquo;Indicators&rdquo; are a tool that help us understand data. We can
-        link indicators to specific impacts or risks.
-      </div>
-    </div>
     <ReportPrecipIndicatorsTable />
     <DownloadCsvButton
       text="Download precipitation data as CSV"

--- a/components/reports/precipitation/ReportPrecipIndicatorsTable.vue
+++ b/components/reports/precipitation/ReportPrecipIndicatorsTable.vue
@@ -1,6 +1,13 @@
 <template>
-  <div class="report--precipitation-indicators">
-    <table class="table report-table" v-if="reportData">
+  <div class="report--precipitation-indicators" v-if="reportData">
+    <div class="content">
+      <h4 class="title is-4 mt-6">Precipitation Indicators</h4>
+      <div class="is-size-5">
+        &ldquo;Indicators&rdquo; are a tool that help us understand data. We can
+        link indicators to specific impacts or risks.
+      </div>
+    </div>
+    <table class="table report-table">
       <caption>
         Precipitation Indicators,
         <span v-html="place"></span

--- a/components/reports/temperature/ReportTempIndicatorsTable.vue
+++ b/components/reports/temperature/ReportTempIndicatorsTable.vue
@@ -1,6 +1,13 @@
 <template>
-  <div class="report--temperature-indicators">
-    <table class="table report-table" v-if="reportData">
+  <div class="report--temperature-indicators" v-if="reportData">
+    <div class="content">
+      <h4 class="title is-4 mt-6">Temperature Indicators</h4>
+      <div class="is-size-5">
+        &ldquo;Indicators&rdquo; are a tool that help us understand data. We can
+        link indicators to specific impacts or risks.
+      </div>
+    </div>
+    <table class="table report-table">
       <caption>
         Temperature Indicators,
         <span v-html="place"></span

--- a/components/reports/temperature/TempReport.vue
+++ b/components/reports/temperature/TempReport.vue
@@ -33,13 +33,6 @@
     </div>
     <ReportTempChart :season="temp_season" />
     <ReportTempTable />
-    <div class="content">
-      <h4 class="title is-4 mt-6">Temperature Indicators</h4>
-      <div class="is-size-5">
-        &ldquo;Indicators&rdquo; are a tool that help us understand data. We can
-        link indicators to specific impacts or risks.
-      </div>
-    </div>
     <ReportTempIndicatorsTable />
     <DownloadCsvButton
       text="Download temperature data as CSV"


### PR DESCRIPTION
This PR hides the temperature and precipitation indicators sections when no data is available. Additionally, this makes the sections all not show if no data is available. Previously, the permafrost and beetle sections would still have a section of blank area appear which in the case of some locations would add a lot of additional whitespace at the bottom of the screen.

Fixes #526 