### PR TITLE
Switch URL to match updates in API

### DIFF
--- a/store/indicators.js
+++ b/store/indicators.js
@@ -85,7 +85,7 @@ export const actions = {
   async fetch(context) {
     let queryUrl =
       process.env.apiUrl +
-      '/indicators/base/' +
+      '/indicators/cmip5/' +
       context.rootGetters['place/urlFragment']()
 
     let returnedData = await $axios


### PR DESCRIPTION
Closes #745 

See that issue for background.  Testing: load the results for Fairbanks, Sutton, anyplace where the indicators load.  Check that the indicators load normally.