### PR TITLE
Modifies anchor link to use the new location for the beetle report PDF.

### DIFF
--- a/components/reports/beetles/BeetleRiskReport.vue
+++ b/components/reports/beetles/BeetleRiskReport.vue
@@ -16,7 +16,7 @@
         </p>
         <p>
           <a
-            href="https://uaf-snap.org/wp-content/uploads/2023/06/20230508_spruce-beetle-climate-model-white-paper.pdf"
+            href="https://uaf-snap.org/wp-content/uploads/2023/06/20230627_spruce-beetle-climate-model-white-paper.pdf"
             >See more details about how the model was developed</a
           >
         </p>


### PR DESCRIPTION
This PR changes the href of an anchor link to point at the correct location for the beetle report PDF.

Closes #562 