### PR TITLE
Add hydrology to missing dataset / error report list

### DIFF
--- a/components/Report.vue
+++ b/components/Report.vue
@@ -222,6 +222,10 @@
                 <strong>Temperature and precipitation:</strong>
                 {{ httpErrors[climateHttpError] }}
               </li>
+              <li v-if="hydrologyHttpError">
+                <strong>Hydrology:</strong>
+                {{ httpErrors[hydrologyHttpError] }}
+              </li>
               <li v-if="elevationHttpError">
                 <strong>Elevation:</strong>
                 {{ httpErrors[elevationHttpError] }}


### PR DESCRIPTION
Closes #586.

This PR adds hydrology to the conditional missing/error message bulleted list, so it'll tell users when hydrology data is missing.

Since the API supports only point queries for hydrology data, this is easy to test. Just pull up a report for an area and it should report that there's no hydrology data under the "The following data is not available at this location:" text. On these pages, for example:

http://localhost:3000/report/area/1909020223
http://localhost:3000/report/area/19050104