### PR TITLE
Grab bag of a few different issues

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -72,4 +72,7 @@ table.table.report-table {
     font-size: 150%;
     padding-bottom: 1rem;
   }
+  .description {
+    display: block;
+  }
 }

--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -13,9 +13,6 @@
             at the
             <a href="https://uaf-iarc.org"
               >International Arctic Research Center</a
-            >. <strong>Contact us</strong> at
-            <a href="mailto:uaf-snap-data-tools@alaska.edu"
-              >uaf-snap-data-tools@alaska.edu</a
             >.
           </p>
 
@@ -31,17 +28,20 @@
             >.
           </p>
           <p>
-            Data available through this tool are subject to the
-            <a href="https://creativecommons.org/licenses/by/4.0/"
-              >Creative Commons Attribution 4.0</a
+            <strong
+              >Please contact
+              <a href="mailto:uaf-snap-data-tools@alaska.edu"
+                >uaf&ndash;snap&ndash;data&ndash;tools@alaska.edu</a
+              >
+              with questions or comments.</strong
             >
-            license. Please contact
-            <a href="mailto:uaf-snap-data-tools@alaska.edu"
-              >uaf&ndash;snap&ndash;data&ndash;tools@alaska.edu</a
-            >
-            with questions or comments.
             <a href="https://uaf-snap.org">Visit the SNAP website</a>
             to see all of our climate tools.
+          </p>
+          <p>
+            Usage of data provided through this tool is subject to license
+            constraints. See the <nuxt-link to="/data">data page</nuxt-link> for
+            details.
           </p>
           <p>
             UA is committed to providing accessible websites.

--- a/components/reports/ColorTable.vue
+++ b/components/reports/ColorTable.vue
@@ -1,47 +1,50 @@
 <template>
-  <div class="content">
-    <table class="table">
-      <thead>
-        <tr>
-          <th scope="col" style="min-width: 16rem">{{ colorHeader }}</th>
-          <th scope="col" style="min-width: 10rem">{{ unitLabel }}</th>
-          <th scope="col" v-if="showInterpretation()">Interpretation</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr v-for="(threshold, index) in thresholds" :key="index">
-          <th scope="row" class="category">
-            <div
-              class="swatch"
-              :class="{ bordered: ifBordered(index) }"
-              :style="{ 'background-color': threshold['color'] }"
-            />
-            {{ threshold['label'] }}
-          </th>
-          <td class="numbers">
-            <span v-if="threshold['min'] == rangeMin()"
-              >&lt;{{ threshold['max'] }}<span v-html="unitSymbol"
-            /></span>
-            <span v-else-if="threshold['max'] == rangeMax()"
-              >&ge;{{ threshold['min'] }}<span v-html="unitSymbol"
-            /></span>
-            <span v-else-if="!threshold['max'] && !threshold['min']">-</span>
-            <span v-else
-              >&ge;{{ threshold['min'] }}<span v-html="unitSymbol" />, &lt;{{
-                threshold['max']
-              }}<span v-html="unitSymbol"
-            /></span>
-          </td>
-          <td v-if="showInterpretation()">
-            {{ threshold['interpretation'] }}
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
+  <table class="table">
+    <thead>
+      <tr>
+        <th scope="col" :class="{ 'color-column-clamp': ifClampColor }">
+          {{ colorHeader }}
+        </th>
+        <th scope="col">{{ unitLabel }}</th>
+        <th scope="col" v-if="showInterpretation()">Interpretation</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="(threshold, index) in thresholds" :key="index">
+        <th scope="row" class="category">
+          <div
+            class="swatch"
+            :class="{ bordered: ifBordered(index) }"
+            :style="{ 'background-color': threshold['color'] }"
+          />
+          {{ threshold['label'] }}
+        </th>
+        <td class="numbers">
+          <span v-if="threshold['min'] == rangeMin()"
+            >&lt;{{ threshold['max'] }}<span v-html="unitSymbol"
+          /></span>
+          <span v-else-if="threshold['max'] == rangeMax()"
+            >&ge;{{ threshold['min'] }}<span v-html="unitSymbol"
+          /></span>
+          <span v-else-if="!threshold['max'] && !threshold['min']">-</span>
+          <span v-else
+            >&ge;{{ threshold['min'] }}<span v-html="unitSymbol" />, &lt;{{
+              threshold['max']
+            }}<span v-html="unitSymbol"
+          /></span>
+        </td>
+        <td v-if="showInterpretation()">
+          {{ threshold['interpretation'] }}
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </template>
 
 <style lang="scss" scoped>
+.color-column-clamp {
+  width: 3rem;
+}
 .content table th:not([align]) {
   text-align: left;
 }
@@ -77,6 +80,7 @@ export default {
     'unitSymbol',
     'borderedColors',
     'colorHeader',
+    'ifClampColor', // clamp the color column to only contain the swatch
   ],
   methods: {
     ifBordered(index) {

--- a/components/reports/hydrology/HydroDiffWidget.vue
+++ b/components/reports/hydrology/HydroDiffWidget.vue
@@ -15,12 +15,6 @@
   &.strong {
     font-weight: 500;
   }
-  &.less {
-    color: #5e3305;
-  }
-  &.more {
-    color: #05335e;
-  }
 }
 </style>
 
@@ -55,7 +49,7 @@ export default {
       return this.pct > 0
     },
     diff() {
-      let diff = parseFloat(this.future - this.past).toFixed(1)
+      let diff = Number(parseFloat(this.future - this.past).toFixed(1))
       if (diff > 0) {
         diff = '&plus;' + diff
       } else if (diff < 0) {

--- a/components/reports/hydrology/HydrologyReport.vue
+++ b/components/reports/hydrology/HydrologyReport.vue
@@ -19,14 +19,15 @@
       </div>
 
       <ReportHydrologyTables />
-      <ReportHydrologyMaps />
-
       <DownloadCsvButton
         text="Download hydrology data as CSV"
         endpoint="hydrology"
         class="mt-3 mb-5"
       />
+
+      <ReportHydrologyMaps />
       <BackToTopButton />
+      
     </div>
   </div>
 </template>

--- a/components/reports/hydrology/ReportHydrologyMaps.vue
+++ b/components/reports/hydrology/ReportHydrologyMaps.vue
@@ -121,14 +121,13 @@
           </tr>
         </tbody>
       </table>
-      <div class="content mb-6">
-        <p>This table is a legend for the maps above.</p>
+      <div class="mt-3 mb-6 is-centered legend">
         <ColorTable
           :unitLabel="mapVar(variable)"
-          colorHeader="Color"
           :unitSymbol="unitSymbol"
           :thresholds="variable == 'evap' ? evapThresholds : runoffThresholds"
           :borderedColors="[0, 1, 2]"
+          :ifClampColor="true"
         />
       </div>
     </div>
@@ -157,7 +156,7 @@ export default {
       runoffThresholds: 'hydrology/runoffThresholds',
     }),
     unitSymbol() {
-      return this.units == 'imperial' ? 'in/season' : 'mm/season'
+      return this.units == 'imperial' ? '&#8239;in/season' : '&#8239;mm/season'
     },
   },
   methods: {
@@ -199,6 +198,11 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
+.legend {
+  max-width: 23rem;
+  margin-left: auto;
+  margin-right: auto;
+}
 table {
   width: 100%;
   table-layout: fixed;

--- a/components/reports/precipitation/PrecipReport.vue
+++ b/components/reports/precipitation/PrecipReport.vue
@@ -48,12 +48,15 @@
     </div>
     <ReportPrecipChart :season="precip_season" />
     <ReportPrecipTable />
-    <ReportPrecipIndicatorsTable />
+    
     <DownloadCsvButton
       text="Download precipitation data as CSV"
       endpoint="precipitation"
       class="mt-3 mb-5"
     />
+
+    <ReportPrecipIndicatorsTable />
+    
     <BackToTopButton />
   </div>
 </template>

--- a/components/reports/temperature/ReportTempIndicatorsTable.vue
+++ b/components/reports/temperature/ReportTempIndicatorsTable.vue
@@ -54,7 +54,7 @@
       <tbody>
         <tr>
           <th scope="row">
-            Very Cold Day Threshold<br />
+            Very Cold Day Threshold
             <span class="description"
               >Only 5 days in a year are colder than this</span
             >
@@ -154,7 +154,7 @@
         </tr>
         <tr>
           <th scope="row">
-            Very Hot Day Threshold<br />
+            Very Hot Day Threshold
             <span class="description"
               >Only 5 days in a year are warmer than this</span
             >
@@ -254,7 +254,7 @@
         </tr>
         <tr>
           <th scope="row">
-            Summer Days<br />
+            Summer Days
             <span class="description"
               >Temperature above {{ suValue }}<UnitWidget type="light"
             /></span>
@@ -353,7 +353,7 @@
         </tr>
         <tr>
           <th scope="row">
-            Deep Winter Days<br />
+            Deep Winter Days
             <span class="description"
               >Temperature below {{ dwValue }}<UnitWidget type="light"
             /></span>
@@ -452,7 +452,7 @@
         </tr>
         <tr>
           <th scope="row">
-            Warm Spell Duration Index<br />
+            Warm Spell Duration Index
             <span class="description"
               >How many hot days in excess of 6-day periods?
             </span>
@@ -558,7 +558,7 @@
         </tr>
         <tr>
           <th scope="row">
-            Cold Spell Duration Index<br />
+            Cold Spell Duration Index
             <span class="description"
               >How many cold days in excess of 6-day periods?
             </span>

--- a/components/reports/temperature/TempReport.vue
+++ b/components/reports/temperature/TempReport.vue
@@ -33,12 +33,12 @@
     </div>
     <ReportTempChart :season="temp_season" />
     <ReportTempTable />
-    <ReportTempIndicatorsTable />
     <DownloadCsvButton
       text="Download temperature data as CSV"
       endpoint="temperature"
       class="mt-3 mb-5"
     />
+    <ReportTempIndicatorsTable />
     <BackToTopButton />
   </div>
 </template>


### PR DESCRIPTION
Closes #594 
Closes #591 
Closes #575 
Closes #514 
Closes #589 

Testing -- point your local instance to apollo/development.earthmaps & open a web browser to the currently-deployed instance at dev.northernclimatereports.org for A/B testing on a bunch of smaller issues:
- Load a report for Chicken.  Check that there aren't colors present in the Hydrology table diff widgets (subtle blue/red were present before) (#594)
- Load a report for Sutton.  Confirm units are in Imperial.  Check the Hydrology table.  There should be up to 1 decimal point for the deltas.  Now switch to Metric.  There should not be any trailing decimals, i.e. `4.0`.
- Check the table widths for the legends under the Hydrology maps -- they should be centered with the color-swatch column not being too wide.  Also look at the legend for Wildfire and if available Permafrost: these should still display the way they used to / not look messed up.  (#591)
- Look at the positioning of the "Download CSV..." buttons.  They should be immediately below the data that can be downloaded for all sections, i.e. not after the Indicators table or below maps. (#575)
- Ensures that indicator "Description bylines" are all on their own line (#514)
- Check the language in the footer.  It removes some duplicated "Contact us" stuff and points the user at the data page for license information.