### PR TITLE
Improves language in table footers

### DIFF
--- a/components/reports/precipitation/ReportPrecipChart.vue
+++ b/components/reports/precipitation/ReportPrecipChart.vue
@@ -82,7 +82,7 @@ export default {
       layout.shapes.push(historicalRegion)
 
       let footerLines = [
-        'The boxplot represents the interquartile range (IQR) of historical means for the season, from 1950–2009 (CRU TS 4.0).',
+        'The boxplot on the left represents the interquartile range (IQR) of historical means for the season, from 1950–2009 (CRU TS 4.0).',
         'The shaded gray region shows the extent of common variation for the historical period.',
         'The line inside the boxplot represents the median historical precipitation.',
       ]

--- a/components/reports/precipitation/ReportPrecipIndicatorsTable.vue
+++ b/components/reports/precipitation/ReportPrecipIndicatorsTable.vue
@@ -626,6 +626,7 @@
       <tfoot>
         <tr>
           <td colspan="10" class="about">
+            Bold text indicates greater change.
             <nuxt-link :to="{ name: 'data' }"
               >Read more about the dataset and processing used to generate these
               data.</nuxt-link

--- a/components/reports/temperature/ReportTempChart.vue
+++ b/components/reports/temperature/ReportTempChart.vue
@@ -89,7 +89,7 @@ export default {
       layout.shapes.push(historicalRegion)
 
       let footerLines = [
-        'The boxplot represents the interquartile range (IQR) of historical means for the season, from 1950–2009 (CRU TS 4.0).',
+        'The boxplot on the left represents the interquartile range (IQR) of historical means for the season, from 1950–2009 (CRU TS 4.0).',
         'The shaded gray region shows the extent of common variation for the historical period.',
         'The line inside the boxplot represents the median historical temperature.',
       ]

--- a/components/reports/temperature/ReportTempIndicatorsTable.vue
+++ b/components/reports/temperature/ReportTempIndicatorsTable.vue
@@ -665,6 +665,7 @@
       <tfoot>
         <tr>
           <td colspan="10" class="about">
+            Red text means warmer, blue means colder. Bold text indicates greater change.
             <nuxt-link :to="{ name: 'data' }"
               >Read more about the dataset and processing used to generate these
               data.</nuxt-link


### PR DESCRIPTION
Closes #78 

Ticket 78 wandered a bit, but the two changes here are:
- Added note about "box plot to the left"
- Added notes on color/bold to the indicators tables