### PR TITLE
Fix logic fetching HUC12s for points / area polygons

### DIFF
--- a/store/place.js
+++ b/store/place.js
@@ -206,13 +206,18 @@ export const actions = {
   // or we can pass `huc12Id` if we need to specify a distinct
   // boundary ID to fetch (used for ALFRESCO data).
   async fetch(context, huc12Id) {
-    // Only fetch for non-point locations
-    if (!context.getters.isPointLocation) {
-      let boundaryId = huc12Id
-        ? 'area/' + huc12Id
-        : context.getters.urlFragment()
+    let boundaryRequestFragment
+    if (huc12Id) {
+      boundaryRequestFragment = '/area/' + huc12Id
+    } else {
+      // Don't try and fetch a boundary for a point.
+      if (!context.getters.isPointLocation) {
+        boundaryRequestFragment = context.getters.urlFragment()
+      }
+    }
+    if (boundaryRequestFragment) {
       // TODO: add error handling here for 404 (no data) etc.
-      let queryUrl = process.env.apiUrl + '/boundary/' + boundaryId
+      let queryUrl = process.env.apiUrl + '/boundary/' + boundaryRequestFragment
       let geoJSON = await this.$http.$get(queryUrl)
       context.commit('setGeoJSON', geoJSON)
     }


### PR DESCRIPTION
Closes #595 
Closes #593 

Testing:
 - Pick a point location.  You should see the HUC12 shaded area / outlines + the map zoom levels should be "natural" (close to / containing the HUC12 bounds for Permafrost, Wildfire, Veg + Hydro).
 - Pick an area-type location (Kanuti Watershed).  It should display the area polygon, have the zoom level set properly, etc.