### PR TITLE
Clear HTTP errors when data is cleared and add missing clear calls

### DIFF
--- a/components/App.vue
+++ b/components/App.vue
@@ -55,10 +55,13 @@ export default {
 
     // Since this component is invoked whenever the `/` route fires,
     // we need to clear the stores.
-    this.$store.commit('place/clear')
+    this.$store.commit('beetle/clear')
     this.$store.commit('climate/clear')
     this.$store.commit('elevation/clear')
+    this.$store.commit('hydrology/clear')
+    this.$store.commit('indicators/clear')
     this.$store.commit('permafrost/clear')
+    this.$store.commit('place/clear')
     this.$store.commit('wildfire/clear')
 
     // Populate the store with places.

--- a/store/beetle.js
+++ b/store/beetle.js
@@ -71,6 +71,7 @@ export const mutations = {
   },
   clear(state) {
     state.beetleData = undefined
+    state.httpError = null
   },
   setHttpError(state, error) {
     state.httpError = error

--- a/store/climate.js
+++ b/store/climate.js
@@ -64,6 +64,7 @@ export const mutations = {
   },
   clear(state) {
     state.climateData = undefined
+    state.httpError = null
   },
   setHttpError(state, error) {
     state.httpError = error

--- a/store/elevation.js
+++ b/store/elevation.js
@@ -50,6 +50,7 @@ export const mutations = {
   },
   clear(state) {
     state.elevation = undefined
+    state.httpError = null
   },
   setHttpError(state, error) {
     state.httpError = error

--- a/store/hydrology.js
+++ b/store/hydrology.js
@@ -196,6 +196,7 @@ export const mutations = {
   },
   clear(state) {
     state.hydrologyData = undefined
+    state.httpError = null
   },
   setHttpError(state, error) {
     state.httpError = error

--- a/store/indicators.js
+++ b/store/indicators.js
@@ -74,6 +74,7 @@ export const mutations = {
   },
   clear(state) {
     state.indicatorData = undefined
+    state.httpError = null
   },
   setHttpError(state, error) {
     state.httpError = error

--- a/store/permafrost.js
+++ b/store/permafrost.js
@@ -127,6 +127,7 @@ export const mutations = {
 
   clear(state) {
     state.permafrostData = undefined
+    state.httpError = null
   },
   setHttpError(state, error) {
     state.httpError = error

--- a/store/wildfire.js
+++ b/store/wildfire.js
@@ -173,6 +173,8 @@ export const mutations = {
   clear(state) {
     state.flammability = undefined
     state.veg_change = undefined
+    state.flammabilityHttpError = null
+    state.vegChangeHttpError = null
   },
   setFlammabilityHttpError(state, error) {
     state.flammabilityHttpError = error


### PR DESCRIPTION
Closes #597.

This PR closes the remainder of #597. The always-missing permafrost part of the issue was already fixed in #598.

This PR simply sets each dataset's `httpError` store variable back to `null` at the same time the data itself is cleared from the store. Before this, the report page would erroneously carry over HTTP error values from the previously loaded location, even when the corresponding data did exist for the new location.

I also discovered that the `clear` mutation was not being called for several of the new datasets we have integrated into NCR (beetles, hydrology, indicators) and I've fixed that too.

To replicate the problem, run this repo from the `main` branch and:

- Load the report for Saint Paul, which has no data and will set `httpError` to no data for all possible datasets.
- Click your browser's back button.
- Load the report for Fairbanks. Despite having data available for all possible datasets, it will report a bunch of erroneous no data errors.

Next, make sure to clear your localstorage for both Saint Paul and Fairbanks since HTTP errors are stored and read from localstorage.

To verify that the problem has been fixed, run this repo from the `clear_http_errors` brach and run through the same steps above. Load Saint Paul, click back, and load Fairbanks. You should no longer see any messages indicating that data is missing for Fairbanks.