### PR TITLE
Prevent "Ground surface" from overlapping legend in exported permafrost charts

### DIFF
--- a/components/reports/permafrost/ReportPermafrostTopChart.vue
+++ b/components/reports/permafrost/ReportPermafrostTopChart.vue
@@ -48,14 +48,8 @@ export default {
       })
 
       let yAxisLabel = 'Depth (' + units + ')'
-      let orig_layout = getLayout(title, yAxisLabel)
-      let layout = {
-        ...orig_layout,
-        yaxis: {
-          ...orig_layout.yaxis,
-          autorange: 'reversed',
-        },
-      }
+      let layout = getLayout(title, yAxisLabel)
+      layout['yaxis']['autorange'] = 'reversed'
 
       let dataTraces = getProjectedTraces(permafrostTopData, units, precision)
       let footerLines = []
@@ -88,15 +82,11 @@ export default {
 
       layout.annotations.push({
         x: 1,
-        y: 0,
+        y: 1.065,
         xref: 'paper',
-        yref: 'y',
+        yref: 'paper',
         text: 'Ground surface',
-        showarrow: true,
-        arrowcolor: '#aaaaaa',
-        arrowhead: 6,
-        ax: 0,
-        ay: -12,
+        showarrow: false,
         font: {
           color: '#888888',
         },


### PR DESCRIPTION
Closes #513.

This PR fixes the issue where the "Ground surface" annotation text was overlapping the legend in exported permafrost charts. It does this by making the right side of the "Ground surface" text flush with the right side of the line, not centered over the end of the line and hanging off like before (as in the screenshot in #513).

I realized while working on this that the xaxis grid lines were being displaying on permafrost charts, unlike all other charts in NCR, and this was (strangely) making the vertical spacing between the "Ground surface" text and annotation line inconsistent between browsers. So I made a small code fix to hide xaxis grid lines as part of this PR as well.

To test, load some locations with permafrost data present (like Fairbanks) and verify that the "Ground surface" text does not overlap the legend when you export the chart to PNG.