### PR TITLE
Hide permafrost qualitative text when rounded degradation rate is zero

### DIFF
--- a/components/reports/QualitativeText.vue
+++ b/components/reports/QualitativeText.vue
@@ -2,8 +2,8 @@
   <div class="qualitative-text content" v-if="qualitativeText">
     <div class="generated" v-html="qualitativeText"></div>
     <p class="about-blurb">
-      Summary across all models and scenarios.  See tables and sections below
-      for more detailed information and definitions.
+      Summary across all models and scenarios. See tables and sections below for
+      more detailed information and definitions.
     </p>
   </div>
 </template>
@@ -77,7 +77,7 @@ export default {
       }
     },
     depthUnitsText() {
-      return this.units == 'metric' ? 'meters' : 'inches'
+      return this.units == 'metric' ? 'centimeters' : 'inches'
     },
     qualitativeText() {
       return this.generateText()
@@ -295,13 +295,19 @@ export default {
 
       let maxDifference = _.max(differences)
 
-      if (maxDifference > 0) {
-        // Inclusively, there are 79 years between 2021 and 2099.
-        let degradationRate = maxDifference / 79
+      // Inclusively, there are 79 years between 2021 and 2099.
+      let degradationRate = maxDifference / 79
 
-        let precision = this.units == 'metric' ? 2 : 1
-        degradationRate = degradationRate.toFixed(precision)
+      // Use centimeters instead of meters for degradation rate since even
+      // small degradation rate values can be meaningful.
+      if (this.units == 'metric') {
+        degradationRate *= 100
+      }
 
+      degradationRate = degradationRate.toFixed(1)
+
+      // Hide permafrost qualitative text if rounded degration rate is zero.
+      if (degradationRate > 0) {
         return (
           '<p>Models indicate that permafrost degradation may occur at a rate of <strong>' +
           degradationRate +

--- a/package-lock.json
+++ b/package-lock.json
@@ -9799,7 +9799,7 @@
     "mgrs": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
-      "integrity": "sha1-+5FYjnjJACVnI5XLQLJffNatGCk="
+      "integrity": "sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA=="
     },
     "micromark": {
       "version": "2.11.4",


### PR DESCRIPTION
Closes #558.

This PR fixes a bug in the permafrost qualitative text. The current code in `main` checks to see if there's a difference between early- and late-era values for permafrost depth, and the permafrost qualitative text is only displayed if the difference is greater than 0.

It turns out this is the wrong thing to check, however, because we are not displaying the raw difference value in the qualitative text, but the degradation rate, which is the difference divided by the number of projected years, then rounded to a fixed decimal precision. During the division and rounding process, it's possible for degradation rate values to be rounded to zero, as in the case of Anchorage described in #558.

This PR fixes this by checking that the post-rounded degradation rate is greater than zero.

I also changed the qualitative text to display the degradation rate as centimeters per year instead of meters per year when in metric mode since it seems more appropriate for small values, and avoids a new situation that emerged where permafrost qualitative text was visible for imperial units but hidden for metric units.

To test, load a few locations and switch between imperial and metric mode, and verify that permafrost degradation rate values are either:

- Hidden if the degradation rate is zero
- Displayed if the degradation rate is greater than zero, and imperial vs. metric units are comparable