### PR TITLE
Fix back button report hydration bug

### DIFF
--- a/store/place.js
+++ b/store/place.js
@@ -43,7 +43,6 @@ export const getters = {
       if (place) {
         return [place.latitude, place.longitude]
       }
-      throw 'Could not find the community by ID.'
     }
 
     // It's not a point-based location with a defined lat/lon.
@@ -80,7 +79,6 @@ export const getters = {
         return place.type
       }
     }
-    throw 'Unknown place type!'
   },
 
   // Is this a point-like type?
@@ -148,7 +146,6 @@ export const getters = {
           return area.name
       }
     }
-    throw 'Could not determine name of place from ID.'
   },
 
   // This returns the name of the HUC without any extra stuff.


### PR DESCRIPTION
Closes #531.
Closes #546.

This fixes the bug described in #531, albeit in an unexpected and potentially _controversial_ way. I discovered that if we simply remove the `throw` statements we had in place in `place.js`, the hydration works as expected.

I added some `console.log` statements while experimenting with this and discovered that when navigating from the Report page to the Data page, then an external website (via the footer), then clicking my browser's back button twice, Nuxt/Vue calls the same place getter functions twice. The first time it gets no results and simply returns `false`. The second time, it gets the data it expects and works as intended. I think calling getter functions repeatedly as different components render is typical Vue behavior so this is not unexpected.

The `throw` statements we had in place interrupted this process, making the app bomb out after the first getter call instead of simply returning `false` and proceeding.

To test:

- Load a report for a location
- Click one of the "Read more about climate models and RCPs" links below a table
- Once the Data page loads, navigate to the footer and click an external link, such as the link to SNAP's website
- Click your browser's back button twice
- The location report should hydrate/populate properly