### PR TITLE
Show Permafrost section intro text for area reports

### DIFF
--- a/components/reports/permafrost/PermafrostReport.vue
+++ b/components/reports/permafrost/PermafrostReport.vue
@@ -3,7 +3,7 @@
     <div class="content">
       <h4 class="title is-3">Permafrost</h4>
       <div class="is-size-5">
-        <div v-if="reportData">
+        <div v-if="reportData || showPermafrostForArea">
           <span
             >The following maps show the projected mean annual ground
             temperature over time at a depth of {{ depthFragment }}.</span
@@ -107,6 +107,7 @@ export default {
       reportData: 'permafrost/permafrostData',
       magtThresholds: 'permafrost/magtThresholds',
       validTopData: 'permafrost/validTopData',
+      showPermafrostForArea: 'permafrost/showPermafrostForArea',
     }),
   },
 }


### PR DESCRIPTION
Closes #739.

This PR is a very small change that fixes the bug described in #739. It shows the Permafrost section's intro text for area-based reports (i.e., even when there is no API data & permafrost charts, because we're still forcing the permafrost mini-maps to be visible).

This change follows the same logic we're using for the Permafrost table-of-contents entry in the main `Report.vue` component:

https://github.com/ua-snap/northern-climate-reports/blob/4401a273b62c5744cc27e83937f91ce9cb64b647/components/Report.vue#L174-L177

To test, load a report for an Alaska-based area & confirm that the intro text for the Permafrost section (as shown in #739) is visible.