### PR TITLE
Finish implementation of WSDI/CSDI

### DIFF
--- a/components/reports/DayDiffWidget.vue
+++ b/components/reports/DayDiffWidget.vue
@@ -6,8 +6,6 @@
       strong: isStrong,
       less: isLess,
       more: isMore,
-      precip: isPrecip,
-      temp: isTemp,
     }"
     v-html="diff"
   ></span>
@@ -15,15 +13,6 @@
 <style lang="scss" scoped>
 .diff {
   display: block;
-
-  &.precip,
-  &.temp.less {
-    color: #05335e;
-  }
-
-  &.temp.more {
-    color: #5e3305;
-  }
 
   &.weak {
     font-weight: 300;
@@ -45,11 +34,6 @@ export default {
       type: Number,
       required: true,
     },
-    // What kind of variable?  ["temp", "precip"] are the options
-    variable: {
-      type: String,
-      required: true,
-    },
   },
   computed: {
     pct() {
@@ -67,12 +51,6 @@ export default {
     },
     isMore() {
       return this.pct > 0
-    },
-    isPrecip() {
-      return this.variable == 'precip'
-    },
-    isTemp() {
-      return this.variable == 'temp'
     },
     diff() {
       let diff = this.future - this.past

--- a/components/reports/precipitation/ReportPrecipIndicatorsTable.vue
+++ b/components/reports/precipitation/ReportPrecipIndicatorsTable.vue
@@ -308,7 +308,6 @@
           <td>
             {{ reportData['cwd']['midcentury']['MRI-CGCM3']['rcp45']['mean'] }}
             <DayDiffWidget
-              variable="precip"
               :future="
                 reportData['cwd']['midcentury']['MRI-CGCM3']['rcp45']['mean']
               "
@@ -320,7 +319,6 @@
           <td>
             {{ reportData['cwd']['midcentury']['NCAR-CCSM4']['rcp45']['mean'] }}
             <DayDiffWidget
-              variable="precip"
               :future="
                 reportData['cwd']['midcentury']['NCAR-CCSM4']['rcp45']['mean']
               "
@@ -332,7 +330,6 @@
           <td>
             {{ reportData['cwd']['midcentury']['MRI-CGCM3']['rcp85']['mean'] }}
             <DayDiffWidget
-              variable="precip"
               :future="
                 reportData['cwd']['midcentury']['MRI-CGCM3']['rcp85']['mean']
               "
@@ -344,7 +341,6 @@
           <td>
             {{ reportData['cwd']['midcentury']['NCAR-CCSM4']['rcp85']['mean'] }}
             <DayDiffWidget
-              variable="precip"
               :future="
                 reportData['cwd']['midcentury']['NCAR-CCSM4']['rcp85']['mean']
               "
@@ -356,7 +352,6 @@
           <td>
             {{ reportData['cwd']['longterm']['MRI-CGCM3']['rcp45']['mean'] }}
             <DayDiffWidget
-              variable="precip"
               :future="
                 reportData['cwd']['longterm']['MRI-CGCM3']['rcp45']['mean']
               "
@@ -368,7 +363,6 @@
           <td>
             {{ reportData['cwd']['longterm']['NCAR-CCSM4']['rcp45']['mean'] }}
             <DayDiffWidget
-              variable="precip"
               :future="
                 reportData['cwd']['longterm']['NCAR-CCSM4']['rcp45']['mean']
               "
@@ -380,7 +374,6 @@
           <td>
             {{ reportData['cwd']['longterm']['MRI-CGCM3']['rcp85']['mean'] }}
             <DayDiffWidget
-              variable="precip"
               :future="
                 reportData['cwd']['longterm']['MRI-CGCM3']['rcp85']['mean']
               "
@@ -392,7 +385,6 @@
           <td>
             {{ reportData['cwd']['longterm']['NCAR-CCSM4']['rcp85']['mean'] }}
             <DayDiffWidget
-              variable="precip"
               :future="
                 reportData['cwd']['longterm']['NCAR-CCSM4']['rcp85']['mean']
               "
@@ -418,7 +410,6 @@
           <td>
             {{ reportData['cdd']['midcentury']['MRI-CGCM3']['rcp45']['mean'] }}
             <DayDiffWidget
-              variable="precip"
               :future="
                 reportData['cdd']['midcentury']['MRI-CGCM3']['rcp45']['mean']
               "
@@ -430,7 +421,6 @@
           <td>
             {{ reportData['cdd']['midcentury']['NCAR-CCSM4']['rcp45']['mean'] }}
             <DayDiffWidget
-              variable="precip"
               :future="
                 reportData['cdd']['midcentury']['NCAR-CCSM4']['rcp45']['mean']
               "
@@ -442,7 +432,6 @@
           <td>
             {{ reportData['cdd']['midcentury']['MRI-CGCM3']['rcp85']['mean'] }}
             <DayDiffWidget
-              variable="precip"
               :future="
                 reportData['cdd']['midcentury']['MRI-CGCM3']['rcp85']['mean']
               "
@@ -454,7 +443,6 @@
           <td>
             {{ reportData['cdd']['midcentury']['NCAR-CCSM4']['rcp85']['mean'] }}
             <DayDiffWidget
-              variable="precip"
               :future="
                 reportData['cdd']['midcentury']['NCAR-CCSM4']['rcp85']['mean']
               "
@@ -466,7 +454,6 @@
           <td>
             {{ reportData['cdd']['longterm']['MRI-CGCM3']['rcp45']['mean'] }}
             <DayDiffWidget
-              variable="precip"
               :future="
                 reportData['cdd']['longterm']['MRI-CGCM3']['rcp45']['mean']
               "
@@ -478,7 +465,6 @@
           <td>
             {{ reportData['cdd']['longterm']['NCAR-CCSM4']['rcp45']['mean'] }}
             <DayDiffWidget
-              variable="precip"
               :future="
                 reportData['cdd']['longterm']['NCAR-CCSM4']['rcp45']['mean']
               "
@@ -490,7 +476,6 @@
           <td>
             {{ reportData['cdd']['longterm']['MRI-CGCM3']['rcp85']['mean'] }}
             <DayDiffWidget
-              variable="precip"
               :future="
                 reportData['cdd']['longterm']['MRI-CGCM3']['rcp85']['mean']
               "
@@ -502,7 +487,6 @@
           <td>
             {{ reportData['cdd']['longterm']['NCAR-CCSM4']['rcp85']['mean'] }}
             <DayDiffWidget
-              variable="precip"
               :future="
                 reportData['cdd']['longterm']['NCAR-CCSM4']['rcp85']['mean']
               "
@@ -530,7 +514,6 @@
               reportData['r10mm']['midcentury']['MRI-CGCM3']['rcp45']['mean']
             }}
             <DayDiffWidget
-              variable="precip"
               :future="
                 reportData['r10mm']['midcentury']['MRI-CGCM3']['rcp45']['mean']
               "
@@ -546,7 +529,6 @@
               reportData['r10mm']['midcentury']['NCAR-CCSM4']['rcp45']['mean']
             }}
             <DayDiffWidget
-              variable="precip"
               :future="
                 reportData['r10mm']['midcentury']['NCAR-CCSM4']['rcp45']['mean']
               "
@@ -562,7 +544,6 @@
               reportData['r10mm']['midcentury']['MRI-CGCM3']['rcp85']['mean']
             }}
             <DayDiffWidget
-              variable="precip"
               :future="
                 reportData['r10mm']['midcentury']['MRI-CGCM3']['rcp85']['mean']
               "
@@ -578,7 +559,6 @@
               reportData['r10mm']['midcentury']['NCAR-CCSM4']['rcp85']['mean']
             }}
             <DayDiffWidget
-              variable="precip"
               :future="
                 reportData['r10mm']['midcentury']['NCAR-CCSM4']['rcp85']['mean']
               "
@@ -592,7 +572,6 @@
           <td>
             {{ reportData['r10mm']['longterm']['MRI-CGCM3']['rcp45']['mean'] }}
             <DayDiffWidget
-              variable="precip"
               :future="
                 reportData['r10mm']['longterm']['MRI-CGCM3']['rcp45']['mean']
               "
@@ -606,7 +585,6 @@
           <td>
             {{ reportData['r10mm']['longterm']['NCAR-CCSM4']['rcp45']['mean'] }}
             <DayDiffWidget
-              variable="precip"
               :future="
                 reportData['r10mm']['longterm']['NCAR-CCSM4']['rcp45']['mean']
               "
@@ -620,7 +598,6 @@
           <td>
             {{ reportData['r10mm']['longterm']['MRI-CGCM3']['rcp85']['mean'] }}
             <DayDiffWidget
-              variable="precip"
               :future="
                 reportData['r10mm']['longterm']['MRI-CGCM3']['rcp85']['mean']
               "
@@ -634,7 +611,6 @@
           <td>
             {{ reportData['r10mm']['longterm']['NCAR-CCSM4']['rcp85']['mean'] }}
             <DayDiffWidget
-              variable="precip"
               :future="
                 reportData['r10mm']['longterm']['NCAR-CCSM4']['rcp85']['mean']
               "

--- a/components/reports/temperature/ReportTempIndicatorsTable.vue
+++ b/components/reports/temperature/ReportTempIndicatorsTable.vue
@@ -54,7 +54,7 @@
       <tbody>
         <tr>
           <th scope="row">
-            Very Cold Day Threshold
+            Very Cold Day Threshold<br />
             <span class="description"
               >Only 5 days in a year are colder than this</span
             >
@@ -154,7 +154,7 @@
         </tr>
         <tr>
           <th scope="row">
-            Very Hot Day Threshold
+            Very Hot Day Threshold<br />
             <span class="description"
               >Only 5 days in a year are warmer than this</span
             >
@@ -254,7 +254,7 @@
         </tr>
         <tr>
           <th scope="row">
-            Summer Days
+            Summer Days<br />
             <span class="description"
               >Temperature above {{ suValue }}<UnitWidget type="light"
             /></span>
@@ -353,9 +353,9 @@
         </tr>
         <tr>
           <th scope="row">
-            Deep Winter Days
+            Deep Winter Days<br />
             <span class="description"
-              >temperature below {{ dwValue }}<UnitWidget type="light"
+              >Temperature below {{ dwValue }}<UnitWidget type="light"
             /></span>
           </th>
           <td class="left">
@@ -452,9 +452,9 @@
         </tr>
         <tr>
           <th scope="row">
-            Warm Spell Duration Index
+            Warm Spell Duration Index<br />
             <span class="description"
-              >how many hot days in excess of 6-day periods?
+              >How many hot days in excess of 6-day periods?
             </span>
           </th>
           <td class="left">
@@ -558,9 +558,9 @@
         </tr>
         <tr>
           <th scope="row">
-            Cold Spell Duration Index
+            Cold Spell Duration Index<br />
             <span class="description"
-              >how many cold days in excess of 6-day periods?
+              >How many cold days in excess of 6-day periods?
             </span>
           </th>
           <td class="left">

--- a/components/reports/temperature/ReportTempIndicatorsTable.vue
+++ b/components/reports/temperature/ReportTempIndicatorsTable.vue
@@ -256,8 +256,7 @@
           <th scope="row">
             Summer Days
             <span class="description"
-              >Temperature above {{ suValue
-              }}<UnitWidget variable="temp" type="light"
+              >Temperature above {{ suValue }}<UnitWidget type="light"
             /></span>
           </th>
           <td class="left">
@@ -266,7 +265,6 @@
           <td>
             {{ reportData['su']['midcentury']['MRI-CGCM3']['rcp45']['mean'] }}
             <DayDiffWidget
-              variable="temp"
               :future="
                 reportData['su']['midcentury']['MRI-CGCM3']['rcp45']['mean']
               "
@@ -278,7 +276,6 @@
           <td>
             {{ reportData['su']['midcentury']['NCAR-CCSM4']['rcp45']['mean'] }}
             <DayDiffWidget
-              variable="temp"
               :future="
                 reportData['su']['midcentury']['NCAR-CCSM4']['rcp45']['mean']
               "
@@ -290,7 +287,6 @@
           <td>
             {{ reportData['su']['midcentury']['MRI-CGCM3']['rcp85']['mean'] }}
             <DayDiffWidget
-              variable="temp"
               :future="
                 reportData['su']['midcentury']['MRI-CGCM3']['rcp85']['mean']
               "
@@ -302,7 +298,6 @@
           <td>
             {{ reportData['su']['midcentury']['NCAR-CCSM4']['rcp85']['mean'] }}
             <DayDiffWidget
-              variable="temp"
               :future="
                 reportData['su']['midcentury']['NCAR-CCSM4']['rcp85']['mean']
               "
@@ -314,7 +309,6 @@
           <td>
             {{ reportData['su']['longterm']['MRI-CGCM3']['rcp45']['mean'] }}
             <DayDiffWidget
-              variable="temp"
               :future="
                 reportData['su']['longterm']['MRI-CGCM3']['rcp45']['mean']
               "
@@ -326,7 +320,6 @@
           <td>
             {{ reportData['su']['longterm']['NCAR-CCSM4']['rcp45']['mean'] }}
             <DayDiffWidget
-              variable="temp"
               :future="
                 reportData['su']['longterm']['NCAR-CCSM4']['rcp45']['mean']
               "
@@ -338,7 +331,6 @@
           <td>
             {{ reportData['su']['longterm']['MRI-CGCM3']['rcp85']['mean'] }}
             <DayDiffWidget
-              variable="temp"
               :future="
                 reportData['su']['longterm']['MRI-CGCM3']['rcp85']['mean']
               "
@@ -350,7 +342,6 @@
           <td>
             {{ reportData['su']['longterm']['NCAR-CCSM4']['rcp85']['mean'] }}
             <DayDiffWidget
-              variable="temp"
               :future="
                 reportData['su']['longterm']['NCAR-CCSM4']['rcp85']['mean']
               "
@@ -364,8 +355,7 @@
           <th scope="row">
             Deep Winter Days
             <span class="description"
-              >temperature below {{ dwValue
-              }}<UnitWidget variable="temp" type="light"
+              >temperature below {{ dwValue }}<UnitWidget type="light"
             /></span>
           </th>
           <td class="left">
@@ -374,7 +364,6 @@
           <td>
             {{ reportData['dw']['midcentury']['MRI-CGCM3']['rcp45']['mean'] }}
             <DayDiffWidget
-              variable="temp"
               :future="
                 reportData['dw']['midcentury']['MRI-CGCM3']['rcp45']['mean']
               "
@@ -386,7 +375,6 @@
           <td>
             {{ reportData['dw']['midcentury']['NCAR-CCSM4']['rcp45']['mean'] }}
             <DayDiffWidget
-              variable="temp"
               :future="
                 reportData['dw']['midcentury']['NCAR-CCSM4']['rcp45']['mean']
               "
@@ -398,7 +386,6 @@
           <td>
             {{ reportData['dw']['midcentury']['MRI-CGCM3']['rcp85']['mean'] }}
             <DayDiffWidget
-              variable="temp"
               :future="
                 reportData['dw']['midcentury']['MRI-CGCM3']['rcp85']['mean']
               "
@@ -410,7 +397,6 @@
           <td>
             {{ reportData['dw']['midcentury']['NCAR-CCSM4']['rcp85']['mean'] }}
             <DayDiffWidget
-              variable="temp"
               :future="
                 reportData['dw']['midcentury']['NCAR-CCSM4']['rcp85']['mean']
               "
@@ -422,7 +408,6 @@
           <td>
             {{ reportData['dw']['longterm']['MRI-CGCM3']['rcp45']['mean'] }}
             <DayDiffWidget
-              variable="temp"
               :future="
                 reportData['dw']['longterm']['MRI-CGCM3']['rcp45']['mean']
               "
@@ -434,7 +419,6 @@
           <td>
             {{ reportData['dw']['longterm']['NCAR-CCSM4']['rcp45']['mean'] }}
             <DayDiffWidget
-              variable="temp"
               :future="
                 reportData['dw']['longterm']['NCAR-CCSM4']['rcp45']['mean']
               "
@@ -446,7 +430,6 @@
           <td>
             {{ reportData['dw']['longterm']['MRI-CGCM3']['rcp85']['mean'] }}
             <DayDiffWidget
-              variable="temp"
               :future="
                 reportData['dw']['longterm']['MRI-CGCM3']['rcp85']['mean']
               "
@@ -458,7 +441,6 @@
           <td>
             {{ reportData['dw']['longterm']['NCAR-CCSM4']['rcp85']['mean'] }}
             <DayDiffWidget
-              variable="temp"
               :future="
                 reportData['dw']['longterm']['NCAR-CCSM4']['rcp85']['mean']
               "
@@ -469,74 +451,214 @@
           </td>
         </tr>
         <tr>
-          <th scope="row">Warm Spell Duration Index <span class="description"
-              >how often are there 6 or more hot days in a row?
-            </span></th>
-          <td class="left">🥦🥦 TBD</td>
+          <th scope="row">
+            Warm Spell Duration Index
+            <span class="description"
+              >how many hot days in excess of 6-day periods?
+            </span>
+          </th>
+          <td class="left">
+            {{
+              reportData['wsdi']['historical']['Daymet']['historical']['mean']
+            }}
+          </td>
           <td>
             {{ reportData['wsdi']['midcentury']['MRI-CGCM3']['rcp45']['mean'] }}
+            <DayDiffWidget
+              :future="
+                reportData['wsdi']['midcentury']['MRI-CGCM3']['rcp45']['mean']
+              "
+              :past="
+                reportData['wsdi']['historical']['Daymet']['historical']['mean']
+              "
+            />
           </td>
           <td>
             {{
               reportData['wsdi']['midcentury']['NCAR-CCSM4']['rcp45']['mean']
             }}
+            <DayDiffWidget
+              :future="
+                reportData['wsdi']['midcentury']['NCAR-CCSM4']['rcp45']['mean']
+              "
+              :past="
+                reportData['wsdi']['historical']['Daymet']['historical']['mean']
+              "
+            />
           </td>
           <td>
             {{ reportData['wsdi']['midcentury']['MRI-CGCM3']['rcp85']['mean'] }}
+            <DayDiffWidget
+              :future="
+                reportData['wsdi']['midcentury']['MRI-CGCM3']['rcp85']['mean']
+              "
+              :past="
+                reportData['wsdi']['historical']['Daymet']['historical']['mean']
+              "
+            />
           </td>
+
           <td>
             {{
               reportData['wsdi']['midcentury']['NCAR-CCSM4']['rcp85']['mean']
             }}
+            <DayDiffWidget
+              :future="
+                reportData['wsdi']['midcentury']['NCAR-CCSM4']['rcp85']['mean']
+              "
+              :past="
+                reportData['wsdi']['historical']['Daymet']['historical']['mean']
+              "
+            />
           </td>
           <td>
             {{ reportData['wsdi']['longterm']['MRI-CGCM3']['rcp45']['mean'] }}
+            <DayDiffWidget
+              :future="
+                reportData['wsdi']['longterm']['MRI-CGCM3']['rcp45']['mean']
+              "
+              :past="
+                reportData['wsdi']['historical']['Daymet']['historical']['mean']
+              "
+            />
           </td>
           <td>
             {{ reportData['wsdi']['longterm']['NCAR-CCSM4']['rcp45']['mean'] }}
+            <DayDiffWidget
+              :future="
+                reportData['wsdi']['longterm']['NCAR-CCSM4']['rcp45']['mean']
+              "
+              :past="
+                reportData['wsdi']['historical']['Daymet']['historical']['mean']
+              "
+            />
           </td>
           <td>
             {{ reportData['wsdi']['longterm']['MRI-CGCM3']['rcp85']['mean'] }}
+            <DayDiffWidget
+              :future="
+                reportData['wsdi']['longterm']['MRI-CGCM3']['rcp85']['mean']
+              "
+              :past="
+                reportData['wsdi']['historical']['Daymet']['historical']['mean']
+              "
+            />
           </td>
           <td>
             {{ reportData['wsdi']['longterm']['NCAR-CCSM4']['rcp85']['mean'] }}
+            <DayDiffWidget
+              :future="
+                reportData['wsdi']['longterm']['NCAR-CCSM4']['rcp85']['mean']
+              "
+              :past="
+                reportData['wsdi']['historical']['Daymet']['historical']['mean']
+              "
+            />
           </td>
         </tr>
         <tr>
           <th scope="row">
             Cold Spell Duration Index
             <span class="description"
-              >how often are there 6 or more cold days in a row?
+              >how many cold days in excess of 6-day periods?
             </span>
           </th>
-          <td class="left">🥕🥕 TBD</td>
+          <td class="left">
+            {{
+              reportData['csdi']['historical']['Daymet']['historical']['mean']
+            }}
+          </td>
           <td>
             {{ reportData['csdi']['midcentury']['MRI-CGCM3']['rcp45']['mean'] }}
+            <DayDiffWidget
+              :future="
+                reportData['csdi']['midcentury']['MRI-CGCM3']['rcp45']['mean']
+              "
+              :past="
+                reportData['csdi']['historical']['Daymet']['historical']['mean']
+              "
+            />
           </td>
           <td>
             {{
               reportData['csdi']['midcentury']['NCAR-CCSM4']['rcp45']['mean']
             }}
+            <DayDiffWidget
+              :future="
+                reportData['csdi']['midcentury']['NCAR-CCSM4']['rcp45']['mean']
+              "
+              :past="
+                reportData['csdi']['historical']['Daymet']['historical']['mean']
+              "
+            />
           </td>
           <td>
             {{ reportData['csdi']['midcentury']['MRI-CGCM3']['rcp85']['mean'] }}
+            <DayDiffWidget
+              :future="
+                reportData['csdi']['midcentury']['MRI-CGCM3']['rcp85']['mean']
+              "
+              :past="
+                reportData['csdi']['historical']['Daymet']['historical']['mean']
+              "
+            />
           </td>
           <td>
             {{
               reportData['csdi']['midcentury']['NCAR-CCSM4']['rcp85']['mean']
             }}
+            <DayDiffWidget
+              :future="
+                reportData['csdi']['midcentury']['NCAR-CCSM4']['rcp85']['mean']
+              "
+              :past="
+                reportData['csdi']['historical']['Daymet']['historical']['mean']
+              "
+            />
           </td>
           <td>
             {{ reportData['csdi']['longterm']['MRI-CGCM3']['rcp45']['mean'] }}
+            <DayDiffWidget
+              :future="
+                reportData['csdi']['longterm']['MRI-CGCM3']['rcp45']['mean']
+              "
+              :past="
+                reportData['csdi']['historical']['Daymet']['historical']['mean']
+              "
+            />
           </td>
           <td>
             {{ reportData['csdi']['longterm']['NCAR-CCSM4']['rcp45']['mean'] }}
+            <DayDiffWidget
+              :future="
+                reportData['csdi']['longterm']['NCAR-CCSM4']['rcp45']['mean']
+              "
+              :past="
+                reportData['csdi']['historical']['Daymet']['historical']['mean']
+              "
+            />
           </td>
           <td>
             {{ reportData['csdi']['longterm']['MRI-CGCM3']['rcp85']['mean'] }}
+            <DayDiffWidget
+              :future="
+                reportData['csdi']['longterm']['MRI-CGCM3']['rcp85']['mean']
+              "
+              :past="
+                reportData['csdi']['historical']['Daymet']['historical']['mean']
+              "
+            />
           </td>
           <td>
             {{ reportData['csdi']['longterm']['NCAR-CCSM4']['rcp85']['mean'] }}
+            <DayDiffWidget
+              :future="
+                reportData['csdi']['longterm']['NCAR-CCSM4']['rcp85']['mean']
+              "
+              :past="
+                reportData['csdi']['historical']['Daymet']['historical']['mean']
+              "
+            />
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
Closes #570 
Closes #541 

This PR...

- Reduces vegetable emojis
- Removes coloration from the DayDiffWidget
- Adds deltas + historical baseline to WSDI/CSDI

Test by pulling up a few locations and seeing that the indicators look OK.

- No colors with the Day Difference rows.
- No vegetables.
- Historical added to WSDI/CSDI, and full deltas.