### PR TITLE
Update expected permafrost era keys to new GIPL 2.0 era keys

### DIFF
--- a/store/permafrost.js
+++ b/store/permafrost.js
@@ -144,7 +144,7 @@ export const actions = {
     let errorKey =
       'permafrostError-' + context.rootGetters['place/urlFragment']()
 
-    let expectedDataKeys = ['1988-2017', '2010-2039', '2040-2069', '2070-2099']
+    let expectedDataKeys = ['2021-2039', '2040-2069', '2070-2099']
 
     let returnedData = await localStorage(
       queryUrl,


### PR DESCRIPTION
Xref: #597.

This PR fixes one part of #597. It brings back the permafrost section for any location that has permafrost data.

The problem was that, last week, I added some additional data validation for each section to make sure all expected data keys have valid data. Unfortunately, I was validating the permafrost data using the old GIPL 1.0 set of keys (which included a historical era), and this was causing the permafrost data validation to fail 100% of the time. I didn't catch this at the time because we also had a bug that didn't report missing permafrost data properly, but this was also fixed last week.

To test, load the report for Fairbanks and verify that all data sections are present, including permafrost. Try a couple other locations where you expect permafrost data to be present, also.