### PR TITLE
Show indicators CSV download buttons only when indicators tables are shown

### DIFF
--- a/components/reports/precipitation/PrecipReport.vue
+++ b/components/reports/precipitation/PrecipReport.vue
@@ -57,12 +57,6 @@
 
     <ReportPrecipIndicatorsTable />
 
-    <DownloadCsvButton
-      text="Download precipitation indicators data as CSV"
-      endpoint="indicators"
-      class="mt-3 mb-5"
-    />
-
     <BackToTopButton />
   </div>
 </template>

--- a/components/reports/precipitation/ReportPrecipIndicatorsTable.vue
+++ b/components/reports/precipitation/ReportPrecipIndicatorsTable.vue
@@ -7,7 +7,7 @@
         link indicators to specific impacts or risks.
       </div>
     </div>
-    <table class="table report-table">
+    <table class="table report-table mb-0">
       <caption>
         Precipitation Indicators,
         <span v-html="place"></span
@@ -636,6 +636,11 @@
         </tr>
       </tfoot>
     </table>
+    <DownloadCsvButton
+      text="Download precipitation indicators data as CSV"
+      endpoint="indicators"
+      class="mt-3 mb-5"
+    />
   </div>
 </template>
 <style lang="scss" scoped>
@@ -645,12 +650,18 @@
 import UnitWidget from '~/components/UnitWidget'
 import PrecipDiffWidget from './PrecipDiffWidget'
 import DayDiffWidget from '../DayDiffWidget'
+import DownloadCsvButton from '~/components/reports/DownloadCsvButton'
 import { mapGetters } from 'vuex'
 import { convertMmToInches } from '~/utils/convert'
 
 export default {
   name: 'ReportPrecipIndicatorsTable',
-  components: { UnitWidget, PrecipDiffWidget, DayDiffWidget },
+  components: {
+    UnitWidget,
+    PrecipDiffWidget,
+    DayDiffWidget,
+    DownloadCsvButton,
+  },
   computed: {
     // Wet day threshold value (1mm)
     wdValue() {

--- a/components/reports/temperature/ReportTempIndicatorsTable.vue
+++ b/components/reports/temperature/ReportTempIndicatorsTable.vue
@@ -7,7 +7,7 @@
         link indicators to specific impacts or risks.
       </div>
     </div>
-    <table class="table report-table">
+    <table class="table report-table mb-0">
       <caption>
         Temperature Indicators,
         <span v-html="place"></span
@@ -454,7 +454,11 @@
           <th scope="row">
             Warm Spell Duration Index
             <span class="description"
-              >Heat wave metric: the number of hot days (&gt;&#8239;90<sup>th</sup> percentile) occurring in a row following an initial warm spell period of six days.
+              >Heat wave metric: the number of hot days (&gt;&#8239;90<sup
+                >th</sup
+              >
+              percentile) occurring in a row following an initial warm spell
+              period of six days.
             </span>
           </th>
           <td class="left">
@@ -560,7 +564,11 @@
           <th scope="row">
             Cold Spell Duration Index
             <span class="description"
-              >Cold spell metric: the number of cold days (&lt;&#8239;10<sup>th</sup> percentile) occurring in a row following an initial cold spell period of six days.
+              >Cold spell metric: the number of cold days (&lt;&#8239;10<sup
+                >th</sup
+              >
+              percentile) occurring in a row following an initial cold spell
+              period of six days.
             </span>
           </th>
           <td class="left">
@@ -675,6 +683,11 @@
         </tr>
       </tfoot>
     </table>
+    <DownloadCsvButton
+      text="Download temperature indicators data as CSV"
+      endpoint="indicators"
+      class="mt-3 mb-5"
+    />
   </div>
 </template>
 <style lang="scss" scoped>
@@ -684,12 +697,13 @@
 import UnitWidget from '~/components/UnitWidget'
 import TempDiffWidget from './TempDiffWidget'
 import DayDiffWidget from '../DayDiffWidget'
+import DownloadCsvButton from '~/components/reports/DownloadCsvButton'
 import { mapGetters } from 'vuex'
 import { convertValueToFahrenheit } from '~/utils/convert'
 
 export default {
   name: 'ReportTempIndicatorsTable',
-  components: { UnitWidget, TempDiffWidget, DayDiffWidget },
+  components: { UnitWidget, TempDiffWidget, DayDiffWidget, DownloadCsvButton },
   computed: {
     // Summer days fixed threshold value 25ºC
     suValue() {

--- a/components/reports/temperature/TempReport.vue
+++ b/components/reports/temperature/TempReport.vue
@@ -39,11 +39,6 @@
       class="mt-3 mb-5"
     />
     <ReportTempIndicatorsTable />
-    <DownloadCsvButton
-      text="Download temperature indicators data as CSV"
-      endpoint="indicators"
-      class="mt-3 mb-5"
-    />
     <BackToTopButton />
   </div>
 </template>


### PR DESCRIPTION
Closes #622.

This PR moves the temperature and precipitation indicators CSV download buttons into their respective `Report*IndicatorsTable.vue` components so that they only show up when the corresponding indicators table is displayed.

To test:

- Load the report for Fairbanks. Make sure the indicators CSV buttons appear under the indicators tables, as expected.
- Load the report for Gulkana Wild And Scenic River. Make sure neither indicators CSV button appears since there are no indicators tables.