### PR TITLE
Add indicators CSV button and fix permafrost and ALFRESCO CSV buttons

### DIFF
--- a/components/reports/DownloadCsvButton.vue
+++ b/components/reports/DownloadCsvButton.vue
@@ -2,10 +2,10 @@
   <a :href="downloadTarget" class="button is-info">{{ text }}</a>
 </template>
 <style lang="scss" scoped>
-  a.button.is-info {
-    background-color: #f7ae05 !important;
-    color: black;
-  }
+a.button.is-info {
+  background-color: #f7ae05 !important;
+  color: black;
+}
 </style>
 <script>
 export default {
@@ -17,13 +17,15 @@ export default {
       if (_.includes(['flammability', 'veg_type'], this.endpoint)) {
         endpointPath = 'alfresco/' + endpointPath
       }
+      if (_.includes(['indicators'], this.endpoint)) {
+        endpointPath = endpointPath + '/base'
+      }
       let url
       if (_.includes(['permafrost'], this.endpoint)) {
         let latLng = this.$store.getters['place/latLng']
         url =
           process.env.apiUrl +
-          '/' +
-          'ncr/permafrost/point/' +
+          '/permafrost/point/' +
           latLng[0] +
           '/' +
           latLng[1] +
@@ -36,6 +38,9 @@ export default {
           '/' +
           this.$store.getters['place/urlFragment']() +
           '?format=csv'
+      }
+      if (_.includes(['flammability', 'veg_type'], this.endpoint)) {
+        url = url.replace('point', 'local')
       }
       if (this.$store.getters['place/type'] == 'community') {
         let communityId = this.$store.getters['place/communityId']

--- a/components/reports/precipitation/PrecipReport.vue
+++ b/components/reports/precipitation/PrecipReport.vue
@@ -48,7 +48,7 @@
     </div>
     <ReportPrecipChart :season="precip_season" />
     <ReportPrecipTable />
-    
+
     <DownloadCsvButton
       text="Download precipitation data as CSV"
       endpoint="precipitation"
@@ -56,7 +56,13 @@
     />
 
     <ReportPrecipIndicatorsTable />
-    
+
+    <DownloadCsvButton
+      text="Download precipitation indicators data as CSV"
+      endpoint="indicators"
+      class="mt-3 mb-5"
+    />
+
     <BackToTopButton />
   </div>
 </template>

--- a/components/reports/temperature/TempReport.vue
+++ b/components/reports/temperature/TempReport.vue
@@ -39,6 +39,11 @@
       class="mt-3 mb-5"
     />
     <ReportTempIndicatorsTable />
+    <DownloadCsvButton
+      text="Download temperature indicators data as CSV"
+      endpoint="indicators"
+      class="mt-3 mb-5"
+    />
     <BackToTopButton />
   </div>
 </template>


### PR DESCRIPTION
Closes #613.

This PR adds two new CSV buttons, one below the Temperature Indicators table and one below the Precipitation Indicators table.

These are a little different from other CSV download buttons, however, because both indicator's buttons link to the same URL. This is because it's not possible to download Temperature Indicators and Precipitation Indicators separately through the API currently (and not without a lot more work). It's also not practical to use just one CSV download button for multiple datasets (like Hydrology) because the Temperature Indicators and Precipitation Indicators tables are not contiguous on the page. The approach in this PR seems like the only feasible approach at the moment.

Also, I've fixed the URLs for the following CSV download buttons, which hadn't been updated with their new API routes:

- Permafrost
- Flammability
- Vegetation Type

To test:

- Load a report for a point or community and make sure all of the CSV download buttons work
- Load a report for an area and make sure all of the CSV download buttons work