### PR TITLE
Corrects logic for displaying error messages when a community or point location is chosen

### DIFF
--- a/components/Report.vue
+++ b/components/Report.vue
@@ -171,7 +171,7 @@
               <a href="#hydrology">Hydrology</a> charts with multiple variables,
               models, and scenarios, grouped decadally and by month of the year.
             </li>
-            <li v-if="permafrostData || showPermafrostForArea">
+            <li v-if="(permafrostData && isLocation) || showPermafrostForArea">
               <a href="#permafrost">Permafrost</a> with specific visualizations
               depending on the presence or absence of permafrost
             </li>
@@ -241,11 +241,11 @@
                 <strong>Elevation:</strong>
                 {{ httpErrors[elevationHttpError] }}
               </li>
-              <li v-if="permafrostHttpError && showPermafrostForArea">
+              <li v-if="permafrostHttpError && isLocation">
                 <strong>Permafrost:</strong>
                 {{ httpErrors[permafrostHttpError] }}
               </li>
-              <li v-else-if="!showPermafrostForArea">
+              <li v-else-if="!isLocation && !showPermafrostForArea">
                 <strong>Permafrost:</strong>
                 Not supported for this area
               </li>
@@ -293,7 +293,7 @@
       </section>
       <section
         class="section is-hidden-touch"
-        v-if="permafrostData || (dataPresent && showPermafrostForArea)"
+        v-if="(permafrostData && isLocation) || showPermafrostForArea"
       >
         <div id="permafrost">
           <PermafrostReport />
@@ -514,6 +514,7 @@ export default {
       demographicsHttpError: 'demographics/httpError',
       isPointLocation: 'place/isPointLocation',
       showPermafrostForArea: 'permafrost/showPermafrostForArea',
+      isLocation: 'permafrost/isLocation',
     }),
   },
   // This component initiates the data fetching so that

--- a/store/permafrost.js
+++ b/store/permafrost.js
@@ -125,12 +125,23 @@ export const getters = {
     return !permafrosttopValues.every(value => value === 0)
   },
 
+  isLocation: (state, getters, rootState, rootGetters) => {
+    let type = rootGetters['place/type']
+
+    // Return true if this is a community or lat/lng location.
+    if (type == 'community' || type == 'latLng') {
+      return true
+    }
+
+    return false
+  },
+
   showPermafrostForArea: (state, getters, rootState, rootGetters) => {
     let type = rootGetters['place/type']
 
-    // Return true if this is not an area type.
+    // Required to ensure communities and lat/lngs don't set this to true.
     if (type == 'community' || type == 'latLng') {
-      return true
+      return false
     }
 
     // The permafrost dataset covers only Alaska, so do not show permafrost


### PR DESCRIPTION
This PR updates the logic used to determine if an error message should be shown when a community or point location is chosen for a NCR report. There were two things that needed to change to make this work:
1. Updates the logic for when the error messages should be shown regarding HTTP error codes 404 or 422 in Report
https://github.com/ua-snap/northern-climate-reports/blob/8da1525f38e27349cab6e73e481546e6b366fb72/components/Report.vue#L244
2. Updates the check for latLng or community location in the permafrost store to return true rather than false
https://github.com/ua-snap/northern-climate-reports/blob/8da1525f38e27349cab6e73e481546e6b366fb72/store/permafrost.js#L132-L134

With these two changes, error messages will only be shown for point locations if an HTTP error is returned from the API.

To test, you can see the difference in the messages shown between the live site and the local development site for these URLs:

https://northernclimatereports.org/report/66.20/-150.00
http://localhost:3000/report/66.20/-150.00

Closes #750 